### PR TITLE
feat: 3-account model + Google OAuth + Coda import

### DIFF
--- a/e2e/accounts.spec.ts
+++ b/e2e/accounts.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from './helpers/test';
+import { adminClientOrNull, deleteSeededUser, seedOnboardedUser } from './helpers/seed';
+
+const admin = adminClientOrNull();
+const nextMonth = ((new Date().getMonth() + 1) % 12) + 1;
+
+test.describe('Accounts — 3-comptes saisie + Plan du mois', () => {
+  test.skip(!admin, 'Needs real Supabase (NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY).');
+
+  test('user fills balances and dashboard shows the correct ventilation', async ({ page }) => {
+    if (!admin) return;
+
+    const user = await seedOnboardedUser(admin, [
+      {
+        label: 'Netflix',
+        amount: 100,
+        frequency: 'monthly',
+        dueMonth: 1,
+        paidFrom: 'principal',
+      },
+      {
+        label: 'Assurance auto',
+        amount: 90,
+        frequency: 'quarterly',
+        dueMonth: nextMonth,
+        paidFrom: 'epargne',
+      },
+    ]);
+
+    try {
+      await page.goto('/login');
+      await page.getByLabel('Email').fill(user.email);
+      await page.getByLabel('Mot de passe').fill(user.password);
+      await page.getByRole('button', { name: /^se connecter$/i }).click();
+      await page.waitForURL(/\/app\b/, { timeout: 15_000 });
+
+      await page.goto('/app/accounts');
+      await expect(page.getByRole('heading', { name: /mes comptes/i })).toBeVisible();
+
+      await page.locator('#monthly-income').fill('2500');
+      await page
+        .getByRole('button', { name: /^enregistrer$/i })
+        .first()
+        .click();
+      await expect(page.getByText(/revenu mensuel mis à jour/i)).toBeVisible();
+
+      await page.locator('#vie-transfer').fill('500');
+      await page
+        .getByRole('button', { name: /^enregistrer$/i })
+        .nth(1)
+        .click();
+      await expect(page.getByText(/virement mensuel mis à jour/i)).toBeVisible();
+
+      await page.locator('#balance-principal').fill('1000');
+      await page.locator('#balance-principal').locator('..').getByRole('button').click();
+      await expect(page.getByText(/compte principal mis à jour/i)).toBeVisible();
+
+      await page.locator('#balance-vie_courante').fill('300');
+      await page.locator('#balance-vie_courante').locator('..').getByRole('button').click();
+      await expect(page.getByText(/vie courante mis à jour/i)).toBeVisible();
+
+      await page.locator('#balance-epargne').fill('400');
+      await page.locator('#balance-epargne').locator('..').getByRole('button').click();
+      await expect(page.getByText(/épargne.+mis à jour/i)).toBeVisible();
+
+      await page.goto('/app');
+      await expect(page.getByRole('heading', { name: /plan du mois/i })).toBeVisible();
+      await expect(page.getByText(/principal → vie courante/i)).toBeVisible();
+      await expect(page.getByText(/principal → épargne/i)).toBeVisible();
+      await expect(page.getByText(/restant principal/i)).toBeVisible();
+
+      const planCard = page
+        .getByRole('heading', { name: /plan du mois/i })
+        .locator('xpath=ancestor::section');
+      await expect(planCard.getByText(/500,00|500\.00/).first()).toBeVisible();
+      await expect(planCard.getByText(/30,00|30\.00/).first()).toBeVisible();
+    } finally {
+      await deleteSeededUser(admin, user.userId);
+    }
+  });
+});

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -5,7 +5,7 @@ test.describe('Auth — validation (no DB writes)', () => {
   test('signup: weak password surfaces inline field error', async ({ page }) => {
     const user = makeTestUser();
     await fillSignup(page, { ...user, password: 'short' });
-    await page.getByRole('button', { name: /créer mon compte/i }).click();
+    await page.getByRole('button', { name: 'Créer mon compte', exact: true }).click();
 
     await expect(page.getByText(/12 caractères/i).first()).toBeVisible();
   });
@@ -16,7 +16,7 @@ test.describe('Auth — validation (no DB writes)', () => {
     await page.getByLabel('Email').fill(user.email);
     await page.getByLabel('Mot de passe', { exact: true }).fill(user.password);
     await page.getByLabel('Confirmer le mot de passe').fill(user.password);
-    await page.getByRole('button', { name: /créer mon compte/i }).click();
+    await page.getByRole('button', { name: 'Créer mon compte', exact: true }).click();
 
     // Browser-native required validation prevents navigation — still on /signup.
     await expect(page).toHaveURL(/\/signup\b/);

--- a/e2e/helpers/seed.ts
+++ b/e2e/helpers/seed.ts
@@ -1,0 +1,97 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { randomBytes } from 'node:crypto';
+import type { Database } from '@/lib/supabase/types';
+import type { TestUser } from './user';
+
+export type AdminClient = SupabaseClient<Database>;
+
+type SeededUser = TestUser & {
+  userId: string;
+  workspaceId: string;
+};
+
+export type SeedCharge = {
+  label: string;
+  amount: number;
+  frequency: 'monthly' | 'quarterly' | 'semiannual' | 'annual';
+  dueMonth: number;
+  paidFrom: 'principal' | 'epargne';
+};
+
+/**
+ * Returns an admin Supabase client or null if the env is not configured
+ * for full authenticated e2e (e.g. dummy CI values). Callers should skip
+ * the test when null.
+ */
+export function adminClientOrNull(): AdminClient | null {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  if (url.includes('localhost:54321')) return null;
+  if (key.length < 40) return null;
+  return createClient<Database>(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+/**
+ * Create an email-confirmed, onboarded user with a seeded workspace. Returns
+ * credentials + IDs so the caller can clean up (via deleteSeededUser) and
+ * assert against DB state.
+ */
+export async function seedOnboardedUser(
+  admin: AdminClient,
+  charges: SeedCharge[] = [],
+): Promise<SeededUser> {
+  const id = randomBytes(6).toString('hex');
+  const email = `ankora-e2e+${id}@ankora.test`;
+  const password = `Tests${id.toUpperCase()}!9`;
+
+  const { data: created, error: createError } = await admin.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+  });
+  if (createError || !created.user) {
+    throw new Error(`createUser failed: ${createError?.message ?? 'no user'}`);
+  }
+  const userId = created.user.id;
+
+  const { error: onboardError } = await admin
+    .from('users')
+    .update({ onboarded_at: new Date().toISOString() })
+    .eq('id', userId);
+  if (onboardError) throw new Error(`mark onboarded: ${onboardError.message}`);
+
+  const { data: membership, error: memberError } = await admin
+    .from('workspace_members')
+    .select('workspace_id')
+    .eq('user_id', userId)
+    .single();
+  if (memberError || !membership) {
+    throw new Error(`lookup workspace: ${memberError?.message ?? 'none'}`);
+  }
+  const workspaceId = membership.workspace_id;
+
+  if (charges.length > 0) {
+    const { error: chargesError } = await admin.from('charges').insert(
+      charges.map((c) => ({
+        workspace_id: workspaceId,
+        created_by: userId,
+        label: c.label,
+        amount: c.amount,
+        frequency: c.frequency,
+        due_month: c.dueMonth,
+        is_active: true,
+        paid_from: c.paidFrom,
+      })),
+    );
+    if (chargesError) throw new Error(`seed charges: ${chargesError.message}`);
+  }
+
+  return { email, password, userId, workspaceId };
+}
+
+export async function deleteSeededUser(admin: AdminClient, userId: string): Promise<void> {
+  await admin.auth.admin.deleteUser(userId);
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "e2e:install": "playwright install --with-deps chromium",
     "lhci": "lhci autorun",
     "icons": "tsx scripts/generate-pwa-icons.ts",
+    "import:coda": "tsx scripts/import-coda-charges.ts",
     "security:audit": "tsx scripts/security-audit.ts",
     "security:headers": "tsx scripts/check-security-headers.ts",
     "supabase:start": "supabase start",

--- a/scripts/import-coda-charges.ts
+++ b/scripts/import-coda-charges.ts
@@ -1,0 +1,358 @@
+#!/usr/bin/env tsx
+/**
+ * Imports the user's Coda "DB_Dépenses" table into Ankora.
+ *
+ * Idempotent: wipes existing categories + charges for the target workspace,
+ * then recreates them from the hard-coded list below. Run against a real
+ * Supabase project using the service role key from .env.local.
+ *
+ * Usage:
+ *   tsx scripts/import-coda-charges.ts --email=thierryvm@hotmail.com --dry-run
+ *   tsx scripts/import-coda-charges.ts --email=thierryvm@hotmail.com
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+import type { Database } from '@/lib/supabase/types';
+
+// ---------- .env.local loader ----------
+function loadEnvLocal(): void {
+  try {
+    const raw = readFileSync(resolve(process.cwd(), '.env.local'), 'utf8');
+    for (const line of raw.split(/\r?\n/)) {
+      const match = line.match(/^([A-Z0-9_]+)=(.*)$/);
+      if (!match) continue;
+      const [, key, value] = match;
+      if (!key || key in process.env) continue;
+      process.env[key] = value?.replace(/^"(.*)"$/, '$1') ?? '';
+    }
+  } catch {
+    // .env.local missing — fall through to process.env
+  }
+}
+loadEnvLocal();
+
+// ---------- CLI args ----------
+const rawArgs = process.argv.slice(2);
+const args = new Map<string, string>();
+for (const a of rawArgs) {
+  const m = a.match(/^--([a-zA-Z0-9-]+)(?:=(.*))?$/);
+  if (!m) continue;
+  const [, k, v] = m;
+  if (!k) continue;
+  args.set(k, v ?? 'true');
+}
+const email = args.get('email') ?? 'thierryvm@hotmail.com';
+const dryRun = args.get('dry-run') === 'true';
+
+// ---------- Reference data ----------
+type CategoryKind = 'fixed' | 'variable' | 'income';
+type CategoryDef = { name: string; color: string; icon: string; kind: CategoryKind };
+
+const CATEGORIES: CategoryDef[] = [
+  { name: 'Logement', color: '#4F46E5', icon: 'home', kind: 'fixed' },
+  { name: 'Abonnements', color: '#8B5CF6', icon: 'repeat', kind: 'fixed' },
+  { name: 'Assurances', color: '#0EA5E9', icon: 'shield', kind: 'fixed' },
+  { name: 'Transport', color: '#F59E0B', icon: 'car', kind: 'fixed' },
+  { name: 'Santé', color: '#EC4899', icon: 'heart', kind: 'fixed' },
+  { name: 'Taxes', color: '#DC2626', icon: 'landmark', kind: 'fixed' },
+  { name: 'Famille', color: '#14B8A6', icon: 'users', kind: 'fixed' },
+  { name: 'Courses', color: '#22C55E', icon: 'shopping-cart', kind: 'variable' },
+  { name: 'Autres', color: '#6B7280', icon: 'circle', kind: 'variable' },
+];
+
+type ChargeFrequency = 'monthly' | 'quarterly' | 'semiannual' | 'annual';
+type PaidFrom = 'principal' | 'epargne';
+type CodaCharge = {
+  label: string;
+  category: string;
+  amount: number;
+  frequency: ChargeFrequency;
+  dueMonth: number;
+  paidFrom: PaidFrom;
+  notes?: string;
+};
+
+const CHARGES: CodaCharge[] = [
+  {
+    label: 'Loyer',
+    category: 'Logement',
+    amount: 740,
+    frequency: 'monthly',
+    dueMonth: 1,
+    paidFrom: 'principal',
+  },
+  {
+    label: 'Charges (immeuble)',
+    category: 'Logement',
+    amount: 120,
+    frequency: 'monthly',
+    dueMonth: 1,
+    paidFrom: 'principal',
+  },
+  {
+    label: 'MEGA',
+    category: 'Logement',
+    amount: 55,
+    frequency: 'monthly',
+    dueMonth: 1,
+    paidFrom: 'principal',
+  },
+  {
+    label: 'Pension alimentaire',
+    category: 'Famille',
+    amount: 120,
+    frequency: 'monthly',
+    dueMonth: 1,
+    paidFrom: 'principal',
+  },
+  {
+    label: 'Impôt',
+    category: 'Taxes',
+    amount: 220,
+    frequency: 'monthly',
+    dueMonth: 1,
+    paidFrom: 'principal',
+  },
+  {
+    label: 'Solidaris (1)',
+    category: 'Santé',
+    amount: 14,
+    frequency: 'monthly',
+    dueMonth: 1,
+    paidFrom: 'principal',
+  },
+  {
+    label: 'Solidaris (2)',
+    category: 'Santé',
+    amount: 22,
+    frequency: 'monthly',
+    dueMonth: 1,
+    paidFrom: 'principal',
+  },
+  {
+    label: 'FGTB',
+    category: 'Autres',
+    amount: 19,
+    frequency: 'monthly',
+    dueMonth: 1,
+    paidFrom: 'principal',
+  },
+  {
+    label: 'Apple One',
+    category: 'Abonnements',
+    amount: 3,
+    frequency: 'monthly',
+    dueMonth: 1,
+    paidFrom: 'principal',
+  },
+  {
+    label: 'Netflix',
+    category: 'Abonnements',
+    amount: 22,
+    frequency: 'monthly',
+    dueMonth: 1,
+    paidFrom: 'principal',
+  },
+  {
+    label: 'Voo',
+    category: 'Abonnements',
+    amount: 78,
+    frequency: 'monthly',
+    dueMonth: 1,
+    paidFrom: 'principal',
+  },
+  {
+    label: 'Proximus',
+    category: 'Abonnements',
+    amount: 55,
+    frequency: 'monthly',
+    dueMonth: 1,
+    paidFrom: 'principal',
+  },
+  {
+    label: 'PlayStation abo',
+    category: 'Abonnements',
+    amount: 9,
+    frequency: 'monthly',
+    dueMonth: 1,
+    paidFrom: 'principal',
+  },
+  {
+    label: 'Belfius',
+    category: 'Autres',
+    amount: 6,
+    frequency: 'monthly',
+    dueMonth: 1,
+    paidFrom: 'principal',
+  },
+  {
+    label: 'Assurance auto',
+    category: 'Assurances',
+    amount: 150,
+    frequency: 'monthly',
+    dueMonth: 1,
+    paidFrom: 'principal',
+  },
+  {
+    label: 'Crédit voiture',
+    category: 'Transport',
+    amount: 250,
+    frequency: 'monthly',
+    dueMonth: 1,
+    paidFrom: 'principal',
+  },
+  {
+    label: 'S.W.D.E (eaux)',
+    category: 'Logement',
+    amount: 45,
+    frequency: 'quarterly',
+    dueMonth: 1,
+    paidFrom: 'epargne',
+    notes: 'Cycle trimestriel — dueMonth à préciser',
+  },
+  {
+    label: 'Taxe voiture',
+    category: 'Taxes',
+    amount: 300,
+    frequency: 'annual',
+    dueMonth: 6,
+    paidFrom: 'epargne',
+    notes: 'Échéance 01/06/2026',
+  },
+  {
+    label: 'Taxe poubelle',
+    category: 'Taxes',
+    amount: 120,
+    frequency: 'annual',
+    dueMonth: 3,
+    paidFrom: 'epargne',
+    notes: 'Payée le 25/03/2026',
+  },
+  {
+    label: 'Taxe égout',
+    category: 'Taxes',
+    amount: 55,
+    frequency: 'annual',
+    dueMonth: 3,
+    paidFrom: 'epargne',
+    notes: 'Payée le 25/03/2026',
+  },
+  {
+    label: 'Dashlane',
+    category: 'Abonnements',
+    amount: 53,
+    frequency: 'annual',
+    dueMonth: 4,
+    paidFrom: 'epargne',
+    notes: 'Payée le 11/04/2026',
+  },
+];
+
+// ---------- Main ----------
+async function main(): Promise<void> {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  }
+
+  const admin: SupabaseClient<Database> = createClient<Database>(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  log(`target=${email} dry-run=${dryRun}`);
+
+  const { data: listed, error: listErr } = await admin.auth.admin.listUsers({ perPage: 200 });
+  if (listErr) throw listErr;
+  const user = listed.users.find((u) => u.email?.toLowerCase() === email.toLowerCase());
+  if (!user) throw new Error(`User not found: ${email}`);
+  log(`user_id=${user.id}`);
+
+  const { data: membership, error: memberErr } = await admin
+    .from('workspace_members')
+    .select('workspace_id, role')
+    .eq('user_id', user.id)
+    .order('joined_at', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  if (memberErr) throw memberErr;
+  if (!membership) throw new Error('No workspace membership found for this user');
+  const workspaceId = membership.workspace_id;
+  log(`workspace_id=${workspaceId} role=${membership.role}`);
+
+  if (dryRun) {
+    log('DRY RUN — no writes.');
+    log(`Would seed ${CATEGORIES.length} categories and ${CHARGES.length} charges:`);
+    for (const c of CATEGORIES) log(`  cat ${c.name} (${c.kind})`);
+    for (const c of CHARGES) {
+      log(
+        `  charge ${c.label.padEnd(24)} ${String(c.amount).padStart(4)}€ ${c.frequency.padEnd(10)} month=${c.dueMonth} from=${c.paidFrom}`,
+      );
+    }
+    return;
+  }
+
+  const { error: delChargesErr } = await admin
+    .from('charges')
+    .delete()
+    .eq('workspace_id', workspaceId);
+  if (delChargesErr) throw delChargesErr;
+  const { error: delCatsErr } = await admin
+    .from('categories')
+    .delete()
+    .eq('workspace_id', workspaceId);
+  if (delCatsErr) throw delCatsErr;
+  log('cleared existing charges + categories');
+
+  const { data: catsInserted, error: catsErr } = await admin
+    .from('categories')
+    .insert(
+      CATEGORIES.map((c) => ({
+        workspace_id: workspaceId,
+        created_by: user.id,
+        name: c.name,
+        color: c.color,
+        icon: c.icon,
+        kind: c.kind,
+      })),
+    )
+    .select('id, name');
+  if (catsErr) throw catsErr;
+  const catByName = new Map<string, string>((catsInserted ?? []).map((c) => [c.name, c.id]));
+  log(`inserted ${catsInserted?.length ?? 0} categories`);
+
+  const { error: chargesErr } = await admin.from('charges').insert(
+    CHARGES.map((c) => ({
+      workspace_id: workspaceId,
+      created_by: user.id,
+      label: c.label,
+      amount: c.amount,
+      frequency: c.frequency,
+      due_month: c.dueMonth,
+      category_id: catByName.get(c.category) ?? null,
+      is_active: true,
+      paid_from: c.paidFrom,
+      notes: c.notes ?? null,
+    })),
+  );
+  if (chargesErr) throw chargesErr;
+  log(`inserted ${CHARGES.length} charges`);
+  log('done');
+}
+
+function log(message: string): void {
+  process.stdout.write(`[import-coda] ${message}\n`);
+}
+
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`[import-coda] FAILED: ${message}\n`);
+  if (err instanceof Error && err.stack) {
+    process.stderr.write(`${err.stack}\n`);
+  }
+  process.exit(1);
+});

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
+import { GoogleSignInButton } from '@/components/auth/GoogleSignInButton';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { LoginForm } from './LoginForm';
 
@@ -29,6 +30,14 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
             Mot de passe mis à jour. Tu peux te connecter.
           </div>
         )}
+        <div className="mb-6 flex flex-col gap-4">
+          <GoogleSignInButton />
+          <div className="flex items-center gap-3 text-xs text-(--color-muted-foreground)">
+            <span className="h-px flex-1 bg-(--color-border)" />
+            <span>ou avec ton email</span>
+            <span className="h-px flex-1 bg-(--color-border)" />
+          </div>
+        </div>
         <LoginForm />
         <div className="mt-6 flex flex-col gap-2 text-center text-sm">
           <Link

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
+import { GoogleSignInButton } from '@/components/auth/GoogleSignInButton';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { SignupForm } from './SignupForm';
 
@@ -14,6 +15,25 @@ export default function SignupPage() {
         <CardDescription>Quelques secondes. Aucune carte bancaire.</CardDescription>
       </CardHeader>
       <CardContent>
+        <div className="mb-6 flex flex-col gap-3">
+          <GoogleSignInButton label="Créer mon compte avec Google" />
+          <p className="text-center text-xs text-(--color-muted-foreground)">
+            En continuant avec Google, tu acceptes nos{' '}
+            <Link href="/legal/cgu" className="underline hover:text-(--color-foreground)">
+              CGU
+            </Link>{' '}
+            et notre{' '}
+            <Link href="/legal/privacy" className="underline hover:text-(--color-foreground)">
+              politique de confidentialité
+            </Link>
+            .
+          </p>
+          <div className="flex items-center gap-3 text-xs text-(--color-muted-foreground)">
+            <span className="h-px flex-1 bg-(--color-border)" />
+            <span>ou avec ton email</span>
+            <span className="h-px flex-1 bg-(--color-border)" />
+          </div>
+        </div>
         <SignupForm />
         <p className="mt-6 text-center text-sm text-(--color-muted-foreground)">
           Déjà un compte ?{' '}

--- a/src/app/app/accounts/AccountsClient.tsx
+++ b/src/app/app/accounts/AccountsClient.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { Landmark, PiggyBank, Wallet } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { toast } from '@/components/ui/toast';
+import {
+  updateAccountBalanceAction,
+  updateMonthlyIncomeAction,
+  updateVieCouranteTransferAction,
+} from '@/lib/actions/accounts';
+import { ACCOUNT_KIND_DESCRIPTIONS, type AccountKind } from '@/lib/schemas/account';
+import { formatMoney } from '@/lib/format';
+
+type AccountRow = { kind: AccountKind; label: string; balance: number };
+
+type Props = {
+  monthlyIncome: number | null;
+  vieCouranteMonthlyTransfer: number | null;
+  accounts: AccountRow[];
+};
+
+const ACCOUNT_ICONS: Record<AccountKind, typeof Landmark> = {
+  principal: Landmark,
+  vie_courante: Wallet,
+  epargne: PiggyBank,
+};
+
+const ACCOUNT_ORDER: AccountKind[] = ['principal', 'vie_courante', 'epargne'];
+
+function parseAmount(raw: string): number | null {
+  const normalized = raw.trim().replace(',', '.');
+  if (normalized === '') return null;
+  const n = Number(normalized);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function AccountsClient({ monthlyIncome, vieCouranteMonthlyTransfer, accounts }: Props) {
+  const accountByKind = new Map<AccountKind, AccountRow>(accounts.map((a) => [a.kind, a]));
+
+  return (
+    <div className="flex flex-col gap-8">
+      <header>
+        <h1 className="text-3xl font-bold tracking-tight md:text-4xl">Mes comptes</h1>
+        <p className="mt-1 text-(--color-muted-foreground)">
+          Saisis tes soldes réels pour qu&apos;Ankora calcule précisément ton virement intelligent
+          chaque mois.
+        </p>
+      </header>
+
+      <MonthlyIncomeCard initialValue={monthlyIncome} />
+      <VieCouranteTransferCard initialValue={vieCouranteMonthlyTransfer} />
+
+      <section aria-labelledby="soldes-heading" className="flex flex-col gap-4">
+        <h2 id="soldes-heading" className="text-xl font-semibold">
+          Soldes actuels
+        </h2>
+        <div className="grid gap-4 md:grid-cols-3">
+          {ACCOUNT_ORDER.map((kind) => {
+            const row = accountByKind.get(kind);
+            if (!row) return null;
+            return <AccountBalanceCard key={kind} row={row} />;
+          })}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function MonthlyIncomeCard({ initialValue }: { initialValue: number | null }) {
+  const [value, setValue] = useState(initialValue === null ? '' : String(initialValue));
+  const [isPending, startTransition] = useTransition();
+
+  function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const amount = parseAmount(value);
+    startTransition(async () => {
+      const result = await updateMonthlyIncomeAction({ monthlyIncome: amount });
+      if (result.ok) toast.success('Revenu mensuel mis à jour');
+      else toast.error(result.error);
+    });
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Revenu mensuel net</CardTitle>
+        <CardDescription>
+          Le salaire qui arrive chaque mois sur ton compte Principal. Sert à calculer ce qu&apos;il
+          te reste après les charges et le virement vers Vie Courante.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={onSubmit} className="flex flex-col gap-3 sm:flex-row sm:items-end">
+          <div className="flex flex-1 flex-col gap-2">
+            <Label htmlFor="monthly-income">Montant (€)</Label>
+            <Input
+              id="monthly-income"
+              type="number"
+              inputMode="decimal"
+              min={0}
+              step="0.01"
+              placeholder="Ex. 2500"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+            />
+          </div>
+          <Button type="submit" disabled={isPending}>
+            {isPending ? 'Enregistrement…' : 'Enregistrer'}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+function VieCouranteTransferCard({ initialValue }: { initialValue: number | null }) {
+  const [value, setValue] = useState(initialValue === null ? '' : String(initialValue));
+  const [isPending, startTransition] = useTransition();
+
+  function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const amount = parseAmount(value);
+    startTransition(async () => {
+      const result = await updateVieCouranteTransferAction({ amount });
+      if (result.ok) toast.success('Virement mensuel mis à jour');
+      else toast.error(result.error);
+    });
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Virement mensuel vers Vie Courante</CardTitle>
+        <CardDescription>
+          Somme fixe transférée chaque mois du Principal vers ton compte Vie Courante. C&apos;est ce
+          qui servira aux courses, à l&apos;essence et aux restos.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={onSubmit} className="flex flex-col gap-3 sm:flex-row sm:items-end">
+          <div className="flex flex-1 flex-col gap-2">
+            <Label htmlFor="vie-transfer">Montant (€)</Label>
+            <Input
+              id="vie-transfer"
+              type="number"
+              inputMode="decimal"
+              min={0}
+              step="0.01"
+              placeholder="Ex. 500"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+            />
+          </div>
+          <Button type="submit" disabled={isPending}>
+            {isPending ? 'Enregistrement…' : 'Enregistrer'}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+function AccountBalanceCard({ row }: { row: AccountRow }) {
+  const Icon = ACCOUNT_ICONS[row.kind];
+  const [value, setValue] = useState(String(row.balance));
+  const [isPending, startTransition] = useTransition();
+
+  function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const amount = parseAmount(value);
+    if (amount === null) {
+      toast.error('Entre un montant valide.');
+      return;
+    }
+    startTransition(async () => {
+      const result = await updateAccountBalanceAction({ kind: row.kind, balance: amount });
+      if (result.ok) toast.success(`${row.label} mis à jour`);
+      else toast.error(result.error);
+    });
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center gap-2 text-(--color-brand-700)">
+          <Icon className="h-5 w-5" aria-hidden />
+          <CardTitle className="text-sm font-medium">{row.label}</CardTitle>
+        </div>
+        <CardDescription className="text-xs">{ACCOUNT_KIND_DESCRIPTIONS[row.kind]}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="mb-3 text-2xl font-bold tabular-nums">{formatMoney(row.balance)}</p>
+        <form onSubmit={onSubmit} className="flex flex-col gap-2">
+          <Label htmlFor={`balance-${row.kind}`} className="sr-only">
+            Solde actuel de {row.label}
+          </Label>
+          <Input
+            id={`balance-${row.kind}`}
+            type="number"
+            inputMode="decimal"
+            step="0.01"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+          />
+          <Button type="submit" size="sm" variant="outline" disabled={isPending}>
+            {isPending ? 'Enregistrement…' : 'Mettre à jour'}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/app/accounts/page.tsx
+++ b/src/app/app/accounts/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next';
+
+import { getWorkspaceSnapshot } from '@/lib/data/workspace-snapshot';
+import { AccountsClient } from './AccountsClient';
+
+export const metadata: Metadata = {
+  title: 'Mes comptes',
+  description:
+    'Suis les soldes de tes comptes Principal, Vie Courante et Épargne. Règle ton revenu mensuel et ton virement vers Vie Courante.',
+};
+
+export default async function AccountsPage() {
+  const snapshot = await getWorkspaceSnapshot();
+
+  return (
+    <AccountsClient
+      monthlyIncome={snapshot.monthlyIncome}
+      vieCouranteMonthlyTransfer={snapshot.vieCouranteMonthlyTransfer}
+      accounts={snapshot.accounts}
+    />
+  );
+}

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -1,12 +1,30 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { ArrowRightLeft, PiggyBank, Receipt, Shield } from 'lucide-react';
+import {
+  ArrowDownLeft,
+  ArrowRightLeft,
+  ArrowUpRight,
+  Landmark,
+  PiggyBank,
+  Receipt,
+  Shield,
+  Wallet,
+} from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Budget, Provision, money } from '@/lib/domain';
+import { Budget, Provision, Transfer, money } from '@/lib/domain';
+import type { AccountKind } from '@/lib/domain/types';
 import { getWorkspaceSnapshot } from '@/lib/data/workspace-snapshot';
 import { formatMoney, formatMonth } from '@/lib/format';
+
+const ACCOUNT_ICONS: Record<AccountKind, typeof Landmark> = {
+  principal: Landmark,
+  vie_courante: Wallet,
+  epargne: PiggyBank,
+};
+
+const ACCOUNT_ORDER: AccountKind[] = ['principal', 'vie_courante', 'epargne'];
 
 export const metadata: Metadata = { title: 'Tableau de bord' };
 
@@ -40,6 +58,20 @@ export default async function DashboardPage() {
         : 'Critique';
 
   const hasCharges = snapshot.charges.length > 0;
+
+  const monthlyIncome = money(snapshot.monthlyIncome ?? 0);
+  const vieCouranteTransferAmount = money(snapshot.vieCouranteMonthlyTransfer ?? 0);
+  const plan = Transfer.computeMonthlyTransferPlan({
+    charges: snapshot.charges,
+    month: currentMonth,
+    monthlyIncome,
+    vieCouranteMonthlyTransfer: vieCouranteTransferAmount,
+  });
+  const epargneNetAbs = plan.epargneTransferNet.abs();
+  const epargneGoesToEpargne = plan.epargneTransferNet.gte(0);
+  const missingSetup =
+    snapshot.monthlyIncome === null || snapshot.vieCouranteMonthlyTransfer === null;
+  const accountByKind = new Map(snapshot.accounts.map((a) => [a.kind, a]));
 
   return (
     <div className="flex flex-col gap-8">
@@ -126,6 +158,137 @@ export default async function DashboardPage() {
             </CardContent>
           </Card>
         </div>
+      )}
+
+      {hasCharges && (
+        <section aria-labelledby="plan-heading" className="flex flex-col gap-4">
+          <div className="flex items-end justify-between gap-2">
+            <div>
+              <h2 id="plan-heading" className="text-xl font-semibold">
+                Plan du mois — {formatMonth(currentMonth)}
+              </h2>
+              <p className="text-sm text-(--color-muted-foreground)">
+                Les virements à exécuter en début de mois sur tes trois comptes.
+              </p>
+            </div>
+            <Button asChild variant="ghost" size="sm">
+              <Link href="/app/accounts">Ajuster mes comptes</Link>
+            </Button>
+          </div>
+
+          {missingSetup ? (
+            <Card>
+              <CardHeader>
+                <CardTitle>Renseigne d&apos;abord tes comptes</CardTitle>
+                <CardDescription>
+                  Pour calculer ton Virement Intelligent, Ankora a besoin de ton revenu mensuel et
+                  du montant fixe que tu envoies sur Vie Courante.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Button asChild>
+                  <Link href="/app/accounts">Configurer mes comptes</Link>
+                </Button>
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-3">
+              <Card>
+                <CardHeader className="pb-2">
+                  <div className="flex items-center gap-2 text-(--color-brand-700)">
+                    <ArrowRightLeft className="h-5 w-5" aria-hidden />
+                    <CardTitle className="text-sm font-medium">Principal → Vie Courante</CardTitle>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-2xl font-bold tabular-nums">
+                    {formatMoney(plan.vieCouranteTransfer)}
+                  </p>
+                  <p className="mt-1 text-xs text-(--color-muted-foreground)">
+                    Enveloppe courses, essence, restos.
+                  </p>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader className="pb-2">
+                  <div className="flex items-center gap-2 text-(--color-brand-700)">
+                    {epargneGoesToEpargne ? (
+                      <ArrowUpRight className="h-5 w-5" aria-hidden />
+                    ) : (
+                      <ArrowDownLeft className="h-5 w-5" aria-hidden />
+                    )}
+                    <CardTitle className="text-sm font-medium">
+                      {epargneGoesToEpargne ? 'Principal → Épargne' : 'Épargne → Principal'}
+                    </CardTitle>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-2xl font-bold tabular-nums">{formatMoney(epargneNetAbs)}</p>
+                  <p className="mt-1 text-xs text-(--color-muted-foreground)">
+                    Provision {formatMoney(plan.epargneProvisionTarget)} − factures{' '}
+                    {formatMoney(plan.epargneBillsDue)}
+                  </p>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader className="pb-2">
+                  <div
+                    className={`flex items-center gap-2 ${
+                      plan.netPrincipalAfterPlan.gte(0)
+                        ? 'text-(--color-success)'
+                        : 'text-(--color-danger)'
+                    }`}
+                  >
+                    <Landmark className="h-5 w-5" aria-hidden />
+                    <CardTitle className="text-sm font-medium">Restant Principal</CardTitle>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <p
+                    className={`text-2xl font-bold tabular-nums ${
+                      plan.netPrincipalAfterPlan.gte(0)
+                        ? 'text-(--color-success)'
+                        : 'text-(--color-danger)'
+                    }`}
+                  >
+                    {formatMoney(plan.netPrincipalAfterPlan)}
+                  </p>
+                  <p className="mt-1 text-xs text-(--color-muted-foreground)">
+                    Après salaire, virements et factures Principal (
+                    {formatMoney(plan.principalBillsDue)}
+                    ).
+                  </p>
+                </CardContent>
+              </Card>
+            </div>
+          )}
+
+          <div className="grid gap-4 md:grid-cols-3">
+            {ACCOUNT_ORDER.map((kind) => {
+              const account = accountByKind.get(kind);
+              const Icon = ACCOUNT_ICONS[kind];
+              return (
+                <Card key={kind}>
+                  <CardHeader className="pb-2">
+                    <div className="flex items-center gap-2 text-(--color-muted-foreground)">
+                      <Icon className="h-4 w-4" aria-hidden />
+                      <CardTitle className="text-xs font-medium tracking-wide uppercase">
+                        {account?.label ?? kind}
+                      </CardTitle>
+                    </div>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-xl font-semibold tabular-nums">
+                      {formatMoney(money(account?.balance ?? 0))}
+                    </p>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        </section>
       )}
 
       <div className="grid gap-4 md:grid-cols-3">

--- a/src/app/app/simulator/SimulatorClient.tsx
+++ b/src/app/app/simulator/SimulatorClient.tsx
@@ -13,7 +13,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Simulation, money, type Charge } from '@/lib/domain';
+import { Simulation, money, type Charge, type ChargePaidFrom } from '@/lib/domain';
 import { formatMoney } from '@/lib/format';
 
 type RawCharge = {
@@ -24,6 +24,7 @@ type RawCharge = {
   dueMonth: number;
   categoryId: string | null;
   isActive: boolean;
+  paidFrom: ChargePaidFrom;
 };
 
 type Mode = 'cancel' | 'negotiate' | 'add';
@@ -48,6 +49,7 @@ export function SimulatorClient({ charges }: { charges: RawCharge[] }) {
         dueMonth: c.dueMonth,
         categoryId: c.categoryId,
         isActive: c.isActive,
+        paidFrom: c.paidFrom,
       })),
     [charges],
   );
@@ -78,6 +80,7 @@ export function SimulatorClient({ charges }: { charges: RawCharge[] }) {
         dueMonth: Number(newDueMonth),
         categoryId: null,
         isActive: true,
+        paidFrom: newFrequency === 'monthly' ? 'principal' : 'epargne',
       },
     });
   }, [mode, chargeId, newAmount, newLabel, newFrequency, newDueMonth, domainCharges]);

--- a/src/components/auth/GoogleSignInButton.tsx
+++ b/src/components/auth/GoogleSignInButton.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { signInWithGoogleAction } from '@/lib/actions/auth';
+
+type Props = {
+  label?: string;
+};
+
+export function GoogleSignInButton({ label = 'Continuer avec Google' }: Props) {
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function onClick() {
+    setError(null);
+    startTransition(async () => {
+      const result = await signInWithGoogleAction();
+      if (!result.ok) setError(result.error);
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Button
+        type="button"
+        variant="outline"
+        className="w-full"
+        onClick={onClick}
+        disabled={isPending}
+      >
+        <GoogleGlyph />
+        <span>{isPending ? 'Redirection…' : label}</span>
+      </Button>
+      {error && (
+        <p role="alert" className="text-center text-xs font-medium text-(--color-danger)">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function GoogleGlyph() {
+  return (
+    <svg
+      className="h-4 w-4"
+      viewBox="0 0 48 48"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+      focusable="false"
+    >
+      <path
+        fill="#FFC107"
+        d="M43.6 20.5H42V20H24v8h11.3c-1.6 4.7-6 8-11.3 8a12 12 0 1 1 0-24c3 0 5.8 1.1 7.9 3l5.7-5.7A20 20 0 0 0 24 4a20 20 0 1 0 19.6 16.5Z"
+      />
+      <path
+        fill="#FF3D00"
+        d="m6.3 14.7 6.6 4.8A12 12 0 0 1 24 12c3 0 5.8 1.1 7.9 3l5.7-5.7A20 20 0 0 0 6.3 14.7Z"
+      />
+      <path
+        fill="#4CAF50"
+        d="M24 44c5.2 0 10-2 13.6-5.2l-6.3-5.3A12 12 0 0 1 12.7 28l-6.6 5A20 20 0 0 0 24 44Z"
+      />
+      <path
+        fill="#1976D2"
+        d="M43.6 20.5H42V20H24v8h11.3a12 12 0 0 1-4 5.5l6.3 5.3C41.8 35.6 44 30.2 44 24c0-1.2-.1-2.3-.4-3.5Z"
+      />
+    </svg>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -55,6 +55,9 @@ export function Header({ variant = 'marketing', isAuthenticated = false }: Heade
               <Link href="/app">Tableau de bord</Link>
             </Button>
             <Button asChild variant="ghost" size="sm">
+              <Link href="/app/accounts">Comptes</Link>
+            </Button>
+            <Button asChild variant="ghost" size="sm">
               <Link href="/app/charges">Charges</Link>
             </Button>
             <Button asChild variant="ghost" size="sm">

--- a/src/components/seo/JsonLd.tsx
+++ b/src/components/seo/JsonLd.tsx
@@ -16,9 +16,14 @@ import { headers } from 'next/headers';
 export async function JsonLd({ data }: { data: object }) {
   const nonce = (await headers()).get('x-nonce') ?? undefined;
   const propKey = ['dangerously', 'Set', 'Inner', 'HTML'].join('');
+  // HTML spec strips the `nonce` attribute from the DOM after parsing (to prevent
+  // exfiltration via CSS selectors), so the client sees nonce="" while SSR emits
+  // the real value. That discrepancy is benign — the JSON-LD payload is static
+  // data, not executable script — so we silence the hydration warning here.
   return createElement('script', {
     type: 'application/ld+json',
     nonce,
+    suppressHydrationWarning: true,
     [propKey]: { __html: JSON.stringify(data) },
   });
 }

--- a/src/lib/actions/accounts.ts
+++ b/src/lib/actions/accounts.ts
@@ -1,0 +1,188 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+import { createClient } from '@/lib/supabase/server';
+import {
+  accountBalanceSchema,
+  accountLabelSchema,
+  ACCOUNT_KIND_LABELS,
+} from '@/lib/schemas/account';
+import { monthlyIncomeSchema, vieCouranteTransferSchema } from '@/lib/schemas/workspace';
+import { AuditEvent, logAuditEvent } from '@/lib/security/audit-log';
+import { rateLimit } from '@/lib/security/rate-limit';
+
+export type ActionResult =
+  | { ok: true }
+  | { ok: false; error: string; fieldErrors?: Record<string, string[]> };
+
+async function resolveSessionWorkspace() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false as const, error: 'Session expirée.' };
+
+  const { data: membership } = await supabase
+    .from('workspace_members')
+    .select('workspace_id, role')
+    .eq('user_id', user.id)
+    .in('role', ['owner', 'editor'])
+    .order('joined_at', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+
+  if (!membership) return { ok: false as const, error: 'Aucun workspace accessible.' };
+
+  return {
+    ok: true as const,
+    supabase,
+    user,
+    workspaceId: membership.workspace_id,
+  };
+}
+
+function revalidateAccountPaths() {
+  revalidatePath('/app');
+  revalidatePath('/app/accounts');
+}
+
+// =========================================================================
+// Update balance on one of the 3 accounts
+// =========================================================================
+export async function updateAccountBalanceAction(input: unknown): Promise<ActionResult> {
+  const ctx = await resolveSessionWorkspace();
+  if (!ctx.ok) return { ok: false, error: ctx.error };
+
+  const rl = await rateLimit('mutation', `user:${ctx.user.id}`);
+  if (!rl.success) return { ok: false, error: 'Trop de requêtes. Attends une minute.' };
+
+  const parsed = accountBalanceSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      error: 'Données invalides',
+      fieldErrors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+    };
+  }
+
+  const { error } = await ctx.supabase
+    .from('accounts')
+    .update({ balance: parsed.data.balance })
+    .eq('workspace_id', ctx.workspaceId)
+    .eq('kind', parsed.data.kind);
+
+  if (error) return { ok: false, error: 'Impossible de mettre à jour le solde.' };
+
+  await logAuditEvent(
+    AuditEvent.ACCOUNT_BALANCE_UPDATED,
+    { userId: ctx.user.id, workspaceId: ctx.workspaceId },
+    { resource_type: 'account', resource_id: parsed.data.kind },
+  );
+
+  revalidateAccountPaths();
+  return { ok: true };
+}
+
+// =========================================================================
+// Rename an account (purely cosmetic, keeps the fixed kind enum)
+// =========================================================================
+export async function renameAccountAction(input: unknown): Promise<ActionResult> {
+  const ctx = await resolveSessionWorkspace();
+  if (!ctx.ok) return { ok: false, error: ctx.error };
+
+  const rl = await rateLimit('mutation', `user:${ctx.user.id}`);
+  if (!rl.success) return { ok: false, error: 'Trop de requêtes.' };
+
+  const parsed = accountLabelSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      error: 'Données invalides',
+      fieldErrors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+    };
+  }
+
+  const trimmed = parsed.data.label.trim() || ACCOUNT_KIND_LABELS[parsed.data.kind];
+
+  const { error } = await ctx.supabase
+    .from('accounts')
+    .update({ label: trimmed })
+    .eq('workspace_id', ctx.workspaceId)
+    .eq('kind', parsed.data.kind);
+
+  if (error) return { ok: false, error: 'Impossible de renommer le compte.' };
+
+  revalidateAccountPaths();
+  return { ok: true };
+}
+
+// =========================================================================
+// Update monthly income (workspaces.monthly_income)
+// =========================================================================
+export async function updateMonthlyIncomeAction(input: unknown): Promise<ActionResult> {
+  const ctx = await resolveSessionWorkspace();
+  if (!ctx.ok) return { ok: false, error: ctx.error };
+
+  const rl = await rateLimit('mutation', `user:${ctx.user.id}`);
+  if (!rl.success) return { ok: false, error: 'Trop de requêtes.' };
+
+  const parsed = monthlyIncomeSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      error: 'Données invalides',
+      fieldErrors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+    };
+  }
+
+  const { error } = await ctx.supabase
+    .from('workspaces')
+    .update({ monthly_income: parsed.data.monthlyIncome })
+    .eq('id', ctx.workspaceId);
+
+  if (error) return { ok: false, error: 'Impossible de mettre à jour le revenu.' };
+
+  await logAuditEvent(AuditEvent.WORKSPACE_UPDATED, {
+    userId: ctx.user.id,
+    workspaceId: ctx.workspaceId,
+  });
+
+  revalidateAccountPaths();
+  return { ok: true };
+}
+
+// =========================================================================
+// Update fixed monthly transfer Principal → Vie Courante
+// =========================================================================
+export async function updateVieCouranteTransferAction(input: unknown): Promise<ActionResult> {
+  const ctx = await resolveSessionWorkspace();
+  if (!ctx.ok) return { ok: false, error: ctx.error };
+
+  const rl = await rateLimit('mutation', `user:${ctx.user.id}`);
+  if (!rl.success) return { ok: false, error: 'Trop de requêtes.' };
+
+  const parsed = vieCouranteTransferSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      error: 'Données invalides',
+      fieldErrors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+    };
+  }
+
+  const { error } = await ctx.supabase
+    .from('workspaces')
+    .update({ vie_courante_monthly_transfer: parsed.data.amount })
+    .eq('id', ctx.workspaceId);
+
+  if (error) return { ok: false, error: 'Impossible de mettre à jour le virement.' };
+
+  await logAuditEvent(AuditEvent.WORKSPACE_UPDATED, {
+    userId: ctx.user.id,
+    workspaceId: ctx.workspaceId,
+  });
+
+  revalidateAccountPaths();
+  return { ok: true };
+}

--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -78,6 +78,36 @@ export async function signupAction(formData: FormData): Promise<ActionResult> {
   redirect('/signup/check-email');
 }
 
+export async function signInWithGoogleAction(): Promise<ActionResult> {
+  const { ip, userAgent } = await contextFromHeaders();
+  const identifier = ip ? `ip:${ip}` : 'anon';
+
+  const rl = await rateLimit('auth', identifier);
+  if (!rl.success) {
+    await logAuditEvent(AuditEvent.AUTH_RATE_LIMITED, { userId: null, ipAddress: ip, userAgent });
+    return { ok: false, error: 'Trop de tentatives. Réessaie dans quelques minutes.' };
+  }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    provider: 'google',
+    options: {
+      redirectTo: `${env.NEXT_PUBLIC_APP_URL}/auth/callback`,
+      queryParams: {
+        access_type: 'offline',
+        prompt: 'consent',
+      },
+    },
+  });
+
+  if (error || !data?.url) {
+    console.error('[signInWithGoogleAction]', error?.message ?? 'no url');
+    return { ok: false, error: 'Connexion Google indisponible. Réessaie plus tard.' };
+  }
+
+  redirect(data.url);
+}
+
 export async function loginAction(formData: FormData): Promise<ActionResult> {
   const { ip, userAgent } = await contextFromHeaders();
   const identifier = ip ? `ip:${ip}` : 'anon';

--- a/src/lib/data/workspace-snapshot.ts
+++ b/src/lib/data/workspace-snapshot.ts
@@ -1,14 +1,28 @@
 import { redirect } from 'next/navigation';
 
 import { createClient } from '@/lib/supabase/server';
-import { money, type Charge, type Expense } from '@/lib/domain/types';
+import {
+  money,
+  type AccountKind,
+  type Charge,
+  type ChargePaidFrom,
+  type Expense,
+} from '@/lib/domain/types';
+
+export type AccountSnapshot = {
+  kind: AccountKind;
+  label: string;
+  balance: number;
+};
 
 export type WorkspaceSnapshot = {
   workspaceId: string;
   workspaceName: string;
   monthlyIncome: number | null;
+  vieCouranteMonthlyTransfer: number | null;
   savingsBalance: number;
   monthsTracked: number;
+  accounts: AccountSnapshot[];
   charges: Charge[];
   rawCharges: Array<{
     id: string;
@@ -19,6 +33,7 @@ export type WorkspaceSnapshot = {
     categoryId: string | null;
     isActive: boolean;
     notes: string | null;
+    paidFrom: ChargePaidFrom;
   }>;
 };
 
@@ -51,8 +66,12 @@ export async function getWorkspaceSnapshot(): Promise<WorkspaceSnapshot> {
 
   const workspaceId = membership.workspace_id;
 
-  const [wsRes, settingsRes, chargesRes] = await Promise.all([
-    supabase.from('workspaces').select('id, name, monthly_income').eq('id', workspaceId).single(),
+  const [wsRes, settingsRes, chargesRes, accountsRes] = await Promise.all([
+    supabase
+      .from('workspaces')
+      .select('id, name, monthly_income, vie_courante_monthly_transfer')
+      .eq('id', workspaceId)
+      .single(),
     supabase
       .from('workspace_settings')
       .select('savings_balance, months_tracked')
@@ -60,9 +79,10 @@ export async function getWorkspaceSnapshot(): Promise<WorkspaceSnapshot> {
       .maybeSingle(),
     supabase
       .from('charges')
-      .select('id, label, amount, frequency, due_month, category_id, is_active, notes')
+      .select('id, label, amount, frequency, due_month, category_id, is_active, notes, paid_from')
       .eq('workspace_id', workspaceId)
       .order('created_at', { ascending: true }),
+    supabase.from('accounts').select('kind, label, balance').eq('workspace_id', workspaceId),
   ]);
 
   if (wsRes.error || !wsRes.data) redirect('/onboarding');
@@ -76,6 +96,7 @@ export async function getWorkspaceSnapshot(): Promise<WorkspaceSnapshot> {
     categoryId: c.category_id,
     isActive: c.is_active,
     notes: c.notes,
+    paidFrom: c.paid_from as ChargePaidFrom,
   }));
 
   const charges: Charge[] = rawCharges.map((c) => ({
@@ -86,14 +107,23 @@ export async function getWorkspaceSnapshot(): Promise<WorkspaceSnapshot> {
     dueMonth: c.dueMonth,
     categoryId: c.categoryId,
     isActive: c.isActive,
+    paidFrom: c.paidFrom,
+  }));
+
+  const accounts: AccountSnapshot[] = (accountsRes.data ?? []).map((a) => ({
+    kind: a.kind as AccountKind,
+    label: a.label,
+    balance: Number(a.balance),
   }));
 
   return {
     workspaceId,
     workspaceName: wsRes.data.name,
     monthlyIncome: wsRes.data.monthly_income,
+    vieCouranteMonthlyTransfer: wsRes.data.vie_courante_monthly_transfer,
     savingsBalance: Number(settingsRes.data?.savings_balance ?? 0),
     monthsTracked: Math.max(1, settingsRes.data?.months_tracked ?? 1),
+    accounts,
     charges,
     rawCharges,
   };
@@ -103,7 +133,7 @@ export async function getExpenses(workspaceId: string, limit = 50): Promise<Expe
   const supabase = await createClient();
   const { data } = await supabase
     .from('expenses')
-    .select('id, label, amount, occurred_on, category_id, note')
+    .select('id, label, amount, occurred_on, category_id, note, paid_from')
     .eq('workspace_id', workspaceId)
     .order('occurred_on', { ascending: false })
     .limit(limit);
@@ -115,5 +145,6 @@ export async function getExpenses(workspaceId: string, limit = 50): Promise<Expe
     occurredOn: e.occurred_on,
     categoryId: e.category_id,
     note: e.note,
+    paidFrom: e.paid_from as AccountKind,
   }));
 }

--- a/src/lib/domain/__tests__/balance.test.ts
+++ b/src/lib/domain/__tests__/balance.test.ts
@@ -10,6 +10,7 @@ const exp = (id: string, amount: number, categoryId: string | null): Expense => 
   occurredOn: '2026-04-15',
   categoryId,
   note: null,
+  paidFrom: 'vie_courante',
 });
 
 describe('summarizeExpenses', () => {

--- a/src/lib/domain/__tests__/budget.test.ts
+++ b/src/lib/domain/__tests__/budget.test.ts
@@ -12,6 +12,7 @@ import type { Charge } from '@/lib/domain/types';
 const base = {
   categoryId: null,
   isActive: true,
+  paidFrom: 'principal',
 } satisfies Partial<Charge>;
 
 const rent: Charge = {

--- a/src/lib/domain/__tests__/provision.test.ts
+++ b/src/lib/domain/__tests__/provision.test.ts
@@ -12,6 +12,7 @@ const charges: Charge[] = [
     dueMonth: 1,
     categoryId: null,
     isActive: true,
+    paidFrom: 'principal',
   },
   {
     id: 'c2',
@@ -21,6 +22,7 @@ const charges: Charge[] = [
     dueMonth: 3,
     categoryId: null,
     isActive: true,
+    paidFrom: 'principal',
   },
 ];
 // Monthly provision target = 900 + 100 = 1000

--- a/src/lib/domain/__tests__/simulation.test.ts
+++ b/src/lib/domain/__tests__/simulation.test.ts
@@ -12,6 +12,7 @@ const charges: Charge[] = [
     dueMonth: 1,
     categoryId: null,
     isActive: true,
+    paidFrom: 'principal',
   },
   {
     id: 'c2',
@@ -21,6 +22,7 @@ const charges: Charge[] = [
     dueMonth: 3,
     categoryId: null,
     isActive: true,
+    paidFrom: 'principal',
   },
 ];
 // Monthly provision = 50 + 100 = 150
@@ -70,6 +72,7 @@ describe('simulate / add', () => {
         dueMonth: 1,
         categoryId: null,
         isActive: true,
+        paidFrom: 'principal',
       },
     });
     expect(result.projectedMonthlyProvision.toNumber()).toBe(165);
@@ -87,6 +90,7 @@ describe('simulate / add', () => {
           dueMonth: 1,
           categoryId: null,
           isActive: true,
+          paidFrom: 'principal',
         },
       }),
     ).toThrow(RangeError);

--- a/src/lib/domain/__tests__/transfer.test.ts
+++ b/src/lib/domain/__tests__/transfer.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect } from 'vitest';
+
+import { money, type Charge } from '@/lib/domain/types';
+import { computeMonthlyTransferPlan, projectedEpargneBalance } from '@/lib/domain/transfer';
+
+const monthlyCharge = (over: Partial<Charge> = {}): Charge => ({
+  id: 'm1',
+  label: 'Loyer',
+  amount: money(900),
+  frequency: 'monthly',
+  dueMonth: 1,
+  categoryId: null,
+  isActive: true,
+  paidFrom: 'principal',
+  ...over,
+});
+
+const annualSmoothed = (over: Partial<Charge> = {}): Charge => ({
+  id: 'a1',
+  label: 'Taxe voiture',
+  amount: money(1200),
+  frequency: 'annual',
+  dueMonth: 6,
+  categoryId: null,
+  isActive: true,
+  paidFrom: 'epargne',
+  ...over,
+});
+
+const quarterlySmoothed = (over: Partial<Charge> = {}): Charge => ({
+  id: 'q1',
+  label: 'Eau',
+  amount: money(90),
+  frequency: 'quarterly',
+  dueMonth: 2,
+  categoryId: null,
+  isActive: true,
+  paidFrom: 'epargne',
+  ...over,
+});
+
+describe('computeMonthlyTransferPlan — lightest case', () => {
+  it('returns zero everywhere when no charges and no salary', () => {
+    const plan = computeMonthlyTransferPlan({
+      charges: [],
+      month: 1,
+      monthlyIncome: money(0),
+      vieCouranteMonthlyTransfer: money(0),
+    });
+
+    expect(plan.epargneProvisionTarget.toNumber()).toBe(0);
+    expect(plan.epargneBillsDue.toNumber()).toBe(0);
+    expect(plan.epargneTransferNet.toNumber()).toBe(0);
+    expect(plan.principalBillsDue.toNumber()).toBe(0);
+    expect(plan.netPrincipalAfterPlan.toNumber()).toBe(0);
+  });
+});
+
+describe('computeMonthlyTransferPlan — monthly bills paid from Principal', () => {
+  it('hits Principal every month; Épargne untouched', () => {
+    const plan = computeMonthlyTransferPlan({
+      charges: [monthlyCharge()],
+      month: 5,
+      monthlyIncome: money(2500),
+      vieCouranteMonthlyTransfer: money(500),
+    });
+
+    expect(plan.principalBillsDue.toNumber()).toBe(900);
+    expect(plan.epargneTransferNet.toNumber()).toBe(0);
+    expect(plan.netPrincipalAfterPlan.toNumber()).toBe(2500 - 500 - 900);
+  });
+});
+
+describe('computeMonthlyTransferPlan — "Virement Intelligent"', () => {
+  it('nets provision against bills due in the same month', () => {
+    // IronBudget reference example: provision 59€, bill 53€ this month → net 6€.
+    const dashlane: Charge = {
+      id: 'dashlane',
+      label: 'Dashlane',
+      amount: money(53),
+      frequency: 'annual',
+      dueMonth: 4,
+      categoryId: null,
+      isActive: true,
+      paidFrom: 'epargne',
+    };
+    // Provision total ≈ 53 / 12 ≈ 4.4166… so we craft another charge to bring it to 59.
+    // Use an annual charge of (59 - 53/12)*12 = 655 to push the monthly provision to 59.
+    const extra: Charge = {
+      id: 'extra',
+      label: 'Charge composée',
+      amount: money(655),
+      frequency: 'annual',
+      dueMonth: 10,
+      categoryId: null,
+      isActive: true,
+      paidFrom: 'epargne',
+    };
+
+    const plan = computeMonthlyTransferPlan({
+      charges: [dashlane, extra],
+      month: 4,
+      monthlyIncome: money(2500),
+      vieCouranteMonthlyTransfer: money(500),
+    });
+
+    expect(plan.epargneProvisionTarget.toNumber()).toBe(59);
+    expect(plan.epargneBillsDue.toNumber()).toBe(53);
+    expect(plan.epargneTransferNet.toNumber()).toBe(6);
+  });
+});
+
+describe('computeMonthlyTransferPlan — heavy-bill month', () => {
+  it('returns negative epargneTransferNet when bills exceed provisioning', () => {
+    const plan = computeMonthlyTransferPlan({
+      charges: [annualSmoothed()],
+      month: 6,
+      monthlyIncome: money(2500),
+      vieCouranteMonthlyTransfer: money(500),
+    });
+
+    expect(plan.epargneProvisionTarget.toNumber()).toBe(100);
+    expect(plan.epargneBillsDue.toNumber()).toBe(1200);
+    expect(plan.epargneTransferNet.toNumber()).toBe(-1100);
+    // Principal recovers 1100 from Épargne, pays the bill (already on Épargne side).
+    expect(plan.netPrincipalAfterPlan.toNumber()).toBe(2500 - 500 - -1100);
+  });
+});
+
+describe('computeMonthlyTransferPlan — periodic charge flagged principal', () => {
+  it('lands bill on Principal in its due month and skips Épargne', () => {
+    const plan = computeMonthlyTransferPlan({
+      charges: [annualSmoothed({ paidFrom: 'principal' })],
+      month: 6,
+      monthlyIncome: money(2500),
+      vieCouranteMonthlyTransfer: money(500),
+    });
+
+    expect(plan.epargneProvisionTarget.toNumber()).toBe(0);
+    expect(plan.epargneBillsDue.toNumber()).toBe(0);
+    expect(plan.epargneTransferNet.toNumber()).toBe(0);
+    expect(plan.principalBillsDue.toNumber()).toBe(1200);
+  });
+
+  it('skips the bill in other months', () => {
+    const plan = computeMonthlyTransferPlan({
+      charges: [annualSmoothed({ paidFrom: 'principal' })],
+      month: 5,
+      monthlyIncome: money(2500),
+      vieCouranteMonthlyTransfer: money(500),
+    });
+    expect(plan.principalBillsDue.toNumber()).toBe(0);
+  });
+});
+
+describe('computeMonthlyTransferPlan — full mix', () => {
+  it('handles monthly + smoothed quarterly + smoothed annual together', () => {
+    const plan = computeMonthlyTransferPlan({
+      charges: [monthlyCharge(), quarterlySmoothed(), annualSmoothed()],
+      month: 2,
+      monthlyIncome: money(2500),
+      vieCouranteMonthlyTransfer: money(500),
+    });
+
+    // Monthly provision of smoothed set = 90/3 + 1200/12 = 30 + 100 = 130
+    expect(plan.epargneProvisionTarget.toNumber()).toBe(130);
+    // Smoothed bills due in month 2 = water 90 (quarterly, dueMonth=2)
+    expect(plan.epargneBillsDue.toNumber()).toBe(90);
+    // Net transfer to Épargne = 130 - 90 = 40
+    expect(plan.epargneTransferNet.toNumber()).toBe(40);
+    // Principal bills this month = rent 900 only
+    expect(plan.principalBillsDue.toNumber()).toBe(900);
+    // Principal remainder = 2500 - 500 - 40 - 900 = 1060
+    expect(plan.netPrincipalAfterPlan.toNumber()).toBe(1060);
+  });
+});
+
+describe('computeMonthlyTransferPlan — input validation', () => {
+  it('rejects month < 1 or > 12', () => {
+    expect(() =>
+      computeMonthlyTransferPlan({
+        charges: [],
+        month: 0,
+        monthlyIncome: money(0),
+        vieCouranteMonthlyTransfer: money(0),
+      }),
+    ).toThrow(RangeError);
+    expect(() =>
+      computeMonthlyTransferPlan({
+        charges: [],
+        month: 13,
+        monthlyIncome: money(0),
+        vieCouranteMonthlyTransfer: money(0),
+      }),
+    ).toThrow(RangeError);
+  });
+
+  it('rejects negative salary', () => {
+    expect(() =>
+      computeMonthlyTransferPlan({
+        charges: [],
+        month: 1,
+        monthlyIncome: money(-1),
+        vieCouranteMonthlyTransfer: money(0),
+      }),
+    ).toThrow(RangeError);
+  });
+
+  it('rejects negative vie courante transfer', () => {
+    expect(() =>
+      computeMonthlyTransferPlan({
+        charges: [],
+        month: 1,
+        monthlyIncome: money(0),
+        vieCouranteMonthlyTransfer: money(-1),
+      }),
+    ).toThrow(RangeError);
+  });
+});
+
+describe('computeMonthlyTransferPlan — inactive charges', () => {
+  it('skips inactive charges entirely', () => {
+    const plan = computeMonthlyTransferPlan({
+      charges: [monthlyCharge({ isActive: false }), annualSmoothed({ isActive: false })],
+      month: 6,
+      monthlyIncome: money(2500),
+      vieCouranteMonthlyTransfer: money(500),
+    });
+    expect(plan.epargneProvisionTarget.toNumber()).toBe(0);
+    expect(plan.epargneBillsDue.toNumber()).toBe(0);
+    expect(plan.principalBillsDue.toNumber()).toBe(0);
+  });
+});
+
+describe('projectedEpargneBalance', () => {
+  it('adds net transfer to current balance', () => {
+    const plan = computeMonthlyTransferPlan({
+      charges: [annualSmoothed()],
+      month: 1,
+      monthlyIncome: money(2500),
+      vieCouranteMonthlyTransfer: money(500),
+    });
+    expect(projectedEpargneBalance(money(300), plan).toNumber()).toBe(400);
+  });
+
+  it('handles negative net transfer (withdrawal from Épargne)', () => {
+    const plan = computeMonthlyTransferPlan({
+      charges: [annualSmoothed()],
+      month: 6,
+      monthlyIncome: money(2500),
+      vieCouranteMonthlyTransfer: money(500),
+    });
+    expect(projectedEpargneBalance(money(1500), plan).toNumber()).toBe(400);
+  });
+});

--- a/src/lib/domain/budget.ts
+++ b/src/lib/domain/budget.ts
@@ -1,11 +1,24 @@
 import { money, zero, type Charge, type ChargeFrequency, type Money } from '@/lib/domain/types';
 
-const FREQUENCY_DIVISOR: Record<ChargeFrequency, number> = {
+export const FREQUENCY_DIVISOR: Record<ChargeFrequency, number> = {
   monthly: 1,
   quarterly: 3,
   semiannual: 6,
   annual: 12,
 };
+
+/**
+ * Whether a charge falls due in a given month.
+ * Monthly charges are always due; periodic charges only on their reference month
+ * and every N months thereafter (N = period in months).
+ */
+export function isChargeDueInMonth(charge: Charge, month: number): boolean {
+  if (!charge.isActive) return false;
+  if (charge.frequency === 'monthly') return true;
+  const period = FREQUENCY_DIVISOR[charge.frequency];
+  if (period === 12) return charge.dueMonth === month;
+  return (((month - charge.dueMonth) % period) + period) % period === 0;
+}
 
 /**
  * Monthly provision target for a single charge — amount spread across its period.
@@ -31,16 +44,10 @@ export function monthlyProvisionTotal(charges: readonly Charge[]): Money {
 export function billsDueInMonth(charges: readonly Charge[], month: number): Money {
   if (month < 1 || month > 12) throw new RangeError(`month must be 1..12, received ${month}`);
 
-  return charges.reduce((acc, charge) => {
-    if (!charge.isActive) return acc;
-    if (charge.frequency === 'monthly') return acc.plus(charge.amount);
-    if (charge.dueMonth === month) return acc.plus(charge.amount);
-    if (charge.frequency === 'quarterly' && (month - charge.dueMonth) % 3 === 0)
-      return acc.plus(charge.amount);
-    if (charge.frequency === 'semiannual' && (month - charge.dueMonth) % 6 === 0)
-      return acc.plus(charge.amount);
-    return acc;
-  }, zero());
+  return charges.reduce(
+    (acc, charge) => (isChargeDueInMonth(charge, month) ? acc.plus(charge.amount) : acc),
+    zero(),
+  );
 }
 
 /**

--- a/src/lib/domain/index.ts
+++ b/src/lib/domain/index.ts
@@ -3,3 +3,4 @@ export * as Budget from '@/lib/domain/budget';
 export * as Provision from '@/lib/domain/provision';
 export * as Simulation from '@/lib/domain/simulation';
 export * as Balance from '@/lib/domain/balance';
+export * as Transfer from '@/lib/domain/transfer';

--- a/src/lib/domain/transfer.ts
+++ b/src/lib/domain/transfer.ts
@@ -1,0 +1,106 @@
+import { zero, type Charge, type Money } from '@/lib/domain/types';
+import {
+  isChargeDueInMonth,
+  monthlyProvisionFor,
+  monthlyProvisionTotal,
+} from '@/lib/domain/budget';
+
+/**
+ * Concrete movements to perform at the start of a month under the 3-account
+ * IronBudget model. All figures are absolute positive amounts except where
+ * noted — UI decides the visual direction from the sign of epargneTransferNet.
+ */
+export type MonthlyTransferPlan = {
+  month: number;
+  /** Salary credited to Principal. */
+  salary: Money;
+  /** Fixed allowance Principal → Vie Courante. */
+  vieCouranteTransfer: Money;
+  /** Net transfer Principal → Épargne for smoothed charges.
+   *  Positive = Principal pays forward into Épargne.
+   *  Negative = Épargne pays back to Principal (heavy bill month). */
+  epargneTransferNet: Money;
+  /** Sum of charges paid directly from Principal in this month (monthly bills
+   *  plus any periodic charge explicitly flagged paid_from='principal'). */
+  principalBillsDue: Money;
+  /** Sum of smoothed (epargne) charges actually dropping this month. */
+  epargneBillsDue: Money;
+  /** Total monthly provision target for smoothed charges — the baseline before
+   *  netting against bills due. Useful for "healthy flow" UI. */
+  epargneProvisionTarget: Money;
+  /** Residual on Principal after salary - vieCouranteTransfer - epargneNet
+   *  - principalBillsDue. Negative = the month does not break even. */
+  netPrincipalAfterPlan: Money;
+};
+
+export type TransferPlanInput = {
+  charges: readonly Charge[];
+  month: number;
+  monthlyIncome: Money;
+  vieCouranteMonthlyTransfer: Money;
+};
+
+/**
+ * Build the month's 3-account movement plan.
+ *
+ * Smoothed charges (paid_from='epargne'): provision sits on Épargne and absorbs
+ * the bill when it drops. We execute a single net transfer each month instead
+ * of the naive "provision-then-withdraw" pair.
+ *
+ * Non-smoothed charges (paid_from='principal'): paid straight from Principal
+ * on their due month. The user's salary must cover them directly.
+ */
+export function computeMonthlyTransferPlan({
+  charges,
+  month,
+  monthlyIncome,
+  vieCouranteMonthlyTransfer,
+}: TransferPlanInput): MonthlyTransferPlan {
+  if (month < 1 || month > 12) throw new RangeError(`month must be 1..12, received ${month}`);
+  if (monthlyIncome.lt(0)) throw new RangeError('monthlyIncome must be >= 0');
+  if (vieCouranteMonthlyTransfer.lt(0))
+    throw new RangeError('vieCouranteMonthlyTransfer must be >= 0');
+
+  const smoothed = charges.filter((c) => c.isActive && c.paidFrom === 'epargne');
+  const principalCharges = charges.filter((c) => c.isActive && c.paidFrom === 'principal');
+
+  const epargneProvisionTarget = monthlyProvisionTotal(smoothed);
+
+  const epargneBillsDue = smoothed.reduce(
+    (acc, c) => (isChargeDueInMonth(c, month) ? acc.plus(c.amount) : acc),
+    zero(),
+  );
+
+  const epargneTransferNet = epargneProvisionTarget.minus(epargneBillsDue);
+
+  const principalBillsDue = principalCharges.reduce(
+    (acc, c) => (isChargeDueInMonth(c, month) ? acc.plus(c.amount) : acc),
+    zero(),
+  );
+
+  const netPrincipalAfterPlan = monthlyIncome
+    .minus(vieCouranteMonthlyTransfer)
+    .minus(epargneTransferNet)
+    .minus(principalBillsDue);
+
+  return {
+    month,
+    salary: monthlyIncome,
+    vieCouranteTransfer: vieCouranteMonthlyTransfer,
+    epargneTransferNet,
+    principalBillsDue,
+    epargneBillsDue,
+    epargneProvisionTarget,
+    netPrincipalAfterPlan,
+  };
+}
+
+/**
+ * Projected Épargne balance after this month's net transfer lands.
+ * Helper for "Plan du mois" UI — caller supplies current balance.
+ */
+export function projectedEpargneBalance(currentBalance: Money, plan: MonthlyTransferPlan): Money {
+  return currentBalance.plus(plan.epargneTransferNet);
+}
+
+export const transferPlanInternals = { monthlyProvisionFor };

--- a/src/lib/domain/types.ts
+++ b/src/lib/domain/types.ts
@@ -9,6 +9,13 @@ export const zero = (): Money => new Decimal(0);
 
 export type ChargeFrequency = 'monthly' | 'quarterly' | 'semiannual' | 'annual';
 
+/** Physical account that settles a charge or an expense. */
+export type AccountKind = 'principal' | 'vie_courante' | 'epargne';
+
+/** Accounts allowed as a charge source. Vie-courante is excluded by design:
+ *  its role is daily spending, not bill settlement. */
+export type ChargePaidFrom = Extract<AccountKind, 'principal' | 'epargne'>;
+
 export type Charge = {
   id: string;
   label: string;
@@ -18,6 +25,9 @@ export type Charge = {
   dueMonth: number;
   categoryId: string | null;
   isActive: boolean;
+  /** Which account settles the bill. Defaults to 'principal' in the DB;
+   *  periodic charges normally use 'epargne' to be smoothed. */
+  paidFrom: ChargePaidFrom;
 };
 
 export type Expense = {
@@ -28,6 +38,7 @@ export type Expense = {
   occurredOn: string;
   categoryId: string | null;
   note: string | null;
+  paidFrom: AccountKind;
 };
 
 export type MonthKey =

--- a/src/lib/schemas/account.ts
+++ b/src/lib/schemas/account.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+
+export const accountKindSchema = z.enum(['principal', 'vie_courante', 'epargne']);
+
+export const accountBalanceSchema = z.object({
+  kind: accountKindSchema,
+  balance: z
+    .number({ error: 'Solde invalide' })
+    .finite()
+    .min(-1_000_000_000_000, { message: 'Valeur hors limites' })
+    .max(1_000_000_000_000, { message: 'Valeur hors limites' }),
+});
+
+export const accountLabelSchema = z.object({
+  kind: accountKindSchema,
+  label: z.string().trim().min(1, { message: 'Libellé requis' }).max(60),
+});
+
+export type AccountKind = z.infer<typeof accountKindSchema>;
+export type AccountBalanceInput = z.infer<typeof accountBalanceSchema>;
+export type AccountLabelInput = z.infer<typeof accountLabelSchema>;
+
+export const ACCOUNT_KIND_LABELS: Record<AccountKind, string> = {
+  principal: 'Compte Principal',
+  vie_courante: 'Vie Courante',
+  epargne: 'Épargne & Provisions',
+};
+
+export const ACCOUNT_KIND_DESCRIPTIONS: Record<AccountKind, string> = {
+  principal: 'Reçoit le salaire, paye les charges fixes mensuelles.',
+  vie_courante: 'Budget du quotidien (courses, essence, restos).',
+  epargne: 'Lisse les factures trimestrielles et annuelles.',
+};

--- a/src/lib/schemas/charge.ts
+++ b/src/lib/schemas/charge.ts
@@ -2,6 +2,8 @@ import { z } from 'zod';
 
 export const chargeFrequencySchema = z.enum(['monthly', 'quarterly', 'semiannual', 'annual']);
 
+export const chargePaidFromSchema = z.enum(['principal', 'epargne']);
+
 export const chargeInputSchema = z.object({
   label: z
     .string()
@@ -22,9 +24,11 @@ export const chargeInputSchema = z.object({
   categoryId: z.string().uuid().nullable(),
   isActive: z.boolean().default(true),
   notes: z.string().max(500).optional().nullable(),
+  paidFrom: chargePaidFromSchema.optional(),
 });
 
 export const chargeUpdateSchema = chargeInputSchema.partial();
 
 export type ChargeInput = z.infer<typeof chargeInputSchema>;
 export type ChargeUpdate = z.infer<typeof chargeUpdateSchema>;
+export type ChargePaidFrom = z.infer<typeof chargePaidFromSchema>;

--- a/src/lib/schemas/expense.ts
+++ b/src/lib/schemas/expense.ts
@@ -1,11 +1,14 @@
 import { z } from 'zod';
 
+import { accountKindSchema } from './account';
+
 export const expenseInputSchema = z.object({
   label: z.string().trim().min(1, { message: 'Libellé requis' }).max(120),
   amount: z.number().finite().min(0).max(1_000_000),
   occurredOn: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, { message: 'Format attendu: YYYY-MM-DD' }),
   categoryId: z.string().uuid().nullable(),
   note: z.string().max(500).nullable(),
+  paidFrom: accountKindSchema.default('vie_courante'),
 });
 
 export const expenseUpdateSchema = expenseInputSchema.partial();

--- a/src/lib/schemas/workspace.ts
+++ b/src/lib/schemas/workspace.ts
@@ -5,9 +5,28 @@ export const workspaceInputSchema = z.object({
   currency: z.enum(['EUR', 'USD', 'GBP', 'CHF']).default('EUR'),
   monthlyIncome: z.number().finite().min(0).max(10_000_000).nullable(),
   fiscalMonthStart: z.number().int().min(1).max(28).default(1),
+  vieCouranteMonthlyTransfer: z.number().finite().min(0).max(100_000_000).nullable().optional(),
 });
 
 export const workspaceUpdateSchema = workspaceInputSchema.partial();
+
+export const monthlyIncomeSchema = z.object({
+  monthlyIncome: z
+    .number({ error: 'Revenu invalide' })
+    .finite()
+    .min(0, { message: 'Doit être ≥ 0' })
+    .max(10_000_000)
+    .nullable(),
+});
+
+export const vieCouranteTransferSchema = z.object({
+  amount: z
+    .number({ error: 'Montant invalide' })
+    .finite()
+    .min(0, { message: 'Doit être ≥ 0' })
+    .max(100_000_000)
+    .nullable(),
+});
 
 export type WorkspaceInput = z.infer<typeof workspaceInputSchema>;
 export type WorkspaceUpdate = z.infer<typeof workspaceUpdateSchema>;

--- a/src/lib/security/audit-log.ts
+++ b/src/lib/security/audit-log.ts
@@ -26,6 +26,7 @@ export const AuditEvent = {
   EXPENSE_CREATED: 'expense.created',
   EXPENSE_UPDATED: 'expense.updated',
   EXPENSE_DELETED: 'expense.deleted',
+  ACCOUNT_BALANCE_UPDATED: 'account.balance_updated',
 
   // GDPR
   GDPR_CONSENT_GIVEN: 'gdpr.consent_given',

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -33,6 +33,38 @@ export type Database = {
   };
   public: {
     Tables: {
+      accounts: {
+        Row: {
+          balance: number;
+          kind: string;
+          label: string;
+          updated_at: string;
+          workspace_id: string;
+        };
+        Insert: {
+          balance?: number;
+          kind: string;
+          label: string;
+          updated_at?: string;
+          workspace_id: string;
+        };
+        Update: {
+          balance?: number;
+          kind?: string;
+          label?: string;
+          updated_at?: string;
+          workspace_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'accounts_workspace_id_fkey';
+            columns: ['workspace_id'];
+            isOneToOne: false;
+            referencedRelation: 'workspaces';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       audit_log: {
         Row: {
           event_type: string;
@@ -141,6 +173,7 @@ export type Database = {
           is_active: boolean;
           label: string;
           notes: string | null;
+          paid_from: string;
           updated_at: string;
           workspace_id: string;
         };
@@ -155,6 +188,7 @@ export type Database = {
           is_active?: boolean;
           label: string;
           notes?: string | null;
+          paid_from?: string;
           updated_at?: string;
           workspace_id: string;
         };
@@ -169,6 +203,7 @@ export type Database = {
           is_active?: boolean;
           label?: string;
           notes?: string | null;
+          paid_from?: string;
           updated_at?: string;
           workspace_id?: string;
         };
@@ -247,6 +282,7 @@ export type Database = {
           label: string;
           note: string | null;
           occurred_on: string;
+          paid_from: string;
           workspace_id: string;
         };
         Insert: {
@@ -258,6 +294,7 @@ export type Database = {
           label: string;
           note?: string | null;
           occurred_on: string;
+          paid_from?: string;
           workspace_id: string;
         };
         Update: {
@@ -269,6 +306,7 @@ export type Database = {
           label?: string;
           note?: string | null;
           occurred_on?: string;
+          paid_from?: string;
           workspace_id?: string;
         };
         Relationships: [
@@ -447,6 +485,7 @@ export type Database = {
           name: string;
           owner_id: string;
           updated_at: string;
+          vie_courante_monthly_transfer: number | null;
         };
         Insert: {
           created_at?: string;
@@ -457,6 +496,7 @@ export type Database = {
           name: string;
           owner_id: string;
           updated_at?: string;
+          vie_courante_monthly_transfer?: number | null;
         };
         Update: {
           created_at?: string;
@@ -467,6 +507,7 @@ export type Database = {
           name?: string;
           owner_id?: string;
           updated_at?: string;
+          vie_courante_monthly_transfer?: number | null;
         };
         Relationships: [
           {
@@ -483,8 +524,19 @@ export type Database = {
       [_ in never]: never;
     };
     Functions: {
+      assert_rls_coverage: {
+        Args: never;
+        Returns: {
+          rls_enabled: boolean;
+          rls_forced: boolean;
+          schema_name: string;
+          table_name: string;
+        }[];
+      };
       is_workspace_editor: { Args: { ws_id: string }; Returns: boolean };
       is_workspace_member: { Args: { ws_id: string }; Returns: boolean };
+      purge_audit_log_older_than_12_months: { Args: never; Returns: number };
+      seed_default_accounts: { Args: { ws_id: string }; Returns: undefined };
     };
     Enums: {
       [_ in never]: never;

--- a/supabase/migrations/20260417000004_three_accounts_model.sql
+++ b/supabase/migrations/20260417000004_three_accounts_model.sql
@@ -1,0 +1,126 @@
+-- =========================================================================
+-- Migration: IronBudget 3-account model
+-- =========================================================================
+-- Each workspace owns exactly 3 named accounts that mirror the real-world
+-- bank architecture described in the product spec:
+--
+--   principal     — receives salary, pays fixed monthly bills
+--   vie_courante  — daily spending pot (fixed transfer from principal)
+--   epargne       — provisioning buffer for quarterly/annual bills
+--
+-- Charges with frequency='monthly' are debited from principal; periodic
+-- charges are debited from epargne (provisioning). Expenses default to
+-- vie_courante but can be reassigned.
+-- =========================================================================
+
+-- -------------------------------------------------------------------------
+-- 1. Accounts table — composite PK (workspace_id, kind) enforces exactly
+--    one row per kind per workspace.
+-- -------------------------------------------------------------------------
+create table public.accounts (
+  workspace_id uuid not null references public.workspaces(id) on delete cascade,
+  kind text not null check (kind in ('principal','vie_courante','epargne')),
+  label text not null check (char_length(label) between 1 and 60),
+  balance numeric(14,2) not null default 0 check (balance >= -1e12 and balance <= 1e12),
+  updated_at timestamptz not null default now(),
+  primary key (workspace_id, kind)
+);
+
+create index accounts_workspace_idx on public.accounts(workspace_id);
+
+alter table public.accounts enable row level security;
+alter table public.accounts force  row level security;
+
+create trigger accounts_touch before update on public.accounts
+  for each row execute function public.touch_updated_at();
+
+-- RLS: member reads, editor updates (mirrors workspace_settings policy).
+-- No INSERT policy — seeding happens via handle_new_user() trigger only.
+-- No DELETE policy — the three accounts are invariants of the workspace.
+create policy "accounts_member_select" on public.accounts
+  for select using (public.is_workspace_member(workspace_id));
+
+create policy "accounts_editor_update" on public.accounts
+  for update using (public.is_workspace_editor(workspace_id))
+  with check (public.is_workspace_editor(workspace_id));
+
+-- -------------------------------------------------------------------------
+-- 2. Workspaces: fixed monthly transfer from principal → vie_courante.
+--    Null = user hasn't set an allowance yet (onboarding-friendly).
+-- -------------------------------------------------------------------------
+alter table public.workspaces
+  add column vie_courante_monthly_transfer numeric(14,2)
+    check (vie_courante_monthly_transfer is null
+           or (vie_courante_monthly_transfer >= 0
+               and vie_courante_monthly_transfer <= 1e8));
+
+-- -------------------------------------------------------------------------
+-- 3. Expenses: which account was debited.
+--    Default 'vie_courante' matches IronBudget's daily-spending model.
+-- -------------------------------------------------------------------------
+alter table public.expenses
+  add column paid_from text not null default 'vie_courante'
+    check (paid_from in ('principal','vie_courante','epargne'));
+
+create index expenses_paid_from_idx on public.expenses(workspace_id, paid_from);
+
+-- -------------------------------------------------------------------------
+-- 4. Charges: which account pays (auto-derivable from frequency but made
+--    explicit so the user can override — e.g. an annual bill auto-debited
+--    from principal instead of epargne).
+-- -------------------------------------------------------------------------
+alter table public.charges
+  add column paid_from text not null default 'principal'
+    check (paid_from in ('principal','epargne'));
+
+-- -------------------------------------------------------------------------
+-- 5. Seeding helper — inserts the 3 default accounts for a workspace.
+-- -------------------------------------------------------------------------
+create or replace function public.seed_default_accounts(ws_id uuid)
+returns void language sql security definer set search_path = public as $$
+  insert into public.accounts (workspace_id, kind, label)
+  values
+    (ws_id, 'principal',    'Compte Principal'),
+    (ws_id, 'vie_courante', 'Vie Courante'),
+    (ws_id, 'epargne',      'Épargne & Provisions')
+  on conflict (workspace_id, kind) do nothing;
+$$;
+
+revoke execute on function public.seed_default_accounts(uuid) from public;
+
+-- -------------------------------------------------------------------------
+-- 6. handle_new_user: also seed the 3 accounts on signup.
+-- -------------------------------------------------------------------------
+create or replace function public.handle_new_user()
+returns trigger language plpgsql security definer set search_path = public as $$
+declare
+  new_workspace_id uuid;
+begin
+  insert into public.users (id, email, display_name)
+  values (new.id, new.email, split_part(new.email, '@', 1));
+
+  insert into public.workspaces (owner_id, name)
+  values (new.id, 'Mon espace')
+  returning id into new_workspace_id;
+
+  insert into public.workspace_members (workspace_id, user_id, role)
+  values (new_workspace_id, new.id, 'owner');
+
+  insert into public.workspace_settings (workspace_id) values (new_workspace_id);
+
+  perform public.seed_default_accounts(new_workspace_id);
+
+  return new;
+end $$;
+
+-- -------------------------------------------------------------------------
+-- 7. Backfill existing workspaces (idempotent via ON CONFLICT).
+-- -------------------------------------------------------------------------
+do $$
+declare
+  ws record;
+begin
+  for ws in select id from public.workspaces loop
+    perform public.seed_default_accounts(ws.id);
+  end loop;
+end $$;


### PR DESCRIPTION
## Summary
- **3-account model** (Principal / Vie Courante / Épargne) with Dashboard "Plan du mois" card powered by `Transfer.computeMonthlyTransferPlan()` and Playwright e2e coverage.
- **Google OAuth sign-in** via Supabase provider (login + signup pages), with audit logging and rate limiting.
- **Coda charges import script** (`npm run import:coda`) to seed real-life categories + charges into production.
- **SEO fix**: silence JsonLd hydration warning caused by the HTML spec stripping the nonce attribute.

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — 0 errors
- [x] `npm run test` — green
- [x] `npm run e2e` — green (local + CI)
- [x] Google OAuth validated end-to-end in real browser: `thierryvm@gmail.com` sign-in lands on `/onboarding` (new user) then `/app` after onboarding.
- [x] Import script executed against prod Supabase: 9 categories + 21 charges seeded on `thierryvm@hotmail.com` workspace (`56d4a74f-…`).
- [ ] Verify Vercel preview deployment
- [ ] Confirm `NEXT_PUBLIC_APP_URL=https://ankora-chi.vercel.app` is set in Vercel Production env vars (required for OAuth callback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)