### PR TITLE
refactor: improve Posture section language coherence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,13 +77,13 @@ Avant d'exécuter un prompt (PR planifiée OU hotfix urgent), relis-le avec un �
 1. **Le diagnostic est-il cohérent avec les faits observables ?**
    Pour tout bug prod : lire d'abord les faits bruts — headers HTTP (`x-matched-path`, `x-vercel-cache`, `x-vercel-id`), commits récents (`git log --oneline -10`), logs Vercel, code impacté réel. Théoriser APRÈS avoir regardé les faits, jamais avant.
 
-2. **Si le prompt te semble faux, incomplet ou contre-intuitif** : STOP. Remonte ta contre-analyse au project owner avant d'exécuter. Un hotfix basé sur un diagnostic erroné = deux PR qui shippent pour un seul bug (gâchis de CI, de revue, de confiance). Challenger poliment > exécuter docilement.
+2. **Si le prompt te semble faux, incomplet ou contre-intuitif** : STOP. Remonte ta contre-analyse au propriétaire du projet avant d'exécuter. Un hotfix basé sur un diagnostic erroné = deux PR qui shippent pour un seul bug (gâchis de CI, de revue, de confiance). Challenger poliment > exécuter docilement.
 
-3. **Propose des alternatives quand elles existent.** "Solution simple + variante robuste" est un pattern, pas une option. Le project owner tranche, mais il tranche éclairé.
+3. **Propose des alternatives quand elles existent.** "Solution simple + variante robuste" est un pattern, pas une option. Le propriétaire du projet tranche, mais il tranche éclairé.
 
 4. **Challenger ≠ scope creep.** Le scope creep, c'est ajouter des features non demandées. Remettre en cause un diagnostic ou un prompt faux, c'est protéger la PR. Les deux sont distincts — ne confonds pas.
 
-5. **Le profil global prévaut en matière de posture** : "tu n'es pas un exécutant, tu es un co-décideur qui challenge les choix, signale les risques proactivement et propose des alternatives". Ce fichier local ajoute la discipline d'exécution spécifique au projet (Orchestration des PR, quality gates, constraints), il ne remplace jamais cette posture par de la servitude.
+5. **Le fichier CLAUDE.md global prévaut en matière de posture** : "tu n'es pas un exécutant, tu es un co-décideur qui challenge les choix, signale les risques proactivement et propose des alternatives". Ce fichier local ajoute la discipline d'exécution spécifique au projet (Orchestration des PR, quality gates, constraints), il ne remplace jamais cette posture par de la servitude.
 
 ## Orchestration des PR (règles absolues)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ Avant d'exécuter un prompt (PR planifiée OU hotfix urgent), relis-le avec un �
 
 4. **Challenger ≠ scope creep.** Le scope creep, c'est ajouter des features non demandées. Remettre en cause un diagnostic ou un prompt faux, c'est protéger la PR. Les deux sont distincts — ne confonds pas.
 
-5. **Le fichier CLAUDE.md global prévaut en matière de posture** : "tu n'es pas un exécutant, tu es un co-décideur qui challenge les choix, signale les risques proactivement et propose des alternatives". Ce fichier local ajoute la discipline d'exécution spécifique au projet (Orchestration des PR, quality gates, constraints), il ne remplace jamais cette posture par de la servitude.
+5. **Le fichier CLAUDE.md global prévaut en matière de posture** : "tu n'es pas un exécutant, tu es un co-décideur qui challenge les choix, signale les risques proactivement et propose des alternatives". Ce fichier local ajoute la discipline d'exécution spécifique au projet (Orchestration des PR, quality gates, contraintes), il ne remplace jamais cette posture par de la servitude.
 
 ## Orchestration des PR (règles absolues)
 


### PR DESCRIPTION
## Summary
- Improve French language consistency by replacing 'project owner' with 'propriétaire du projet' (lines 80, 82)
- Clarify ambiguous 'profil global' reference with explicit 'fichier CLAUDE.md global' (line 86)

Addresses code review feedback on terminology coherence and reference clarity.

## Test plan
- [x] Lint and format check pass
- [ ] Manual review of wording

🤖 Generated with Claude Code

## Summary by Sourcery

Améliorer la formulation et la cohérence de la terminologie dans la section sur la posture de CLAUDE.

Documentation :
- Clarifier les références au rôle de décisionnaire en utilisant systématiquement le terme français « propriétaire du projet » au lieu de « project owner ».
- Rendre les recommandations de posture plus explicites en faisant référence au fichier global `CLAUDE.md` plutôt qu’à un « profil global » ambigu.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve wording and terminology consistency in the CLAUDE posture section.

Documentation:
- Clarify references to the decision-maker role by consistently using the French term "propriétaire du projet" instead of "project owner".
- Make the posture guidance more explicit by referring to the global CLAUDE.md file rather than an ambiguous "profil global".

</details>