### PR TITLE
chore(i18n): remove obsolete dashboard keys

### DIFF
--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -476,25 +476,7 @@
       "transferPrincipalRemainingHint": "Après salaire, virements et factures Principal ({bills}).",
       "ctaCharges": "Mes charges",
       "ctaExpenses": "Mes dépenses",
-      "ctaSimulator": "Simuler",
-      "title": "Tableau de bord",
-      "welcome": "Bienvenue {name}",
-      "subtitle": "Ton cockpit en un coup d'œil.",
-      "emptyState": "Ajoute tes premières charges pour voir apparaître ton plan de provision.",
-      "cards": {
-        "provision": {
-          "title": "Provision du mois",
-          "description": "Somme à mettre de côté ce mois-ci."
-        },
-        "available": {
-          "title": "Disponible vie courante",
-          "description": "Budget libre après provision et charges du mois."
-        },
-        "upcoming": {
-          "title": "Prochaines échéances",
-          "description": "Factures à venir dans les 3 mois."
-        }
-      }
+      "ctaSimulator": "Simuler"
     },
     "charges": {
       "title": "Mes charges",

--- a/messages/en.json
+++ b/messages/en.json
@@ -476,25 +476,7 @@
       "transferPrincipalRemainingHint": "Après salaire, virements et factures Principal ({bills}).",
       "ctaCharges": "Mes charges",
       "ctaExpenses": "Mes dépenses",
-      "ctaSimulator": "Simuler",
-      "title": "Tableau de bord",
-      "welcome": "Bienvenue {name}",
-      "subtitle": "Ton cockpit en un coup d'œil.",
-      "emptyState": "Ajoute tes premières charges pour voir apparaître ton plan de provision.",
-      "cards": {
-        "provision": {
-          "title": "Provision du mois",
-          "description": "Somme à mettre de côté ce mois-ci."
-        },
-        "available": {
-          "title": "Disponible vie courante",
-          "description": "Budget libre après provision et charges du mois."
-        },
-        "upcoming": {
-          "title": "Prochaines échéances",
-          "description": "Factures à venir dans les 3 mois."
-        }
-      }
+      "ctaSimulator": "Simuler"
     },
     "charges": {
       "title": "Mes charges",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -476,25 +476,7 @@
       "transferPrincipalRemainingHint": "Après salaire, virements et factures Principal ({bills}).",
       "ctaCharges": "Mes charges",
       "ctaExpenses": "Mes dépenses",
-      "ctaSimulator": "Simuler",
-      "title": "Tableau de bord",
-      "welcome": "Bienvenue {name}",
-      "subtitle": "Ton cockpit en un coup d'œil.",
-      "emptyState": "Ajoute tes premières charges pour voir apparaître ton plan de provision.",
-      "cards": {
-        "provision": {
-          "title": "Provision du mois",
-          "description": "Somme à mettre de côté ce mois-ci."
-        },
-        "available": {
-          "title": "Disponible vie courante",
-          "description": "Budget libre après provision et charges du mois."
-        },
-        "upcoming": {
-          "title": "Prochaines échéances",
-          "description": "Factures à venir dans les 3 mois."
-        }
-      }
+      "ctaSimulator": "Simuler"
     },
     "charges": {
       "title": "Mes charges",

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -476,25 +476,7 @@
       "transferPrincipalRemainingHint": "Après salaire, virements et factures Principal ({bills}).",
       "ctaCharges": "Mes charges",
       "ctaExpenses": "Mes dépenses",
-      "ctaSimulator": "Simuler",
-      "title": "Tableau de bord",
-      "welcome": "Bienvenue {name}",
-      "subtitle": "Ton cockpit en un coup d'œil.",
-      "emptyState": "Ajoute tes premières charges pour voir apparaître ton plan de provision.",
-      "cards": {
-        "provision": {
-          "title": "Provision du mois",
-          "description": "Somme à mettre de côté ce mois-ci."
-        },
-        "available": {
-          "title": "Disponible vie courante",
-          "description": "Budget libre après provision et charges du mois."
-        },
-        "upcoming": {
-          "title": "Prochaines échéances",
-          "description": "Factures à venir dans les 3 mois."
-        }
-      }
+      "ctaSimulator": "Simuler"
     },
     "charges": {
       "title": "Mes charges",

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -476,25 +476,7 @@
       "transferPrincipalRemainingHint": "Après salaire, virements et factures Principal ({bills}).",
       "ctaCharges": "Mes charges",
       "ctaExpenses": "Mes dépenses",
-      "ctaSimulator": "Simuler",
-      "title": "Tableau de bord",
-      "welcome": "Bienvenue {name}",
-      "subtitle": "Ton cockpit en un coup d'œil.",
-      "emptyState": "Ajoute tes premières charges pour voir apparaître ton plan de provision.",
-      "cards": {
-        "provision": {
-          "title": "Provision du mois",
-          "description": "Somme à mettre de côté ce mois-ci."
-        },
-        "available": {
-          "title": "Disponible vie courante",
-          "description": "Budget libre après provision et charges du mois."
-        },
-        "upcoming": {
-          "title": "Prochaines échéances",
-          "description": "Factures à venir dans les 3 mois."
-        }
-      }
+      "ctaSimulator": "Simuler"
     },
     "charges": {
       "title": "Mes charges",


### PR DESCRIPTION
## Context

Première des trois dettes identifiées pendant la review post-PR-1bis (cf. `docs/ROADMAP.md` §"Dettes post-PR-1bis").

## Scope

Suppression de 5 clés orphelines dans `messages/*.json` → namespace `app.dashboard` :

- `title`
- `welcome`
- `subtitle`
- `emptyState`
- `cards` (avec ses 3 sous-objets `provision`, `available`, `upcoming` → 6 feuilles)

Soit **10 feuilles supprimées × 5 locales = 50 entrées retirées** pour 5 insertions nettes (fermeture de bloc).

## Justification

Grep-vérifié avant suppression : aucune utilisation dans `src/`.

Le dashboard live (`src/app/[locale]/app/page.tsx`) utilise `metaTitle`, `headerTitle`, `emptyTitle`, `emptyDescription`, `emptyCta`, `kpi*`, `health*`, `plan*`, `missingSetup*`, `transfer*`, `cta*` — aucune des 5 clés retirées n'apparaît nulle part.

Ces clés étaient des vestiges d'un layout dashboard antérieur jamais formellement retiré avec la nouvelle structure introduite par PR-1.

## Quality gates

- [x] Lint : 0 erreur
- [x] TypeScript : 0 erreur (next-intl génère les types depuis fr-BE — la suppression propage proprement)
- [x] Tests Vitest : 105/105 pass (parity sync conservé puisque les 5 locales sont alignées)
- [x] Pas de `t('welcome')` / `t('cards.*')` résiduel dans `src/`

## Known debt post-merge (toujours tracké)

- `feat(i18n): locale-aware formatters` — PR suivante (conditionne le port des mockups v2)
- `chore(tailwind): migrate to canonical classes` — PR finale des 3 dettes

Refs: PR-1bis post-merge debt #1

## Résumé par Sourcery

Tâches :
- Nettoyer les clés de traduction `app.dashboard` inutilisées dans tous les fichiers JSON de locales.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Clean up unused `app.dashboard` translation keys across all locale JSON files.

</details>