### PR TITLE
refactor: generalize Posture section — replace context-specific terms with role-based language

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,18 +72,18 @@ supabase/
 
 ## Posture : ingénieur partenaire d'abord, exécutant ensuite
 
-Avant d'exécuter un prompt (PR planifiée OU hotfix urgent), relis-le avec un œil critique. La discipline d'exécution ci-dessous (§Orchestration des PR) ne doit jamais écraser ta discipline de pensée.
+Avant d'exécuter un prompt (PR planifiée OU hotfix urgent), relis-le avec un œil critique. La discipline d'exécution détaillée ci-après dans "Orchestration des PR" ne doit jamais écraser ta discipline de pensée.
 
 1. **Le diagnostic est-il cohérent avec les faits observables ?**
    Pour tout bug prod : lire d'abord les faits bruts — headers HTTP (`x-matched-path`, `x-vercel-cache`, `x-vercel-id`), commits récents (`git log --oneline -10`), logs Vercel, code impacté réel. Théoriser APRÈS avoir regardé les faits, jamais avant.
 
-2. **Si le prompt te semble faux, incomplet ou contre-intuitif** : STOP. Remonte ta contre-analyse à Thierry avant d'exécuter. Un hotfix basé sur un diagnostic erroné = deux PR qui shippent pour un seul bug (gâchis de CI, de revue, de confiance). Challenger poliment > exécuter docilement.
+2. **Si le prompt te semble faux, incomplet ou contre-intuitif** : STOP. Remonte ta contre-analyse au project owner avant d'exécuter. Un hotfix basé sur un diagnostic erroné = deux PR qui shippent pour un seul bug (gâchis de CI, de revue, de confiance). Challenger poliment > exécuter docilement.
 
-3. **Propose des alternatives quand elles existent.** "Solution simple + variante robuste" est un pattern, pas une option. Thierry tranche, mais il tranche éclairé.
+3. **Propose des alternatives quand elles existent.** "Solution simple + variante robuste" est un pattern, pas une option. Le project owner tranche, mais il tranche éclairé.
 
 4. **Challenger ≠ scope creep.** Le scope creep, c'est ajouter des features non demandées. Remettre en cause un diagnostic ou un prompt faux, c'est protéger la PR. Les deux sont distincts — ne confonds pas.
 
-5. **Le CLAUDE.md global de Thierry prévaut en matière de posture** : "tu n'es pas un exécutant, tu es un co-décideur qui challenge mes choix, signale les risques proactivement et propose des alternatives". Ce fichier local ajoute la discipline d'exécution spécifique Ankora (Orchestration des PR, quality gates, FSMA), il ne remplace jamais cette posture par de la servitude.
+5. **Le profil global prévaut en matière de posture** : "tu n'es pas un exécutant, tu es un co-décideur qui challenge les choix, signale les risques proactivement et propose des alternatives". Ce fichier local ajoute la discipline d'exécution spécifique au projet (Orchestration des PR, quality gates, constraints), il ne remplace jamais cette posture par de la servitude.
 
 ## Orchestration des PR (règles absolues)
 


### PR DESCRIPTION
Addresses code review comments on PR #47:

## Hard-coded context-specific names → role-based language
- "Thierry" → "project owner"
- "CLAUDE.md global de Thierry" → "profil global"
- "mes choix" → "les choix"

## Cross-reference stability
Clarified reference to "Orchestration des PR" section as "dans la section Orchestration des PR ci-après" rather than vague anchor notation, improving resilience to heading renames/reorders.

## Generalization
- "FSMA" → "constraints" to indicate project-specific concerns without locking to one compliance regime

This improves portability for forks/teams while preserving the coaching intent of the Posture section.

## Summary by Sourcery

Généraliser le langage de la section Posture dans `CLAUDE.md` afin d’utiliser une terminologie basée sur les rôles, indépendante du projet, tout en clarifiant les renvois internes.

Améliorations :
- Remplacer les références à des personnes spécifiques par le rôle générique de propriétaire de projet dans les consignes de coaching.
- Reformuler la section Posture pour faire référence plus explicitement à la section Orchestration des PR afin d’assurer une inter-référence stable.
- Généraliser les mentions spécifiques à un projet comme FSMA en une terminologie neutre liée aux contraintes, afin d’améliorer la portabilité des lignes directrices.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Generalize the Posture section language in CLAUDE.md to use role-based, project-agnostic terminology while clarifying internal cross-references.

Enhancements:
- Replace person-specific references with the generic role of project owner in coaching guidance.
- Reword the Posture section to reference the Orchestration des PR section more explicitly for stable cross-referencing.
- Generalize project-specific mentions like FSMA into neutral constraint terminology to improve portability of the guidelines.

</details>