### PR TITLE
chore(ci): harden PR merge posture (Sourcery gate + DONE definition)

### DIFF
--- a/.github/workflows/sourcery-gate.yml
+++ b/.github/workflows/sourcery-gate.yml
@@ -17,16 +17,16 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          # Fetch Sourcery inline comments on the PR
-          comments=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments" \
-            --jq '[.[] | select(.user.login == "sourcery-ai[bot]") | select(.commit_id == "'${HEAD_SHA}'")] | length')
+          # Fetch Sourcery inline comments on the PR (with pagination to handle large PRs)
+          comments=$(gh api --paginate "repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments" \
+            --jq --arg head "$HEAD_SHA" '[.[] | select(.user.login == "sourcery-ai[bot]") | select(.commit_id == $head)] | length')
 
           echo "Active Sourcery comments on HEAD (${HEAD_SHA}): $comments"
 
           if [ "$comments" -gt 0 ]; then
             echo "::error::Sourcery has $comments active comments on the latest commit. Resolve them before merging."
-            gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments" \
-              --jq '[.[] | select(.user.login == "sourcery-ai[bot]") | select(.commit_id == "'${HEAD_SHA}'") | {path, line, body}]'
+            gh api --paginate "repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments" \
+              --jq --arg head "$HEAD_SHA" '[.[] | select(.user.login == "sourcery-ai[bot]") | select(.commit_id == $head) | {path, line, body}]'
             exit 1
           fi
 

--- a/.github/workflows/sourcery-gate.yml
+++ b/.github/workflows/sourcery-gate.yml
@@ -1,0 +1,33 @@
+name: Sourcery Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check-sourcery-resolved:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for active Sourcery comments on latest commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Fetch Sourcery inline comments on the PR
+          comments=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments" \
+            --jq '[.[] | select(.user.login == "sourcery-ai[bot]") | select(.commit_id == "'${HEAD_SHA}'")] | length')
+
+          echo "Active Sourcery comments on HEAD (${HEAD_SHA}): $comments"
+
+          if [ "$comments" -gt 0 ]; then
+            echo "::error::Sourcery has $comments active comments on the latest commit. Resolve them before merging."
+            gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments" \
+              --jq '[.[] | select(.user.login == "sourcery-ai[bot]") | select(.commit_id == "'${HEAD_SHA}'") | {path, line, body}]'
+            exit 1
+          fi
+
+          echo "✅ No active Sourcery comments on HEAD."

--- a/.github/workflows/sourcery-gate.yml
+++ b/.github/workflows/sourcery-gate.yml
@@ -18,15 +18,16 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # Fetch Sourcery inline comments on the PR (with pagination to handle large PRs)
-          comments=$(gh api --paginate "repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments" \
-            --jq --arg head "$HEAD_SHA" '[.[] | select(.user.login == "sourcery-ai[bot]") | select(.commit_id == $head)] | length')
+          # Use escaped shell variable within jq filter to safely compare commit_id
+          filter='[.[] | select(.user.login == "sourcery-ai[bot]") | select(.commit_id == "'$HEAD_SHA'")] | length'
+          comments=$(gh api --paginate "repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments" --jq "$filter")
 
           echo "Active Sourcery comments on HEAD (${HEAD_SHA}): $comments"
 
           if [ "$comments" -gt 0 ]; then
             echo "::error::Sourcery has $comments active comments on the latest commit. Resolve them before merging."
-            gh api --paginate "repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments" \
-              --jq --arg head "$HEAD_SHA" '[.[] | select(.user.login == "sourcery-ai[bot]") | select(.commit_id == $head) | {path, line, body}]'
+            detail_filter='[.[] | select(.user.login == "sourcery-ai[bot]") | select(.commit_id == "'$HEAD_SHA'") | {path, line, body}]'
+            gh api --paginate "repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments" --jq "$detail_filter"
             exit 1
           fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,31 @@ supabase/
 - Lighthouse ≥ 95 performance, 100 a11y/BP/SEO
 - Pas de warning console en dev
 
+## Définition de DONE (anti "push done = task done")
+
+Un push, un commit ou une PR ouverte ne signifie PAS "terminé". Une tâche
+n'est DONE qu'une fois TOUS ces critères satisfaits:
+
+1. ✅ Tous les checks CI verts (Lint, Typecheck, Tests, E2E, Security, Build)
+2. ✅ Sourcery bot silencieux sur le DERNIER commit de la PR
+   (aucun commentaire inline actif, aucune review non résolue)
+3. ✅ Toutes les reviews humaines approuvées et résolues
+4. ✅ Pas de conflit avec main
+5. ✅ Rapport final livré à Thierry avec preuve de chaque critère
+
+**Vérification systématique de Sourcery après chaque push**:
+
+```bash
+gh api repos/thierryvm/ankora/pulls/<N>/comments \
+  --jq '.[] | select(.user.login == "sourcery-ai[bot]") | .body'
+```
+
+Si output non vide → corriger avant de déclarer DONE.
+
+**Règle de refus**: ne JAMAIS déclarer une tâche terminée sans avoir
+explicitement vérifié les 5 critères ci-dessus. Un push sans vérif Sourcery
+= tâche incomplète, point.
+
 ## Posture : ingénieur partenaire d'abord, exécutant ensuite
 
 Avant d'exécuter un prompt (PR planifiée OU hotfix urgent), relis-le avec un œil critique. La discipline d'exécution détaillée ci-après dans "Orchestration des PR" ne doit jamais écraser ta discipline de pensée.


### PR DESCRIPTION
## Contexte

Suite à l'incident PR #50 où 4 bugs Sourcery sont passés à travers la review
parce que la posture "push done = task done" n'était pas verrouillée
mécaniquement, cette PR installe un double filet:

### Fix 1 — Définition de DONE (posture)
Ajout d'une section explicite dans CLAUDE.md qui définit les 5 critères
obligatoires avant de déclarer une tâche terminée. Les agents d'exécution
(CC Ankora, Claude Code) ont désormais cette règle dans leur contexte permanent.

### Fix 3 — Sourcery Gate (mécanique)
Nouveau workflow GitHub Actions qui vérifie si Sourcery a des commentaires
inline actifs sur le HEAD de la PR. Fail-fast = merge impossible tant que
Sourcery n'est pas silencieux.

## Configuration branch protection (action Thierry manuelle)

Après merge de cette PR, ajouter le check `check-sourcery-resolved` aux
**required status checks** de la branch protection sur `main`:

GitHub → Settings → Branches → main → Edit →
"Require status checks to pass before merging" → ajouter "check-sourcery-resolved"

## Tests

- [x] YAML workflow valide
- [x] Logique curl/jq testée en local sur PR #50 (post-merge) et PR #49
- [ ] À valider: première PR qui passe le gate après merge de celle-ci

## Scope verrouillé

Aucune modif hors des 2 fichiers listés. Pas de refactor annexe.

Refs: incident PR #50

## Résumé par Sourcery

Définir des critères de TERMINÉ explicites et ajouter une étape automatique Sourcery pour empêcher la fusion des PR contenant des commentaires Sourcery non résolus.

CI :
- Introduire un workflow GitHub Actions qui fait échouer les PR lorsqu’il existe des commentaires actifs du bot Sourcery sur le dernier commit.

Documentation :
- Documenter des critères explicites de TERMINÉ et les vérifications requises avant de déclarer une tâche terminée.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Define explicit DONE criteria and add an automated Sourcery gate to block merging PRs with unresolved Sourcery comments.

CI:
- Introduce a GitHub Actions workflow that fails PRs when there are active Sourcery bot comments on the latest commit.

Documentation:
- Document explicit DONE criteria and required checks before declaring a task complete.

</details>