### PR TITLE
fix(seo): remove redundant /fr-BE redirect breaking glossary SSG

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -39,7 +39,6 @@ const nextConfig: NextConfig = {
   async redirects() {
     return [
       { source: '/fr', destination: '/', permanent: true },
-      { source: '/fr-BE', destination: '/', permanent: true },
       { source: '/nl', destination: '/nl-BE', permanent: true },
       { source: '/de', destination: '/de-DE', permanent: true },
       { source: '/es', destination: '/es-ES', permanent: true },


### PR DESCRIPTION
Hotfix for PR #105 glossary feature.

**Problem**: All /glossaire routes return 404 on production because next.config.ts line 42 creates a redirect loop:
- generateStaticParams returns { locale: 'fr-BE' } routes
- Redirect rule /fr-BE/:path* → /:path* is applied
- Root layout has no [locale] segment to catch the destination
- 404 Not Found

**Solution**: Remove redundant redirect line (already handled by localePrefix: 'as-needed' in src/i18n/routing.ts)

**Testing after merge**:
- Verify prod URLs respond 200:
  - https://ankora.be/glossaire
  - https://ankora.be/glossaire/budget-de-lissage
  - https://ankora.be/nl-BE/glossaire
  - https://ankora.be/en/glossaire

## Summary by Sourcery

Corrections de bugs :
- Correction des erreurs 404 pour les routes `/glossaire` en supprimant une redirection `/fr-BE` redondante qui entrait en conflit avec la configuration de routage des paramètres de langue.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix 404 errors for /glossaire routes by deleting a redundant /fr-BE redirect that conflicted with locale routing configuration.

</details>