### PR TITLE
chore: tune Lighthouse thresholds to realistic production targets

### DIFF
--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -9,15 +9,11 @@
       }
     },
     "assert": {
-      "preset": "lighthouse:recommended",
       "assertions": {
-        "categories:performance": ["error", { "minScore": 0.95 }],
-        "categories:accessibility": ["error", { "minScore": 1.0 }],
-        "categories:best-practices": ["error", { "minScore": 1.0 }],
-        "categories:seo": ["error", { "minScore": 1.0 }],
-        "csp-xss": "warn",
-        "unused-javascript": "off",
-        "uses-rel-preconnect": "off"
+        "categories:performance": ["error", { "minScore": 0.85 }],
+        "categories:accessibility": ["error", { "minScore": 0.95 }],
+        "categories:best-practices": ["error", { "minScore": 0.9 }],
+        "categories:seo": ["error", { "minScore": 0.95 }]
       }
     },
     "upload": {


### PR DESCRIPTION
Adjust Lighthouse CI assertions to realistic thresholds for production PWA on Vercel:

- Removed `preset: lighthouse:recommended` (too noisy with individual audit assertions)
- Updated category thresholds:
  - performance: 0.85 (accounts for Vercel cold starts)
  - accessibility: 0.95 (from 1.0)
  - best-practices: 0.90 (from 1.0)
  - seo: 0.95 (from 1.0)

This aligns with realistic expectations for a production deployment and eliminates flaky failures on marginal scores.

## Résumé par Sourcery

CI :
- Assouplir les assertions sur les scores de catégories Lighthouse dans `.lighthouserc.json` en les adaptant à des seuils appropriés pour la production et supprimer le préréglage générique recommandé.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Relax Lighthouse category score assertions in .lighthouserc.json to production-appropriate thresholds and remove the generic recommended preset.

</details>