### PR TITLE
chore(ci): group Dependabot updates and auto-merge safe PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+  # npm — weekly, heavily grouped to minimize PR noise
   - package-ecosystem: npm
     directory: /
     schedule:
@@ -10,12 +11,12 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
-      - triage
     commit-message:
       prefix: chore
       prefix-development: chore
       include: scope
     groups:
+      # Critical frameworks — review manually
       next:
         patterns:
           - next
@@ -30,27 +31,29 @@ updates:
       supabase:
         patterns:
           - '@supabase/*'
-      testing:
-        patterns:
-          - vitest
-          - '@vitest/*'
-          - '@playwright/*'
-          - playwright
-      linting:
-        patterns:
-          - eslint
-          - eslint-*
-          - '@eslint/*'
-          - prettier
-          - '*-prettier'
-      types:
-        patterns:
-          - '@types/*'
+      # Everything else minor/patch gets bundled into ONE PR per week
+      dev-minor-patch:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      prod-minor-patch:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+        exclude-patterns:
+          - next
+          - '@next/*'
+          - react
+          - react-dom
+          - '@supabase/*'
     ignore:
-      # Pin Node types to Node 22 LTS series
+      # Pin Node types to current LTS major
       - dependency-name: '@types/node'
         update-types: ['version-update:semver-major']
 
+  # GitHub Actions — one grouped PR per week, auto-merged by workflow
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -58,10 +61,14 @@ updates:
       day: monday
       time: '07:00'
       timezone: Europe/Brussels
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 1
     labels:
       - ci
       - dependencies
     commit-message:
       prefix: ci
       include: scope
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,38 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-approve safe updates
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor' ||
+          steps.meta.outputs.package-ecosystem == 'github_actions'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for safe updates
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor' ||
+          steps.meta.outputs.package-ecosystem == 'github_actions'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,8 @@
 name: Dependabot auto-merge
 
-on: pull_request
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: write
@@ -17,21 +19,57 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Auto-approve safe updates
-        if: |
-          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
-          steps.meta.outputs.update-type == 'version-update:semver-minor' ||
-          steps.meta.outputs.package-ecosystem == 'github_actions'
+      # Safe = github-actions bumps OR npm dev deps on patch/minor,
+      # OR npm prod deps on patch only AND not in the critical-framework list.
+      # Critical frameworks (next / react / @supabase/*) are kept for manual review.
+      - name: Decide auto-merge eligibility
+        id: gate
+        env:
+          ECOSYSTEM: ${{ steps.meta.outputs.package-ecosystem }}
+          DEP_TYPE: ${{ steps.meta.outputs.dependency-type }}
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+          DEP_NAMES: ${{ steps.meta.outputs.dependency-names }}
+        run: |
+          critical='^(next|@next/.*|eslint-config-next|react|react-dom|@types/react|@types/react-dom|@supabase/.*)$'
+          eligible=false
+
+          if [ "$ECOSYSTEM" = "github_actions" ] && \
+             { [ "$UPDATE_TYPE" = "version-update:semver-patch" ] || [ "$UPDATE_TYPE" = "version-update:semver-minor" ]; }; then
+            eligible=true
+          elif [ "$ECOSYSTEM" = "npm_and_yarn" ] && \
+               [ "$DEP_TYPE" = "direct:development" ] && \
+               { [ "$UPDATE_TYPE" = "version-update:semver-patch" ] || [ "$UPDATE_TYPE" = "version-update:semver-minor" ]; }; then
+            eligible=true
+          elif [ "$ECOSYSTEM" = "npm_and_yarn" ] && \
+               [ "$DEP_TYPE" = "direct:production" ] && \
+               [ "$UPDATE_TYPE" = "version-update:semver-patch" ]; then
+            eligible=true
+          fi
+
+          # Veto if any listed dependency matches the critical-framework allowlist.
+          if [ "$eligible" = "true" ] && [ -n "$DEP_NAMES" ]; then
+            IFS=',' read -ra names <<< "$DEP_NAMES"
+            for name in "${names[@]}"; do
+              trimmed=$(echo "$name" | xargs)
+              if echo "$trimmed" | grep -Eq "$critical"; then
+                eligible=false
+                echo "Critical framework detected ($trimmed) — manual review required."
+                break
+              fi
+            done
+          fi
+
+          echo "eligible=$eligible" >> $GITHUB_OUTPUT
+
+      - name: Auto-approve
+        if: steps.gate.outputs.eligible == 'true'
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable auto-merge for safe updates
-        if: |
-          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
-          steps.meta.outputs.update-type == 'version-update:semver-minor' ||
-          steps.meta.outputs.package-ecosystem == 'github_actions'
+      - name: Enable auto-merge
+        if: steps.gate.outputs.eligible == 'true'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary
- Groups Dependabot npm updates into `dev-minor-patch` + `prod-minor-patch` buckets (2 PRs/week max) while keeping `next`, `react`, `supabase` as separate manual-review groups for safety.
- Bundles all `github-actions` version bumps into a single grouped PR per week.
- Adds `.github/workflows/dependabot-auto-merge.yml` that auto-approves and enables auto-merge on semver patch/minor bumps and any `github-actions` bump. Major versions still require manual review.

## Why
Dependabot was opening one PR per dependency bump, generating notification spam. This reduces the volume to ~3-4 PRs/week, most of which will auto-merge on green CI.

## Test plan
- [ ] Merge and wait for next Dependabot run (Monday 07:00 Europe/Brussels) to confirm grouping behavior.
- [ ] Verify that when a safe Dependabot PR opens, the auto-merge workflow approves it and enables auto-merge.
- [ ] Confirm majors (e.g. eslint 9→10) still require manual review.

## Summary by Sourcery

Regrouper les mises à jour de dépendances Dependabot et introduire une gestion automatisée pour les montées de version sûres afin de réduire le bruit des PR tout en conservant les mises à niveau critiques en manuel.

CI :
- Ajuster la configuration de Dependabot pour regrouper les mises à jour mineures et de patch npm dev/prod et consolider les mises à jour GitHub Actions en une seule PR hebdomadaire.
- Ajouter un workflow d’auto-merge Dependabot qui approuve automatiquement et active l’auto-merge pour les mises à jour semver de type patch/minor et les mises à jour GitHub Actions, tout en laissant les montées de version majeures pour une revue manuelle.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Group Dependabot dependency updates and introduce automated handling for safe version bumps to reduce PR noise while keeping critical upgrades manual.

CI:
- Adjust Dependabot configuration to group npm dev/prod minor and patch updates and consolidate GitHub Actions bumps into a single weekly PR.
- Add a Dependabot auto-merge workflow that auto-approves and enables auto-merge for semver patch/minor and GitHub Actions updates while leaving major bumps for manual review.

</details>