### PR TITLE
fix(ci): Lighthouse audits canonical prod URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,6 @@ jobs:
           cache: npm
       - run: npm ci
       - name: Wait for Vercel production deploy
-        id: vercel
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
@@ -110,11 +109,10 @@ jobs:
           for i in $(seq 1 60); do
             payload=$(curl -sf -H "Authorization: Bearer $VERCEL_TOKEN" \
               "https://api.vercel.com/v6/deployments?projectId=$VERCEL_PROJECT_ID&teamId=$VERCEL_TEAM_ID&target=production&limit=10") || true
-            url=$(echo "$payload" | jq -r --arg sha "$COMMIT_SHA" \
+            ready=$(echo "$payload" | jq -r --arg sha "$COMMIT_SHA" \
               '.deployments[]? | select(.meta.githubCommitSha == $sha and .readyState == "READY") | .url' | head -n1)
-            if [ -n "$url" ] && [ "$url" != "null" ]; then
-              echo "url=https://$url" >> "$GITHUB_OUTPUT"
-              echo "Production deploy READY: https://$url"
+            if [ -n "$ready" ] && [ "$ready" != "null" ]; then
+              echo "Production deploy READY for $COMMIT_SHA: https://$ready"
               exit 0
             fi
             echo "Waiting for Vercel production deploy ($i/60)…"
@@ -122,5 +120,8 @@ jobs:
           done
           echo "Timeout: no READY production deploy for $COMMIT_SHA" >&2
           exit 1
-      - name: Run Lighthouse against production
-        run: npm run lhci -- --collect.url="${{ steps.vercel.outputs.url }}/"
+      - name: Run Lighthouse against canonical production URL
+        # The deployment-specific *.vercel.app hostname is gated by Vercel SSO
+        # (Deployment Protection), so Lighthouse hits the login page and every
+        # perf/a11y assertion fails. The canonical alias skips the gate.
+        run: npm run lhci -- --collect.url="https://ankora-chi.vercel.app/"


### PR DESCRIPTION
## Summary
- Lighthouse was auditing the deployment-specific `*.vercel.app` hostname returned by the Deployments API — that URL is behind Vercel SSO (Deployment Protection), so every request hit the login page and assertions like `redirects` and `unused-css-rules` failed.
- Keep the wait loop (confirms the new commit is READY in prod) but audit `https://ankora-chi.vercel.app/` which is publicly reachable.

## Test plan
- [ ] After merge, main CI passes including Lighthouse CI

## Summary by Sourcery

Met à jour le workflow CI pour attendre que le dernier déploiement de production soit en état READY et exécuter Lighthouse sur l’URL canonique publique de production plutôt que sur le nom d’hôte spécifique au déploiement.

CI :
- Ajuster l’étape Lighthouse CI pour auditer l’URL canonique publique de production plutôt que l’URL Vercel spécifique au déploiement, protégée par SSO.
- Simplifier l’étape d’attente du déploiement Vercel pour uniquement vérifier l’état de préparation sans exporter l’URL de déploiement pour les étapes suivantes.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update CI workflow to wait for the latest production deployment to be READY and run Lighthouse against the public canonical production URL instead of the deployment-specific hostname.

CI:
- Adjust Lighthouse CI step to audit the canonical public production URL rather than the deployment-specific Vercel URL gated by SSO.
- Simplify the Vercel deployment wait step to only verify readiness without exporting the deployment URL for later steps.

</details>