### PR TITLE
chore(gitignore): ignore .playwright-mcp/ temp folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ design-mockup-*.html
 
 # internal PR prompts
 prompts/
+
+# Playwright MCP temp folder
+.playwright-mcp/


### PR DESCRIPTION
Micro-PR: add .playwright-mcp/ to .gitignore to stop polluting git status.

No code touched.

## Résumé par Sourcery

Met à jour les règles d’ignorance du dépôt afin d’exclure du contrôle de version les artefacts temporaires de Playwright MCP.

Build :
- Ajoute le répertoire temporaire `.playwright-mcp/` au fichier `.gitignore` pour l’exclure de `git status` et des commits.

Tâches diverses :
- Nettoie la configuration du contrôle de version afin d’éviter le suivi des fichiers temporaires générés par Playwright MCP.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Mettre à jour les règles Git ignore pour exclure les artefacts temporaires Playwright MCP.

Build :
- Ajouter le répertoire temporaire `.playwright-mcp/` à `.gitignore` afin qu’il ne soit pas suivi ni affiché dans le statut git.

Chores :
- Nettoyer la configuration du contrôle de version afin d’éviter le suivi des fichiers temporaires de Playwright MCP.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Git ignore rules to exclude temporary Playwright MCP artifacts.

Build:
- Add the `.playwright-mcp/` temporary directory to `.gitignore` so it is not tracked or shown in git status.

Chores:
- Clean up version control configuration to avoid tracking Playwright MCP temporary files.

</details>

</details>