### PR TITLE
chore(husky): enforce 'use server' lint in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
 #!/usr/bin/env sh
+npm run lint:use-server
 npx lint-staged


### PR DESCRIPTION
## Summary
Adds `npm run lint:use-server` to the Husky pre-commit hook so developers catch violations locally before pushing. This complements the CI-level enforcement added in PR #39.

## Motivation
- P0 production bug (#37/#38) was caused by `'use server'` directive with non-async exports
- CI-level guard (PR #39) prevents this from reaching main, but catching it locally is faster
- Shift-left: fail fast at commit time rather than CI time

## Changes
- `.husky/pre-commit`: added `npm run lint:use-server` before `npx lint-staged`
  - Structure validation (use-server exports) runs first
  - Code formatting (lint-staged) runs second

## Testing
- Hook executes successfully on commit (verified with this PR)
- No impact on lint-staged or other hooks

---
*Generated by [Claude Code](https://claude.com/claude-code) during post-merge follow-up*

## Résumé par Sourcery

Build :
- Met à jour le hook pre-commit Husky pour exécuter `npm run lint:use-server` avant `npx lint-staged` afin de détecter plus tôt les violations de directives.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update Husky pre-commit hook to run `npm run lint:use-server` before `npx lint-staged` to catch directive violations earlier.

</details>