### PR TITLE
chore: reboot v1.0 — docs + agents for cap v1.0 publique

### DIFF
--- a/.claude/agents/admin-dashboard-auditor.md
+++ b/.claude/agents/admin-dashboard-auditor.md
@@ -1,0 +1,85 @@
+---
+name: admin-dashboard-auditor
+description: |
+  Audits admin dashboard for security enforcement, data accuracy, query performance, and accessibility.
+  Triggered on changes to admin pages, components, and migrations touching admin roles.
+---
+
+# Admin Dashboard Auditor
+
+## Triggers
+
+Run this agent after modifications to:
+
+- `src/app/[locale]/app/admin/**` (admin pages and layouts)
+- `src/lib/admin/**` (admin utilities, services, hooks)
+- `supabase/migrations/*` (schema changes affecting admin tables or RLS)
+
+## Mission
+
+Verify that the admin dashboard **enforces access control rigorously, maintains data precision under concurrent load, delivers fast queries with indexed lookups, and meets WCAG 2.2 AA accessibility standards**. Prevent unauthorized data exposure and performance regressions that could compromise incident response.
+
+## Checklist (≥12 points verified)
+
+### Security & Authorization
+
+- [ ] **requireAdmin() enforced** — every admin page/handler calls `requireAdmin()` before rendering or accessing sensitive data
+- [ ] **RLS policies active** — admin tables have row-level security policies; no direct `select *` without `current_user_id()` checks
+- [ ] **No hardcoded user IDs** — admin routes accept `user_id` from query params only if explicitly validated via Zod + session
+- [ ] **Audit logging present** — sensitive actions (data export, config change, user deletion) emit `logAuditEvent()` with actor + timestamp
+- [ ] **Rate limiting on write** — admin mutations (update, delete) pass through `rateLimit()` to prevent mass actions
+
+### Data Integrity & Performance
+
+- [ ] **Query performance** — EXPLAIN ANALYZE on all admin queries shows ≤ 10ms p95 for fetch operations; joins indexed
+- [ ] **Concurrent writes safe** — no race conditions when multiple admins update same resource (use optimistic locking or advisory locks)
+- [ ] **Data freshness** — stale data detection (e.g., modal shows "data updated 2m ago" if >1m old; refresh button present)
+- [ ] **Pagination present** — tables with >100 rows have cursor-based or limit/offset pagination (no `select *` on large tables)
+- [ ] **No N+1 queries** — admin dashboards batch-load related data (users, events, errors) in single query or use `dataloader` pattern
+
+### UI & Accessibility
+
+- [ ] **Responsive design** — admin layout works on mobile + tablet + desktop (not just desktop-first assumption)
+- [ ] **Keyboard navigation** — all controls keyboard-accessible (no mouse-only data table interaction, focus indicators visible)
+- [ ] **Color contrast** — text ≥ 4.5:1 on small text, ≥ 3:1 on large; chart colors distinguishable for colorblind (not red-only)
+- [ ] **ARIA labels** — tables have role="table" / role="grid", headers aria-sort, status indicators have aria-live regions
+- [ ] **Loading + error states** — skeleton loaders or spinners during data fetch; error messages clear + actionable ("retry", "contact support")
+
+### Dashboard-Specific Elements
+
+- [ ] **Tech Health section** — uptime indicator, error rate graph, p50/p95/p99 latency, top 10 errors 7d, CI build status (GitHub API)
+- [ ] **Product Health section** — DAU/WAU/MAU sparklines, retention cohorts (1/7/30d), onboarding funnel (step 1 → complete), feature heatmap (charges, expenses, simulator)
+- [ ] **Acquisition section** — signup trend 7d/30d, top referrers, UTM breakdown, conversion "first workspace created" rate
+- [ ] **Rule-based alerts** — contextualized recommendations ("Step 3 onboarding drop 23%", "Error form-charge ×40 this week", "15 signups same domain 1h")
+
+## Report Format
+
+### GO (pass all checks)
+
+```
+✅ Admin dashboard audit PASSED
+- All 12+ checklist items verified
+- requireAdmin() enforced on all routes
+- No N+1 queries detected
+- WCAG 2.2 AA compliance confirmed
+```
+
+### NO-GO (fail ≥1 item)
+
+```
+❌ Admin dashboard audit FAILED
+
+Failures:
+- [ ] Point 1: /app/admin/users missing requireAdmin() guard
+- [ ] Point 8: /api/admin/metrics query N+1 (loads users in loop instead of batch)
+- [ ] Point 12: Mobile layout breaks on tablet — charts overflow
+
+Next: fix the 3 failures, then re-run audit.
+```
+
+## Notes
+
+- **EXPLAIN ANALYZE**: For any query in admin, run `EXPLAIN ANALYZE SELECT...` in psql to verify indexing and execution time.
+- **Audit log retention**: Admin actions logged to `audit_log` table (append-only, 90-day retention minimum).
+- **Concurrent safety**: Use Supabase's advisory locks (`pg_advisory_lock`) or row versioning (`updated_at` optimistic locking) when multiple admins can modify the same row.
+- **Data export format**: Admin exports to JSON must validate PII redaction (no secrets, no passwords, no raw tokens).

--- a/.claude/agents/dashboard-ux-auditor.md
+++ b/.claude/agents/dashboard-ux-auditor.md
@@ -1,0 +1,93 @@
+---
+name: dashboard-ux-auditor
+description: |
+  Audits user dashboard for design coherence, accessibility, and alignment with Ankora's design system (Tailwind + design tokens).
+  Triggered on changes to dashboard user pages, layouts, and UI components.
+---
+
+# Dashboard UX Auditor
+
+## Triggers
+
+Run this agent after modifications to:
+
+- `src/app/[locale]/app/page.tsx` (dashboard index)
+- `src/app/[locale]/app/layout.tsx` (dashboard layout)
+- `src/components/dashboard/**` (dashboard-specific components)
+- `src/components/features/**` (feature components used in dashboard)
+
+## Mission
+
+Verify that the user dashboard maintains **coherence in design tokens, micro-interactions, state handling, and visual feedback**. Prevent regressions in UX consistency and align new components with Ankora's design vision (Monarch Money level of polish).
+
+## Checklist (≥15 points verified)
+
+### Design Tokens & Styling
+
+- [ ] **No hex colors inline** — all colors use Tailwind utility classes or @theme tokens from globals.css
+- [ ] **Spacing consistent** — uses Tailwind spacing scale (4, 8, 12, 16, 20, 24, 32, 40, 48, etc.)
+- [ ] **Typography hierarchy** — h1, h2, h3 sizes follow Tailwind scale, font-weights correct (medium 500, semibold 600, bold 700)
+- [ ] **Border radius** — uses Tailwind border-radius tokens (rounded-lg, rounded-xl, etc.), no arbitrary values
+
+### Micro-interactions & Feedback
+
+- [ ] **Hover states** — interactive elements have visual feedback (hover:bg-\*, hover:shadow, hover:scale, etc.)
+- [ ] **Focus states** — keyboard navigation visible (focus-ring, focus-outline for a11y)
+- [ ] **Active states** — buttons/tabs show active state with color or background change
+- [ ] **Transition timing** — animations use Tailwind duration (duration-200, duration-300) for consistency
+- [ ] **Loading states** — skeleton loaders, spinners, or disabled buttons present where applicable
+
+### Empty, Error, & Loading States
+
+- [ ] **Empty state** — page has a friendly empty state message when no data (e.g., "No transactions yet")
+- [ ] **Error state** — error messages are clear and actionable (not generic "Error 500")
+- [ ] **Loading state** — loading spinner or skeleton present while data fetches
+- [ ] **State transitions** — smooth transitions between states (no jarring jumps)
+
+### Component Accessibility & Semantics
+
+- [ ] **Semantic HTML** — uses `<main>`, `<nav>`, `<section>`, `<article>` correctly (not all divs)
+- [ ] **ARIA labels** — interactive elements have aria-label or visible text labels
+- [ ] **Color contrast** — text meets WCAG AA standards (4.5:1 for small text, 3:1 for large)
+- [ ] **Keyboard navigation** — all interactive elements keyboard-accessible (no mouse-only features)
+
+### Dashboard-Specific Elements
+
+- [ ] **Hero/waterfall section** — clearly shows income → envelopes → outflows
+- [ ] **Health score gauge** — visible, understandable provision status
+- [ ] **Timeline section** — 6-month cashflow prediction clearly laid out
+- [ ] **Envelope cards** — drag-to-rebalance ready (if implemented), interactive feedback
+- [ ] **Prochaines factures** — 7/14/30j buckets clearly separated
+- [ ] **Goals section** — ETA visible, progress bars present
+- [ ] **What-if simulator link** — accessible from dashboard (drawer or modal)
+- [ ] **Recent activity** — transactions or events listed with timestamps
+
+## Report Format
+
+### GO (pass all checks)
+
+```
+✅ Dashboard UX audit PASSED
+- All 15+ checklist items verified
+- No regressions detected
+- Aligned with Ankora design system
+```
+
+### NO-GO (fail ≥1 item)
+
+```
+❌ Dashboard UX audit FAILED
+
+Failures:
+- [ ] Point 3: Spacing not using Tailwind scale (custom padding: 13px detected on .envelope-card)
+- [ ] Point 8: Hover state missing on envelope rebalance button
+- [ ] Point 12: Error state not implemented (blank screen on API fail)
+
+Next: fix the 3 failures, then re-run audit.
+```
+
+## Notes
+
+- **Mockup v3 alignment**: Only check when `F:\PROJECTS\Apps\ankora-user-dashboard-v3.html` is available (post-design).
+- **Mobile-first**: Run Lighthouse audit separately if needed (via ui-auditor or lighthouse-auditor).
+- **Figma specs**: Fetch from Cowork's Figma if tokens seem off-brand.

--- a/.claude/agents/dashboard-ux-auditor.md
+++ b/.claude/agents/dashboard-ux-auditor.md
@@ -88,6 +88,6 @@ Next: fix the 3 failures, then re-run audit.
 
 ## Notes
 
-- **Mockup v3 alignment**: Only check when `F:\PROJECTS\Apps\ankora-user-dashboard-v3.html` is available (post-design).
+- **Mockup v3 alignment**: Only check when mockup v3 (HTML or Figma) is available post-design review.
 - **Mobile-first**: Run Lighthouse audit separately if needed (via ui-auditor or lighthouse-auditor).
 - **Figma specs**: Fetch from Cowork's Figma if tokens seem off-brand.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,35 +5,13 @@ Ce fichier complète le `CLAUDE.md` global de Thierry. En cas de conflit, ce fic
 
 ## Cap v1.0 publique (verrouillé 2026-04-23)
 
-Cible : SaaS v1.0 sur ankora.be, signups ouverts, **12 semaines max** depuis 2026-04-23.
+**Source unique de vérité** : `docs/NORTH_STAR.md` (consolidation de la vision, 3 jalons, 5 piliers, 9 contraintes non négociables, cibles mesurables).
 
-**Communication externe = 12 semaines, jamais moins.** Aucune fausse promesse. Si on livre en 9, c'est du bonus.
+Résumé local :
 
-### Trois jalons
-
-| Jalon         | Horizon      | Contenu                                                                          |
-| ------------- | ------------ | -------------------------------------------------------------------------------- |
-| Alpha privé   | ~4 semaines  | Thierry + 2-3 proches, FR seul, cœur fonctionnel + baseline sécurité             |
-| Beta privée   | ~8 semaines  | 5-10 testeurs externes, CGU/Privacy UE+BE 2026, GDPR complet, bug reporting live |
-| v1.0 publique | ~12 semaines | Signups libres, AEO/SEO/Lighthouse 100, FR + EN, /roadmap publique               |
-
-### Les 5 piliers (parallélisables)
-
-- **A — Fondations & Hygiène** : ROADMAP à jour, CLAUDE.md, agents QA, CI gates
-- **B — Product Excellence** : recherche concurrentielle, mockups dashboard user v3, admin panel v1
-- **C — Core Fonctionnel** : PR-B1 bug report, PR-3 port mockups, auth + MFA, onboarding, CRUD, simulateur intégré
-- **D — Sécurité & Légal** : CGU/Privacy UE+BE 2026, Klaro!, GDPR export/deletion, rate limiting, audit log
-- **E — SEO/AEO/Perf** : schemas JSON-LD fintech, entity consistency, /roadmap publique, Lighthouse 100
-
-Cowork pilote A+B+contenus D/E, CC Ankora pilote C+tech D/E, Thierry valide + merge.
-
-### Contraintes 2026 verrouillées
-
-- **FSMA non-régulé** : outil éducation budgétaire, jamais "conseil"
-- **PSD2 exclu** (ADR-001)
-- **GDPR renforcé** : APD belge enforcement +++ 2026-2028, privacy policy **en langue user** obligatoire
-- **DORA / NIS2 / MiFID II** : non-applicables à notre échelle, on suit leurs baselines par hygiène
-- **Budget 0 €** : Thierry sur mutuelle Solidaris Belgique, aucun revenu autorisé en Phase 1
+- **Horizon** : 12 semaines max depuis 2026-04-23 (Alpha ~4w, Beta ~8w, v1.0 publique ~12w)
+- **Gouvernance** : Cowork pilote A+B+contenus D/E, CC Ankora pilote C+tech D/E, Thierry valide + merge
+- **Contraintes clés** : FSMA non régulé, PSD2 exclu, GDPR renforcé, Budget 0 €
 
 ### Dashboard Excellence — non négociable
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,72 @@
 Projet **Ankora** : cockpit personnel de finances (PWA Next.js 16 + Supabase, hébergé UE).
 Ce fichier complète le `CLAUDE.md` global de Thierry. En cas de conflit, ce fichier prévaut.
 
+## Cap v1.0 publique (verrouillé 2026-04-23)
+
+Cible : SaaS v1.0 sur ankora.be, signups ouverts, **12 semaines max** depuis 2026-04-23.
+
+**Communication externe = 12 semaines, jamais moins.** Aucune fausse promesse. Si on livre en 9, c'est du bonus.
+
+### Trois jalons
+
+| Jalon         | Horizon      | Contenu                                                                          |
+| ------------- | ------------ | -------------------------------------------------------------------------------- |
+| Alpha privé   | ~4 semaines  | Thierry + 2-3 proches, FR seul, cœur fonctionnel + baseline sécurité             |
+| Beta privée   | ~8 semaines  | 5-10 testeurs externes, CGU/Privacy UE+BE 2026, GDPR complet, bug reporting live |
+| v1.0 publique | ~12 semaines | Signups libres, AEO/SEO/Lighthouse 100, FR + EN, /roadmap publique               |
+
+### Les 5 piliers (parallélisables)
+
+- **A — Fondations & Hygiène** : ROADMAP à jour, CLAUDE.md, agents QA, CI gates
+- **B — Product Excellence** : recherche concurrentielle, mockups dashboard user v3, admin panel v1
+- **C — Core Fonctionnel** : PR-B1 bug report, PR-3 port mockups, auth + MFA, onboarding, CRUD, simulateur intégré
+- **D — Sécurité & Légal** : CGU/Privacy UE+BE 2026, Klaro!, GDPR export/deletion, rate limiting, audit log
+- **E — SEO/AEO/Perf** : schemas JSON-LD fintech, entity consistency, /roadmap publique, Lighthouse 100
+
+Cowork pilote A+B+contenus D/E, CC Ankora pilote C+tech D/E, Thierry valide + merge.
+
+### Contraintes 2026 verrouillées
+
+- **FSMA non-régulé** : outil éducation budgétaire, jamais "conseil"
+- **PSD2 exclu** (ADR-001)
+- **GDPR renforcé** : APD belge enforcement +++ 2026-2028, privacy policy **en langue user** obligatoire
+- **DORA / NIS2 / MiFID II** : non-applicables à notre échelle, on suit leurs baselines par hygiène
+- **Budget 0 €** : Thierry sur mutuelle Solidaris Belgique, aucun revenu autorisé en Phase 1
+
+### Dashboard Excellence — non négociable
+
+Le dashboard user EST le produit. Cible : niveau Monarch Money, pensé enveloppes (pas comptes agrégés).
+
+Sections obligatoires user dashboard v3 :
+
+1. Hero cashflow waterfall (salaire → enveloppes → sorties)
+2. Health score provisions (jauge + nudges)
+3. Timeline 6 mois prédictive
+4. Enveloppes actives (drag-to-rebalance)
+5. Prochaines factures 7/14/30j
+6. Goals épargne avec ETA
+7. Simulateur what-if en drawer
+8. Activité récente
+
+Admin panel obligatoire : santé technique, santé produit, acquisition, recommandations rule-based.
+
+Tout dashboard minimaliste = refus de merge.
+
+### Agents QA (10 au total)
+
+Existants : `security-auditor`, `rls-flow-tester`, `financial-formula-validator`, `ui-auditor`, `lighthouse-auditor`, `seo-geo-auditor`, `gdpr-compliance-auditor`, `test-runner`.
+
+Nouveaux : `dashboard-ux-auditor`, `admin-dashboard-auditor` (ajoutés pilier A).
+
+### Choix techniques lockés
+
+- **Auth MFA** : TOTP via Supabase Auth natif (optionnel user, UI dans `/app/settings/security`)
+- **Cookie consent** : Klaro! (open source, TCF v2.2, 0 €)
+- **Langues v1.0** : FR + EN seulement. NL/DE/ES annoncées dans `/roadmap` publique, livrées post-launch
+- **Admin auth** : `requireAdmin()` basé sur `user_id` Thierry initialement
+
+---
+
 ## Positionnement réglementaire (non-négociable)
 
 Ankora est un **outil d'éducation budgétaire et d'organisation**.

--- a/docs/NORTH_STAR.md
+++ b/docs/NORTH_STAR.md
@@ -1,0 +1,111 @@
+# North Star — Ankora v1.0
+
+Source unique de vérité pour la vision et les décisions produit jusqu'à la v1.0 publique.
+
+Dernière mise à jour : 23 avril 2026.
+
+---
+
+## Mission
+
+Aider les particuliers belges et européens à **maîtriser leur cashflow personnel** grâce à un modèle d'enveloppes prédictif, sans agrégation bancaire automatique, sans conseil en investissement, sans coût pour l'utilisateur en Phase 1.
+
+Ankora n'est **pas** une banque, **pas** un agrégateur (pas PSD2), **pas** un conseiller (pas FSMA). C'est un **outil d'éducation budgétaire et d'organisation financière**.
+
+## Cap v1.0 publique — 12 semaines max
+
+Date de départ : 23 avril 2026. Cible : mi-juillet 2026. Enveloppe communicable : **12 semaines**. Aucune fausse promesse — si on livre en 9, c'est du bonus.
+
+### Trois jalons verrouillés
+
+| #   | Jalon         | Horizon      | Contenu minimal                                                                                                   |
+| --- | ------------- | ------------ | ----------------------------------------------------------------------------------------------------------------- |
+| 1   | Alpha privé   | ~4 semaines  | Thierry + 2-3 proches, FR seul, auth + onboarding + CRUD + dashboard v3 + simulateur + MFA optionnel              |
+| 2   | Beta privée   | ~8 semaines  | 5-10 testeurs externes, CGU/Privacy UE+BE 2026 rédigées, GDPR export/deletion live, bug reporting, Klaro! intégré |
+| 3   | v1.0 publique | ~12 semaines | Signups libres sur ankora.be, FR + EN, schemas AEO complets, Lighthouse 100, /roadmap publique, admin panel v1    |
+
+## Les 5 piliers parallélisables
+
+### A — Fondations & Hygiène
+
+ROADMAP sync, CLAUDE.md, agents QA (10), CI gates (Sourcery required, Lighthouse budget, parity tests), branch protection rigoureuse.
+
+### B — Product Excellence
+
+Recherche concurrentielle formelle (12 acteurs), mockups user dashboard v3 (niveau Monarch-enveloppes), mockup admin panel v1 (4 sections + rule-based reco), design tokens finaux.
+
+### C — Core Fonctionnel
+
+PR-B1 Bug reporting MVP (filet avant chantier UI), PR-3 port des mockups v3 en React prod, auth complète (Supabase + MFA TOTP), onboarding 3 étapes, CRUD charges/dépenses/catégories, dashboard core live, simulateur what-if intégré, goals épargne.
+
+### D — Sécurité & Légal (UE + BE 2026)
+
+CGU conformes loi belge 30/07/2018 + directive ePrivacy + AI Act (non-applicable Phase 1), Privacy Policy **en langue utilisateur**, Cookies Policy + intégration Klaro! open source (TCF v2.2), GDPR export JSON + deletion grace 30j, rate limiting Upstash multicouches, audit log append-only.
+
+### E — SEO/AEO/Perf
+
+Schemas JSON-LD fintech avancés (FinancialProduct, SoftwareApplication, Organization, FAQPage, DefinedTerm), llms-full.txt enrichi, entity consistency (LinkedIn, Product Hunt, G2), `/roadmap` publique (confiance + AEO), Lighthouse 100/100/100/100 mobile + desktop, Service Worker offline-first.
+
+## Règles d'or (non négociables)
+
+1. **Aucune fausse promesse** publique ou interne. 12 semaines = plafond, pas cible.
+2. **Budget 0 €** strict — Thierry sur mutuelle Solidaris, aucun revenu autorisé Phase 1. Toute dépendance payante = validation explicite requise.
+3. **Dashboard Excellence** — minimaliste inacceptable. Niveau Monarch obligatoire.
+4. **Tests + agents QA** avant chaque merge. CI verte + Sourcery silent + DONE-5 appliqué.
+5. **GDPR by design** + langue utilisateur par défaut (sanctions APD belge 2026+).
+6. **Push done ≠ task done**.
+7. **Scope creep interdit** — toute déviation = validation Thierry avant d'ouvrir une ligne de code.
+
+## Anti-patterns interdits
+
+- PR > 600 lignes (sauf cas exceptionnel justifié)
+- Skipping de phase dans un prompt délégué
+- Mockup recyclé au lieu d'un vrai mockup v3
+- "On verra après" sur la sécurité ou le légal
+- Déclarer une tâche DONE sans vérif Sourcery sur HEAD
+- Introduire une dépendance payante en production sans validation explicite
+
+## Cibles mesurables v1.0
+
+| Métrique                        | Cible                                    |
+| ------------------------------- | ---------------------------------------- |
+| Lighthouse Performance          | ≥ 95 (mobile + desktop)                  |
+| Lighthouse A11y / BP / SEO      | 100 / 100 / 100                          |
+| Uptime ankora.be                | ≥ 99.5%                                  |
+| TTFB p95                        | < 400 ms                                 |
+| Coverage domain                 | ≥ 90% lignes + fonctions, ≥ 85% branches |
+| Coverage global                 | ≥ 80%                                    |
+| Erreurs console prod            | 0                                        |
+| Critical + High npm audit       | 0                                        |
+| Incidents sécurité avant launch | 0 exploitable                            |
+
+## Positionnement concurrentiel (à affiner après recherche)
+
+Ankora se distingue des outils US/FR existants par :
+
+| Axe fort Ankora                          | Vide concurrentiel                                            |
+| ---------------------------------------- | ------------------------------------------------------------- |
+| Modèle enveloppes prédictif sans PSD2    | Monarch/Linxo = agrégation live, Ankora = saisie + prédiction |
+| Waterfall salaire → enveloppes → sorties | YNAB le fait à moitié, personne ne le fait beau               |
+| Timeline cashflow 6-12 mois              | Monarch sur comptes agrégés uniquement                        |
+| Health score provisions                  | Inexistant ailleurs                                           |
+| Simulateur what-if intégré dashboard     | Fait à part chez tous                                         |
+| Alertes J-7 factures provisionnées       | Rocket Money = abonnements seulement                          |
+| GDPR conformité belge stricte            | Most US tools ignorent APD belge                              |
+| 100 % 0 € utilisateur Phase 1            | YNAB 99$/an, Monarch 99$/an                                   |
+
+## Gouvernance
+
+- **Cowork** (Claude desktop) : recherche, mockups, contenu vision/légal, prompts délégués, orchestration
+- **CC Ankora** (terminal avec gh/npm/Brave+Claude extension) : code, commits, PRs, vérifications
+- **Thierry** : backup décisionnel quand cela se justifie vraiment, merge PRs, validation mockups
+
+Les décisions techniques sont autonomes côté Cowork et CC Ankora dans le cadre verrouillé ici. Tout écart = validation Thierry obligatoire.
+
+## Après v1.0
+
+- Pots partagés inter-utilisateurs (Phase 2)
+- IA BYOK (Anthropic/OpenRouter, l'utilisateur fournit sa clé, Ankora ne facture jamais le compute)
+- Import CSV / OFX (pas PSD2)
+- Notifications push PWA
+- Tarification payante plan pro (le moment où Ankora peut enfin engager des coûts d'infra)

--- a/docs/NORTH_STAR.md
+++ b/docs/NORTH_STAR.md
@@ -40,7 +40,7 @@ PR-B1 Bug reporting MVP (filet avant chantier UI), PR-3 port des mockups v3 en R
 
 ### D — Sécurité & Légal (UE + BE 2026)
 
-CGU conformes loi belge 30/07/2018 + directive ePrivacy + AI Act (non-applicable Phase 1), Privacy Policy **en langue utilisateur**, Cookies Policy + intégration Klaro! open source (TCF v2.2), GDPR export JSON + deletion grace 30j, rate limiting Upstash multicouches, audit log append-only.
+CGU conformes loi belge 30/07/2018 + directive ePrivacy + AI Act (non-applicable Phase 1), Privacy Policy **en langue utilisateur**, Cookies Policy + intégration Klaro! open source (TCF v2.2), GDPR export JSON + suppression avec délai de grâce de 30j, rate limiting Upstash multicouches, audit log append-only.
 
 ### E — SEO/AEO/Perf
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -43,6 +43,8 @@ Tous les agents résident dans `.claude/agents/` et sont trigger-driven. Chaque 
 | 9   | `dashboard-ux-auditor`        | User dashboard UX + design tokens | touch app/app/\*\*      | ✅ requis PR-3  |
 | 10  | `admin-dashboard-auditor`     | Admin security, perf, a11y        | touch app/admin/\*\*    | ✅ requis PR-B2 |
 
+**Note sur les triggers** : Les chemins documentés (ex. `touch auth/**`, `touch app/app/**`) définissent les cas d'usage _intentionnels_ pour chaque agent. L'invocation manuelle reste primaire pour la Phase 1. Une automatisation CI complète (détection de fichiers + dispatch d'agents) est une future amélioration Pilier A (Phase 2+).
+
 ---
 
 ## ⚠️ Contrainte transverse : Budget 0 €

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,47 @@
 # Roadmap — Ankora
 
-Dernière mise à jour : 20 avril 2026 — PR #27 (post-PR-25 debts) mergée. Prêt pour PR-2 (traductions).
+Dernière mise à jour : 23 avril 2026 — Reboot v1.0 Pilier A (gouvernance + agents QA) complété. Prêt pour PR-2 (traductions).
+
+## Cap v1.0 publique — Vision & Jalons (23 avril 2026)
+
+**Source unique de vérité** : `docs/NORTH_STAR.md` (19 avril 2026). Ce document consolide la vision v1.0 publique, les 5 piliers parallélisables, les contraintes non négociables et les cibles mesurables.
+
+### Trois jalons verrouillés
+
+| Jalon     | Horizon      | Contenu minimal                                                                                    |
+| --------- | ------------ | -------------------------------------------------------------------------------------------------- |
+| **Alpha** | ~4 semaines  | Thierry + 2-3 proches, FR seul, auth + onboarding + CRUD + dashboard v3 + simulateur + MFA         |
+| **Beta**  | ~8 semaines  | 5-10 testeurs, CGU/Privacy UE+BE 2026, GDPR export/delete, bug reporting live, Klaro!              |
+| **v1.0**  | ~12 semaines | Signups ouverts ankora.be, FR + EN, AEO complet, Lighthouse 100, /roadmap publique, admin panel v1 |
+
+### Cinq piliers parallélisables
+
+- **A — Fondations & Hygiène** : ROADMAP sync, agents QA (10), CI gates (Sourcery, Lighthouse budget), branch protection
+- **B — Product Excellence** : recherche concurrentielle (12 acteurs), mockups user dashboard v3, admin panel v1, design tokens finaux
+- **C — Core Fonctionnel** : auth + MFA, onboarding 3 étapes, CRUD charges/dépenses, dashboard core, simulateur intégré, goals
+- **D — Sécurité & Légal** : CGU/Privacy en langue user (BE 2026), Klaro! TCF v2.2, GDPR export/deletion, rate limiting, audit log
+- **E — SEO/AEO/Perf** : schemas JSON-LD fintech, llms-full.txt, /roadmap publique, Lighthouse 100/100/100/100, Service Worker
+
+Cowork pilote A+B+contenus D/E. CC Ankora pilote C+tech D/E. Thierry valide + merge.
+
+---
+
+## Agents QA Pilier A (10 au total)
+
+Tous les agents résident dans `.claude/agents/` et sont trigger-driven. Chaque agent valide un domaine critique avant merge.
+
+| #   | Agent                         | Domaine                           | Trigger                 | Gate            |
+| --- | ----------------------------- | --------------------------------- | ----------------------- | --------------- |
+| 1   | `security-auditor`            | Auth, middleware, RLS, headers    | touch auth/\*\*         | ✅ requis       |
+| 2   | `rls-flow-tester`             | Supabase RLS + migrations         | touch migrations/\*\*   | ✅ requis       |
+| 3   | `financial-formula-validator` | `src/lib/domain/`                 | touch domain/\*\*       | ✅ requis       |
+| 4   | `ui-auditor`                  | WCAG 2.2 AA, mobile, Tailwind 4   | touch components/\*\*   | ✅ requis       |
+| 5   | `lighthouse-auditor`          | Performance, a11y, BP, SEO        | pre-release only        | ✅ requis RC    |
+| 6   | `seo-geo-auditor`             | SEO signals, entity consistency   | touch public pages      | ✅ requis       |
+| 7   | `gdpr-compliance-auditor`     | PII, consent, export, deletion    | touch PII, auth, D-lang | ✅ requis       |
+| 8   | `test-runner`                 | Vitest + Playwright               | post-change             | ✅ requis       |
+| 9   | `dashboard-ux-auditor`        | User dashboard UX + design tokens | touch app/app/\*\*      | ✅ requis PR-3  |
+| 10  | `admin-dashboard-auditor`     | Admin security, perf, a11y        | touch app/admin/\*\*    | ✅ requis PR-B2 |
 
 ---
 
@@ -73,7 +114,7 @@ Trois PRs atomiques enchaînées **dans cet ordre** pour éviter les conflits su
 - [x] Headers sécurité A+ (CSP nonce, HSTS, COOP, Permissions-Policy)
 - [x] Couche domaine pure (budget, provision, simulation, balance) testée
 - [x] Migrations Supabase + RLS complètes
-- [x] `.claude/agents/` (7 QA agents)
+- [x] `.claude/agents/` (10 QA agents — 7 bootstrap + dashboard-ux-auditor + admin-dashboard-auditor)
 - [x] CI GitHub Actions (lint + typecheck + test + e2e + lighthouse + audit)
 - [x] Husky pre-commit + commit-msg
 - [x] PWA manifest + llms.txt + sitemap + robots

--- a/docs/competitive-landscape.md
+++ b/docs/competitive-landscape.md
@@ -1,0 +1,217 @@
+# Paysage concurrentiel — Finance personnelle 2026
+
+Source de vérité pour les décisions produit Ankora v1.0. Analyse de 13 acteurs (US + FR + UK + BE) réalisée le 23 avril 2026.
+
+Pour la vision produit, voir `NORTH_STAR.md`. Pour l'ordre d'exécution, voir `ROADMAP.md`.
+
+---
+
+## Synthèse exécutive
+
+Marché en croissance forte (+25 % annuel, 207 Md$ en 2026). Les leaders mondiaux (Monarch, YNAB, Copilot) sont **US-only** ou **mal localisés UE**, et monétisent à 80-100 $/an. Les leaders français (Linxo, Bankin') s'appuient sur l'**agrégation PSD2**. Aucun acteur belge natif ne domine. **Trois gaps structurels exploitables** par Ankora :
+
+1. **Aucun concurrent mondial ne combine** modèle enveloppes-first + prédiction cashflow 6-12 mois + zéro agrégation PSD2
+2. **Marché BE orphelin** : YNAB, Bankin' et Buxfer y sont, mais aucun n'est belge natif ni conçu pour la conformité APD 2026
+3. **Pricing wars** : tous payants (79-120 $/an), Ankora peut tenir en 0 € jusqu'à Phase 3 grâce au modèle enveloppes (pas d'infra PSD2 à payer)
+
+La proposition de valeur différenciante Ankora : **"Savoir où va ton argent dans 6 mois, sans connecter ta banque, sans payer, conforme Belgique"**.
+
+---
+
+## Vue marché 2026
+
+- Marché global personal finance apps : 165 Md$ (2025) → 207 Md$ (2026), CAGR 25,2 %
+- Belgique : 69 % des habitants utilisent le banking en ligne (au-dessus moyenne UE 54 %)
+- Fintech belge : +300 % en 3 ans, 85 % des banques API-enabled (PSD2)
+- Features standards 2026 : AI categorization, prédiction cashflow, goals automatisés, net worth tracker, recurring payments
+- Tendance forte : **custom dashboards** (Monarch, Rocket Money) — les users veulent personnaliser
+- Tendance forte : **couple/family mode** (Monarch différenciateur majeur)
+
+---
+
+## 13 concurrents analysés
+
+### 1. Monarch Money (US) — 99 $/an
+
+**Force** : référence absolue du dashboard personnel finance 2026. Net worth, budgets, investments, goals, tout sur un écran customisable. Collaborative mode pour couples (vraie killer feature). Tracks all investment holdings.
+
+**Faiblesse Ankora peut exploiter** : US-only UX, pas de localisation UE sérieuse, pas de conformité APD belge, agrégation PSD2 imparfaite en Europe, prix élevé (99 $/an).
+
+**À copier** : hiérarchie visuelle du dashboard, custom widgets, cohérence design tokens.
+
+### 2. YNAB (US) — 99 $/an
+
+**Force** : gold standard du zero-based budgeting. Méthode pédagogique forte, communauté fidèle. Présent en Belgique via marketplaces EU.
+
+**Faiblesse Ankora peut exploiter** : pas d'IA, pas de prédiction cashflow forward, interface vieillissante, méthode manuelle pure (rigide), prix dissuasif pour marché belge.
+
+**À copier** : discipline d'assignation de chaque euro à une enveloppe (concept proche d'Ankora).
+
+### 3. Copilot Money (US Apple) — 95 $/an
+
+**Force** : meilleure UX iOS/Mac du marché. IA catégorisation qui apprend des corrections. Interface premium.
+
+**Faiblesse Ankora peut exploiter** : Apple-only (exclut Android + desktop Web = gros morceau marché BE), pas européen, agrégation US-centric.
+
+**À copier** : qualité animation, densité d'information sans surcharge, feedback visuel sur chaque action.
+
+### 4. Rocket Money (US) — 6-12 $/mois (freemium)
+
+**Force** : focus abonnements (détecte, négocie, résilie). Dashboard customisable. Widgets iOS natifs. Net worth + Financial Goals + transaction tags + account sharing.
+
+**Faiblesse Ankora peut exploiter** : focus trop étroit (abonnements only), pas de modèle enveloppes ni prédiction multi-mois, pas localisé UE.
+
+**À copier** : customizable dashboard pattern, widgets premium, détection automatique des récurrences.
+
+### 5. Emma (UK) — freemium
+
+**Force** : open banking UK, scan des paiements récurrents, UI jeune.
+
+**Faiblesse Ankora peut exploiter** : UK-first, localisation UE incomplète, pas d'angle prédictif fort.
+
+### 6. Lunch Money (Global) — 10 $/mois
+
+**Force** : multi-devises, dev-friendly, API publique, customisation poussée.
+
+**Faiblesse Ankora peut exploiter** : très niche (dev/power users), UX non grand-public.
+
+**À copier** : approche headless, export des données, tagging flexible.
+
+### 7. Origin Financial (US) — 99 $/an
+
+**Force** : AI insights + accès advisor humain. Positionnement premium "advisor + tools".
+
+**Faiblesse Ankora peut exploiter** : cible haut de gamme US, advisor = hors scope Ankora (FSMA), prix.
+
+### 8. Tiller (US) — 79 $/an
+
+**Force** : spreadsheet-based (Google Sheets + Excel sync bancaire automatique). Power users adorent.
+
+**Faiblesse Ankora peut exploiter** : pas d'app native, dépendance Google/Excel, pas de vraie UX produit.
+
+### 9. Goodbudget (US) — Free ou 80 $/an
+
+**Force** : **LE concurrent conceptuel direct** d'Ankora. Envelope budgeting manuel, pas de bank sync (comme nous), 20 enveloppes en free. Philosophy "saisie manuelle = dépenses plus conscientes" = exactement notre thèse.
+
+**Faiblesse Ankora peut exploiter** : UX très vieillie (early 2010s), aucune prédiction cashflow avancée, pas de health score, pas de timeline forward, pas de simulateur what-if. Ankora = Goodbudget 2026 avec Monarch-level dashboard.
+
+**À copier** : validation du concept envelope-first + saisie manuelle accepté par le marché.
+
+### 10. Linxo (FR, filiale Crédit Agricole) — 4,49 €/mois ou 29,99 €/an
+
+**Force** : 320 banques agrégées PSD2 (incluant belges), prévision cashflow 30 jours (Premium), leader marché FR, Crédit Agricole backing.
+
+**Faiblesse Ankora peut exploiter** : prévision limitée à 30 jours (Ankora = 6-12 mois), prévision en **Premium uniquement** (Ankora = gratuit), dépendance connexion bancaire (Ankora = zéro friction), UI français pur (pas de EN), pas d'angle conformité APD belge explicite.
+
+### 11. Bilan (FR) — freemium
+
+**Force** : alternative FR à Linxo.
+
+**Faiblesse Ankora peut exploiter** : notoriété moindre, pas de différenciateur fort vs Linxo.
+
+### 12. Cashbee (FR)
+
+**Ne pas traiter comme concurrent direct** : Cashbee est un produit épargne/investissement, pas un budget tracker. Positionnement différent. Utile uniquement comme référence UX mobile FR.
+
+### 13. Acteur belge natif : aucun dominant identifié
+
+Les apps populaires en Belgique sont Payconiq by Bancontact (paiement mobile, pas budget), KBC Mobile, Belfius Mobile, ING Banking (apps banques natives). Côté budget pur : YNAB, Bankin' et Buxfer y opèrent mais aucun n'est belge natif ni conçu pour la conformité APD 2026. **C'est l'opportunité centrale d'Ankora.**
+
+---
+
+## Gaps exploitables pour Ankora v1.0
+
+| Gap                                    | Qui l'exploite aujourd'hui | Comment Ankora gagne                                              |
+| -------------------------------------- | -------------------------- | ----------------------------------------------------------------- |
+| Envelope-first + prédiction 6-12 mois  | Personne                   | Core produit Ankora                                               |
+| 100 % gratuit (pas freemium)           | Goodbudget (partial)       | Ankora complet gratuit Phase 1                                    |
+| Conformité APD belge stricte 2026      | Personne                   | Privacy langue user + CGU loi 30/07/2018                          |
+| Pas de PSD2 → zéro friction onboarding | Goodbudget, YNAB           | Dashboard Monarch-level + saisie fluide                           |
+| Health score provisions                | Personne                   | Indice propriétaire Ankora                                        |
+| Simulateur what-if intégré dashboard   | Personne                   | Drawer latéral natif                                              |
+| Timeline cashflow waterfall animé      | Personne (YNAB partiel)    | Hero section Ankora                                               |
+| Belgique natif                         | Personne                   | Localisation BE + fiscalité + CBC/KBC/Belfius/ING support display |
+
+---
+
+## Recommandations pour mockup user dashboard v3
+
+Synthèse des patterns gagnants observés chez Monarch + Copilot + Rocket Money, adaptés au modèle enveloppes Ankora.
+
+### Sections retenues (ordre visuel top-to-bottom)
+
+1. **Hero cashflow waterfall** (unique à Ankora) — salaire → enveloppes → sorties, animation progressive au scroll
+2. **KPI cards** (patrimoine net, provisions du mois, reste après factures, factures à venir) — pattern Monarch
+3. **Timeline 6-12 mois prédictive** (unique à Ankora vs Linxo 30j limité) — courbe + jalons
+4. **Enveloppes actives** (drag-to-rebalance) — pattern Goodbudget modernisé
+5. **Health score provisions** (unique à Ankora) — jauge + 1-3 nudges actionnables
+6. **Prochaines factures 7/14/30j** — pattern Rocket Money sur provisions au lieu d'abonnements
+7. **Goals épargne avec ETA** — pattern Monarch, calcul prédictif Ankora
+8. **Simulateur what-if en drawer latéral** (unique à Ankora) — slider what-if sans quitter le dashboard
+9. **Activité récente** — timeline événements (ajout charge, transfert, etc.)
+
+### Patterns UX à adopter
+
+- **Custom dashboard** : permettre masquer/réorganiser les widgets (Monarch/Rocket Money)
+- **Widgets iOS/Android** (PWA) : KPI principale en home screen (Rocket Money)
+- **Dark mode natif** automatique (tous les concurrents l'ont)
+- **Density équilibrée** : ni mur d'infos (Emma) ni vide marketing (Goodbudget), inspiration Copilot
+- **Feedback visuel systématique** : chaque action a une micro-animation (Copilot)
+- **Empty/error/loading states** explicites (tous les concurrents matures)
+
+### Patterns à NE PAS copier
+
+- Le graphe en donut de YNAB (complexe, peu lisible sur mobile)
+- La densité de Lunch Money (power-user-only)
+- L'interface vieillie de Goodbudget
+
+---
+
+## Recommandations pour mockup admin panel v1
+
+Aucun concurrent n'expose publiquement son admin, donc on part sur les **4 sections ADR B2** avec inspiration générique des dashboards SaaS modernes (Vercel, Linear, PostHog pour la lisibilité).
+
+### Sections et métriques
+
+1. **Santé technique** — uptime, error rate, p50/p95/p99 latency, top 10 erreurs 7j, bug reports status funnel, build statuses CI (via GitHub API)
+2. **Santé produit** — DAU/WAU/MAU, retention cohortes 1/7/30 jours, funnel onboarding (étape 1 → complet), feature usage heatmap (charges, dépenses, simulateur)
+3. **Acquisition** — signups/jour, sources referrer, UTMs, conversion first-workspace-created, pays origine
+4. **Recommandations rule-based** (ADR-002) — alertes contextuelles : "Étape 3 onboarding abandon 23 %", "Erreur charge-form X40 cette semaine", "15 signups même domaine gmail en 1h"
+
+Toutes les données doivent être **calculées server-side** (pas de calcul client des KPI), requêtes agrégées avec index Postgres, refresh cron ou bouton manuel. `requireAdmin()` partout. Graphiques Recharts, lisibilité prioritaire sur esthétique.
+
+---
+
+## Positionnement final Ankora (one-liner)
+
+> **Ankora — Le cockpit finances belge qui te montre ton argent dans 6 mois, sans connecter ta banque.**
+
+Angle émotionnel : **prédictibilité, tranquillité, conformité**. Contre le stress du "est-ce que j'ai assez pour la facture de février", Ankora montre la courbe jusqu'à juin.
+
+Public cible v1.0 : **particuliers belges 25-55 ans, double revenu, 1-2 enfants, factures lissables (assurances, impôts, abonnements), veulent reprendre le contrôle sans installer encore une app qui veut leur numéro de compte**.
+
+---
+
+## Livrables de cette recherche (complétés 23 avril 2026)
+
+1. ✅ Document rempli avec analyse 13 concurrents
+2. ✅ Recommandations dashboard user v3 (sections + patterns)
+3. ✅ Recommandations admin panel v1 (4 sections)
+4. ✅ Positionnement final Ankora (one-liner + public cible)
+5. ⏳ Mockup user dashboard v3 HTML (tâche #133, suite logique)
+6. ⏳ Mockup admin panel v1 HTML (tâche #134, suite logique)
+
+## Sources
+
+- [Era vs Monarch vs Copilot vs YNAB 2026](https://era.app/articles/era-vs-monarch-vs-copilot-vs-ynab/)
+- [YNAB vs Monarch vs Copilot — WalletHub 2026](https://wallethub.com/edu/b/ynab-vs-monarch-vs-copilot-vs-wallethub/150687)
+- [Best AI Personal Finance Tools 2026 — Techno-Pulse](https://www.techno-pulse.com/2026/04/best-ai-personal-finance-tools-in-2026.html)
+- [Best Budgeting Apps 2026 — Engadget](https://www.engadget.com/apps/best-budgeting-apps-120036303.html)
+- [Linxo Avis 2026 — Economiser Mon Argent](https://www.economiser-mon-argent.com/avis-linxo/)
+- [Linxo Avis Complet — Selectra](https://selectra.info/finance/guides/compte-bancaire/linxo-avis)
+- [12 Best Budgeting Apps for Europe 2026 — Freenance](https://freenance.io/budgeting/best-free-budgeting-apps-europe/)
+- [Best Budget App Belgium — Buxfer](https://www.buxfer.com/countries/22/best-budgeting-app-belgium)
+- [Rocket Money Review 2026 — Wall Street Survivor](https://www.wallstreetsurvivor.com/rocket-money-review/)
+- [Tiller Money Pricing 2026](https://sheetlink.app/tiller-money-pricing-2026)
+- [Belgium Digital Finance 2026 — Beaumont Capital](https://beaumont-capitalmarkets.co.uk/belgium-digital-finance-ai-open-banking-initiatives/)
+- [Personal Finance Apps Market Report 2026](https://www.researchandmarkets.com/report/personal-finance-app-market)

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,6 +1,6 @@
 # ankora.be — Full content export for LLMs
 
-Last generated: 2026-04-21
+Last generated: 2026-04-23
 Canonical URL: https://ankora.be
 License: content available for citation with attribution. Code is proprietary.
 


### PR DESCRIPTION
Pilier A reboot: NORTH_STAR, CLAUDE.md lock, competitive analysis, ROADMAP sync, 2 new QA agents

## Summary by Sourcery

Définir et verrouiller la version publique v1.0 du produit avec une gouvernance, une vision et des garde-fous QA alignés pour Ankora.

Nouvelles fonctionnalités :
- Introduire un document NORTH_STAR comme source unique de vérité pour la vision Ankora v1.0, ses piliers et ses objectifs mesurables.
- Ajouter un document détaillé sur le paysage concurrentiel couvrant les principales applications de finances personnelles et positionnant Ankora sur le marché de 2026.
- Définir deux nouveaux agents QA dédiés à l’audit de l’UX du tableau de bord utilisateur et du tableau de bord administrateur.

Améliorations :
- Affiner la feuille de route du projet autour de la version publique v1.0 avec des jalons explicites, des piliers menés en parallèle et des responsabilités clairement définies.
- Étendre le cadre des agents QA à 10 agents pilotés par des déclencheurs, liés aux domaines critiques et aux portes de CI.
- Clarifier, dans CLAUDE.md, les contraintes non négociables, les exigences d’excellence des tableaux de bord et les choix techniques pour la version v1.0.

Documentation :
- Mettre à jour CLAUDE.md et ROADMAP.md pour refléter le nouveau plan v1.0, les règles de gouvernance et le modèle de gating QA.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Define and lock the public v1.0 product cap with aligned governance, vision, and QA guardrails for Ankora.

New Features:
- Introduce a NORTH_STAR document as the single source of truth for Ankora v1.0 vision, pillars, and measurable targets.
- Add a detailed competitive landscape document covering key personal finance apps and positioning Ankora within the 2026 market.
- Define two new QA agents dedicated to auditing the user dashboard UX and the admin dashboard.

Enhancements:
- Refine the project roadmap around the v1.0 public cap with explicit milestones, parallel pillars, and ownership.
- Expand the QA agents framework to 10 trigger-driven agents tied to critical domains and CI gates.
- Clarify non-negotiable constraints, dashboard excellence requirements, and technical choices for the v1.0 release in CLAUDE.md.

Documentation:
- Update CLAUDE.md and ROADMAP.md to reflect the rebooted v1.0 plan, governance rules, and QA gating model.

</details>