### PR TITLE
chore(glossary): extract Params type for better maintainability

### DIFF
--- a/src/app/[locale]/(public)/glossaire/[slug]/page.tsx
+++ b/src/app/[locale]/(public)/glossaire/[slug]/page.tsx
@@ -16,7 +16,8 @@ import { notFound } from 'next/navigation';
 
 export const dynamicParams = false;
 
-type LocaleSlugParams = { params: Promise<{ locale: string; slug: string }> };
+type Params = { locale: string; slug: string };
+type LocaleSlugParams = { params: Promise<Params> };
 
 export async function generateMetadata({ params }: LocaleSlugParams) {
   const { locale, slug } = await params;

--- a/src/app/[locale]/(public)/glossaire/page.tsx
+++ b/src/app/[locale]/(public)/glossaire/page.tsx
@@ -13,7 +13,8 @@ import { notFound } from 'next/navigation';
 
 export const dynamicParams = false;
 
-type LocaleParams = { params: Promise<{ locale: string }> };
+type Params = { locale: string };
+type LocaleParams = { params: Promise<Params> };
 
 export async function generateMetadata({ params }: LocaleParams) {
   const { locale } = await params;


### PR DESCRIPTION
Refactor glossary route handlers to match the pattern used elsewhere
in the app (src/app/[locale]/(public)/page.tsx):
- Extract Params shape into a reusable type alias
- Use Params in the LocaleParams / LocaleSlugParams type definition
- Makes future migrations and type changes easier to apply consistently

No behavioral changes.

## Résumé par Sourcery

Améliorations :
- Extraction d’un type `Params` réutilisable pour les routes du glossaire et mise à jour des types de paramètres liés à la locale existants pour l’utiliser.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Extract a reusable Params type for glossary routes and update existing locale-related param types to use it.

</details>