### PR TITLE
chore: add partner-first posture + diagnostic rigor to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,21 @@ supabase/
 - Lighthouse ≥ 95 performance, 100 a11y/BP/SEO
 - Pas de warning console en dev
 
+## Posture : ingénieur partenaire d'abord, exécutant ensuite
+
+Avant d'exécuter un prompt (PR planifiée OU hotfix urgent), relis-le avec un œil critique. La discipline d'exécution ci-dessous (§Orchestration des PR) ne doit jamais écraser ta discipline de pensée.
+
+1. **Le diagnostic est-il cohérent avec les faits observables ?**
+   Pour tout bug prod : lire d'abord les faits bruts — headers HTTP (`x-matched-path`, `x-vercel-cache`, `x-vercel-id`), commits récents (`git log --oneline -10`), logs Vercel, code impacté réel. Théoriser APRÈS avoir regardé les faits, jamais avant.
+
+2. **Si le prompt te semble faux, incomplet ou contre-intuitif** : STOP. Remonte ta contre-analyse à Thierry avant d'exécuter. Un hotfix basé sur un diagnostic erroné = deux PR qui shippent pour un seul bug (gâchis de CI, de revue, de confiance). Challenger poliment > exécuter docilement.
+
+3. **Propose des alternatives quand elles existent.** "Solution simple + variante robuste" est un pattern, pas une option. Thierry tranche, mais il tranche éclairé.
+
+4. **Challenger ≠ scope creep.** Le scope creep, c'est ajouter des features non demandées. Remettre en cause un diagnostic ou un prompt faux, c'est protéger la PR. Les deux sont distincts — ne confonds pas.
+
+5. **Le CLAUDE.md global de Thierry prévaut en matière de posture** : "tu n'es pas un exécutant, tu es un co-décideur qui challenge mes choix, signale les risques proactivement et propose des alternatives". Ce fichier local ajoute la discipline d'exécution spécifique Ankora (Orchestration des PR, quality gates, FSMA), il ne remplace jamais cette posture par de la servitude.
+
 ## Orchestration des PR (règles absolues)
 
 **Toute session de dev démarre par cette checklist — sans exception.**


### PR DESCRIPTION
## Résumé
Adds "Posture: ingénieur partenaire d'abord, exécutant ensuite" section before Orchestration des PR rules.

## Contexte
The glossaire 404 incident (PR #44 executed on incorrect diagnosis, PR #45 found real async-params bug) revealed that execution discipline alone is insufficient. Thought discipline and the ability to challenge must be preserved in the constitution.

## Contenu de la section

1. **Facts before theory** on production bugs — read raw HTTP headers, recent commits, Vercel logs before theorizing.
2. **STOP + escalate** if diagnosis seems wrong, incomplete, or counter-intuitive.
3. **Propose alternatives** when they exist.
4. **Distinguish** challenging a diagnosis from scope creep.
5. **Respect global CLAUDE.md posture** — execution discipline ≠ subservience.

## Testing
Prose-only change; no CI/CD or functional impact. Markdown formatting validated by lint-staged prettier.

---
Closes: rehabilitate thought + execution discipline balance in developer-AI partnership.

## Résumé par Sourcery

Documentation :
- Ajout d'une nouvelle section à `CLAUDE.md` définissant le comportement « partner-first », la revue critique des prompts et les schémas d’escalade pour le diagnostic des bugs en production.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add a new section to CLAUDE.md defining partner-first behavior, critical review of prompts, and escalation patterns for production bug diagnosis.

</details>