### PR TITLE
fix(glossary): await params in Next.js 16 async route handlers

### DIFF
--- a/src/app/[locale]/(public)/glossaire/[slug]/page.tsx
+++ b/src/app/[locale]/(public)/glossaire/[slug]/page.tsx
@@ -16,10 +16,10 @@ import { notFound } from 'next/navigation';
 
 export const dynamicParams = false;
 
-type Params = { locale: string; slug: string };
+type LocaleSlugParams = { params: Promise<{ locale: string; slug: string }> };
 
-export async function generateMetadata({ params }: { params: Params }) {
-  const { locale, slug } = params;
+export async function generateMetadata({ params }: LocaleSlugParams) {
+  const { locale, slug } = await params;
 
   if (!isGlossaryLocale(locale)) {
     notFound();
@@ -53,8 +53,8 @@ export async function generateStaticParams() {
   );
 }
 
-export default async function GlossaireTermPage({ params }: { params: Params }) {
-  const { locale, slug } = params;
+export default async function GlossaireTermPage({ params }: LocaleSlugParams) {
+  const { locale, slug } = await params;
 
   if (!isGlossaryLocale(locale)) {
     notFound();

--- a/src/app/[locale]/(public)/glossaire/page.tsx
+++ b/src/app/[locale]/(public)/glossaire/page.tsx
@@ -13,9 +13,10 @@ import { notFound } from 'next/navigation';
 
 export const dynamicParams = false;
 
-type Params = { locale: string };
+type LocaleParams = { params: Promise<{ locale: string }> };
 
-export async function generateMetadata({ params }: { params: Params }) {
+export async function generateMetadata({ params }: LocaleParams) {
+  const { locale } = await params;
   const t = await getTranslations('glossary');
 
   return {
@@ -28,8 +29,8 @@ export async function generateStaticParams() {
   return GLOSSARY_LOCALES.map((locale) => ({ locale }));
 }
 
-export default async function GlossairePage({ params }: { params: Params }) {
-  const { locale } = params;
+export default async function GlossairePage({ params }: LocaleParams) {
+  const { locale } = await params;
 
   if (!isGlossaryLocale(locale)) {
     notFound();


### PR DESCRIPTION
Next.js 16 changed params from sync object to Promise.
Glossary pages were missed during migration, causing locale to be
undefined at runtime → isGlossaryLocale(undefined) false → notFound() → 404.
Fixed by aligning with pattern used elsewhere in the app
(see src/app/[locale]/(public)/page.tsx).

Post-mortem: previous hotfix (#44) removed a legitimately redundant
redirect but was not the root cause of the 404s. Headers
(x-matched-path + x-vercel-cache: MISS) confirmed routing worked;
404 came from the handler.

## Summary by Sourcery

Aligner les gestionnaires de routes du glossaire avec les paramètres asynchrones de Next.js 16 pour éviter des erreurs 404 incorrectes sur des pages de glossaire valides.

Corrections de bugs :
- Attendre (`await`) les paramètres de route asynchrones dans les gestionnaires de métadonnées et de pages du glossaire afin que les locales soient correctement résolues au lieu de provoquer des 404 via `notFound()`.

Améliorations :
- Introduire des wrappers typés partagés pour les paramètres des routes du glossaire afin de correspondre au modèle de paramètres asynchrones utilisé ailleurs dans l’application.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align glossary route handlers with Next.js 16 async params to prevent incorrect 404s for valid glossary pages.

Bug Fixes:
- Await async route params in glossary metadata and page handlers so locales are correctly resolved instead of causing notFound() 404s.

Enhancements:
- Introduce shared typed param wrappers for glossary routes to match the async params pattern used elsewhere in the app.

</details>