### PR TITLE
fix(security): patch tmp symlink vuln (GHSA-52f5-9888-hmc6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "vitest": "^4.1.4"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": "24.x"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -7387,19 +7387,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/external-editor/node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -10772,16 +10759,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -12875,30 +12852,13 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "rimraf": "^2.6.3"
-      },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tmp/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -93,5 +93,8 @@
     "tsx": "^4.21.0",
     "typescript": "^5",
     "vitest": "^4.1.4"
+  },
+  "overrides": {
+    "tmp": "^0.2.4"
   }
 }


### PR DESCRIPTION
## Summary
- Bumps transitive dep `tmp` from 0.1.0 / 0.0.33 to 0.2.5 via npm `overrides`
- Patches GHSA-52f5-9888-hmc6 (CVSS 2.5, low): arbitrary temp write via symlink in `dir` param
- Dev-only chain: `@lhci/cli` → `inquirer` → `external-editor` → `tmp`

## Test plan
- [x] `npm audit` → 0 vulnerabilities
- [x] `npm ls tmp` → resolves to 0.2.5
- [ ] CI: Lighthouse job still works (auto-run on main push after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fixer `tmp` sur une version sécurisée via les `overrides` npm afin de corriger une vulnérabilité de sécurité transitive dans les outils de développement.

Corrections de bugs :
- Atténuer la vulnérabilité de liens symboliques GHSA-52f5-9888-hmc6 en forçant `tmp` à se résoudre vers une version non vulnérable via les `overrides` npm.

Build :
- Mettre à jour `package.json` et le lockfile pour imposer `tmp` en version `^0.2.4` pour les dépendances transitives dans la toolchain Node.js.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Pin tmp to a secure version via npm overrides to address a transitive security vulnerability in dev tooling.

Bug Fixes:
- Mitigate the GHSA-52f5-9888-hmc6 symlink vulnerability by forcing tmp to resolve to a non-vulnerable version through npm overrides.

Build:
- Update package.json and lockfile to enforce tmp ^0.2.4 for transitive dependencies in the Node.js toolchain.

</details>