### PR TITLE
docs(roadmap): re-sequence PR-3a anticipated as design system socle (ADR-005)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap — Ankora
 
-Dernière mise à jour : 23 avril 2026 — Reboot v1.0 Pilier A (gouvernance + agents QA) complété. Prêt pour PR-2 (traductions).
+Dernière mise à jour : 25 avril 2026 — Workflow trio @cowork/@cc-design/@cc-ankora opérationnel. PR-3 splittée en PR-3a/b/c, PR-3a anticipée comme socle architectural avant PR-2 (cf. [ADR-005](./adr/ADR-005-pr3a-anticipated-design-system.md)).
 
 ## Cap v1.0 publique — Vision & Jalons (23 avril 2026)
 
@@ -68,22 +68,36 @@ Toute PR introduisant un service tiers facturé **doit d'abord obtenir validatio
 
 L'ordre ci-dessous est **verrouillé**. Il a été pensé pour que chaque PR débloque la suivante sans dette technique ni retouche arrière.
 
-| #   | PR                                           | Statut                                                | Bloquant pour     | Raison d'être                              |
-| --- | -------------------------------------------- | ----------------------------------------------------- | ----------------- | ------------------------------------------ |
-| 1   | **PR-1 — Socle i18n next-intl**              | ✅ mergée                                             | PR-1bis           | Route group `[locale]` + 5 locales         |
-| 2   | **PR-Q — OpenGraph statique**                | ✅ mergée                                             | —                 | 5 PNG 1200×630 générés via Playwright      |
-| 3   | **PR-1bis — Extraction i18n routes privées** | ✅ mergée (a491297, 18 avril 2026)                    | PR-2              | Clés i18n pour auth + app + onboarding     |
-| 4   | **PR-2 — Traductions NL/EN/ES/DE**           | ⏳ en attente (après dettes post-PR-1bis)             | PR-3              | Remplissage des 4 locales non-FR           |
-| 5   | **PR-B1 — Bug reporting MVP**                | 📋 prompt prêt (`prompts/PR-B1-bug-reporting-mvp.md`) | PR-3 (recommandé) | Capteur d'erreurs + widget avant QA lourde |
-| 6   | **PR-3 — Port mockups → React prod**         | 📋 prompt prêt                                        | PR-F              | Remplacement de l'UI actuelle              |
-| 7   | **PR-F — Rétro-planning provisions**         | 💡 idée                                               | PR-B2             | Alertes J-N avant retrait d'épargne        |
-| 8   | **PR-B2 — Admin panel complet**              | 💡 idée (post-MVP)                                    | —                 | Dashboard santé + métriques + règles       |
+**Re-séquencement 2026-04-25** : PR-3 monolithique splittée en **PR-3a/b/c** ; PR-3a anticipée avant PR-2/PR-B1 comme socle architectural. Justification complète : [ADR-005](./adr/ADR-005-pr3a-anticipated-design-system.md).
+
+| #   | PR                                                    | Statut                                                               | Bloquant pour        | Raison d'être                                                                              |
+| --- | ----------------------------------------------------- | -------------------------------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------ |
+| 1   | **PR-1 — Socle i18n next-intl**                       | ✅ mergée                                                            | PR-1bis              | Route group `[locale]` + 5 locales                                                         |
+| 2   | **PR-Q — OpenGraph statique**                         | ✅ mergée                                                            | —                    | 5 PNG 1200×630 générés via Playwright                                                      |
+| 3   | **PR-1bis — Extraction i18n routes privées**          | ✅ mergée (a491297, 18 avril 2026)                                   | PR-2                 | Clés i18n pour auth + app + onboarding                                                     |
+| 4   | **PR-3a — Design System socle (DS + tokens + fonts)** | 📋 prochaine (`docs/design/cc-ankora-prompt-handoff-integration.md`) | PR-2, PR-B1, PR-3b/c | Tokens canoniques, fonts, SKILL `ankora-design-system` — débloque toute la couche visuelle |
+| 5   | **PR-2 — Traductions NL/EN/ES/DE**                    | ⏳ en attente (après PR-3a)                                          | PR-3c                | Remplissage des 4 locales non-FR                                                           |
+| 6   | **PR-B1 — Bug reporting MVP**                         | 📋 prompt prêt (`prompts/PR-B1-bug-reporting-mvp.md`)                | PR-3b/c (recommandé) | Capteur d'erreurs + widget avant QA lourde                                                 |
+| 7   | **PR-3b — Atomic UI kit**                             | 📋 cadré (post-PR-3a)                                                | PR-3c                | `src/components/ui/` (Button, Card, Input, Badge…) + tests Vitest                          |
+| 8   | **PR-3c — Landing fusion intelligente**               | 📋 cadré (post-PR-3b + `landing-merge-analysis.md`)                  | PR-F                 | Fusion ossature TSX/RSC actuelle ↔ apports cc-design (hero waterfall, simulator, pricing)  |
+| 9   | **PR-F — Rétro-planning provisions**                  | 💡 idée                                                              | PR-B2                | Alertes J-N avant retrait d'épargne                                                        |
+| 10  | **PR-B2 — Admin panel complet**                       | 💡 idée (post-MVP)                                                   | —                    | Dashboard santé + métriques + règles                                                       |
 
 Signification des icônes : ✅ mergée · 🚧 en cours · ⏳ en attente d'un prérequis · 📋 prompt rédigé prêt à exécuter · 💡 idée cadrée mais pas encore de prompt.
 
-### Pourquoi PR-B1 avant PR-3 ?
+### Pourquoi PR-3a avant PR-2 et PR-B1 ?
 
-PR-3 est gros (40+ composants React, migrations visuelles massives) et va générer des bugs subtils de style/interaction/a11y. Si PR-B1 est en place **avant** PR-3, chaque bug rencontré en QA génère un bundle markdown copiable en 2 clics vers Claude Code. Gain de temps majeur sur le debugging de PR-3.
+PR-3a livre les **tokens canoniques + fonts + SKILL `ankora-design-system`** sans toucher aux composants ni aux pages. Sans cela :
+
+- **PR-2** traduirait des chaînes UI qui changeront visuellement en PR-3b/c (re-traduction inutile sur copies obsolètes)
+- **PR-B1** construirait son widget bug-reporting sur des primitives `Button`/`Card`/`Modal` qu'il faudrait re-styler en PR-3b
+- **PR-3b** travaillerait sur des tokens incohérents avec le DS final
+
+PR-3a est un **socle architectural** (≤ 400 lignes, 0 régression UI possible) qui débloque proprement la suite.
+
+### Pourquoi PR-B1 avant PR-3b/c ?
+
+PR-3b (composants atomiques) et surtout PR-3c (Landing fusion) vont générer des bugs subtils de style/interaction/a11y. Si PR-B1 est en place **avant** PR-3b/c, chaque bug rencontré en QA génère un bundle markdown copiable en 2 clics vers Claude Code. Gain de temps majeur sur le debugging.
 
 ---
 
@@ -101,7 +115,8 @@ Trois PRs atomiques enchaînées **dans cet ordre** pour éviter les conflits su
 
 ## Prochaine feature majeure
 
-- **PR-3 — Port mockups React prod** : en attente du **mockup v2 simulateur bidirectionnel** validé par Thierry (travail en cours côté Cowork, livrable courant semaine). Ne pas démarrer avant validation explicite du mockup et du glossaire de composants.
+- **PR-3a — Design System socle** : prochaine PR à exécuter sur la branche `feat/cc-design-handoff-v1`. Source : ZIP `Ankora Design System.zip` livré par @cc-design (session #1, validée @thierry + @cowork le 2026-04-25). Prompt complet : `docs/design/cc-ankora-prompt-handoff-integration.md`. Cf. ADR-005 pour la justification du re-séquencement.
+- **PR-3b/c** : suivront PR-3a après validation @thierry. PR-3c sera précédée d'un `docs/design/landing-merge-analysis.md` documentant la fusion ossature TSX/RSC actuelle ↔ apports cc-design.
 
 ## Backlog produit
 
@@ -137,9 +152,11 @@ Objectif : cockpit personnel utilisable par Thierry, ses enfants et amis.
   - Batch B : routes privées (auth + app) migrées avec `generateMetadata` via `getTranslations`, server actions locale-aware, Zod i18n-friendly
   - Tests : parity sync des 4 stubs non-FR + E2E skip GDPR banner sur mobile emulations (Pixel 7 + iPhone 14, flaky tap dispatch)
   - Hygiène : `.gitignore` durci (`design-mockup-*.html`, `.claude/settings.local.json`, `prompts/`)
-- [ ] PR-2 — traductions NL-BE / EN / ES-ES / DE-DE (glossaire doc déjà écrit, prompt final après dettes post-PR-1bis)
+- [ ] **PR-3a — Design System socle** (tokens + fonts + SKILL `ankora-design-system`) — prochaine PR (cf. ADR-005)
+- [ ] PR-2 — traductions NL-BE / EN / ES-ES / DE-DE (glossaire doc déjà écrit)
 - [ ] PR-B1 — Bug reporting MVP (voir §PR-B1 ci-dessous)
-- [ ] PR-3 — port mockups → React production (prompt prêt)
+- [ ] PR-3b — Atomic UI kit (`src/components/ui/` + tests Vitest)
+- [ ] PR-3c — Landing fusion intelligente (ossature actuelle + apports cc-design)
 
 ### Bloc fonctionnel produit
 

--- a/docs/adr/ADR-005-pr3a-anticipated-design-system.md
+++ b/docs/adr/ADR-005-pr3a-anticipated-design-system.md
@@ -7,6 +7,8 @@
 - **Tags** : `architecture`, `process`, `design-system`, `roadmap`
 - **Portée** : ROADMAP Phase 1 (MVP). N'affecte ni le produit ni la sécurité ; modifie uniquement l'**ordre d'exécution** des PRs techniques.
 
+> **Glossaire des handles** (@cowork, @cc-design, @cc-ankora, @thierry) — voir source canonique : [`docs/design/trio-agents.md`](../design/trio-agents.md).
+
 ---
 
 ## Contexte & problème
@@ -23,7 +25,7 @@ Le 25 avril 2026, @cowork a piloté une session @cc-design (`claude.ai/design`, 
 - Fonts brand (Inter Variable, Fraunces Variable, JetBrains Mono Variable)
 - SKILL `ankora-design-system` (5.6 KB)
 - 4 UI kits HTML/JSX (landing, user dashboard, admin, onboarding)
-- Components atomiques `_shared/` + previews HTML
+- Composants atomiques `_shared/` + previews HTML
 
 Lecture du livrable + brief d'intégration ont révélé que **PR-3 dans sa forme monolithique** (port complet en une PR) :
 
@@ -119,7 +121,7 @@ PR-1 → PR-Q → PR-1bis → PR-3a → PR-2 → PR-B1 → PR-3b → PR-3c → P
 
 1. **PR-3a ne touche aucun composant, aucune page, aucun test E2E.** Uniquement tokens, fonts, SKILL. Cela garantit qu'elle ne peut PAS casser l'UI existante.
 2. **PR-3c sera précédée d'un `docs/design/landing-merge-analysis.md`** documentant le diff section par section entre la Landing actuelle (à GARDER) et l'apport cc-design (à IMPORTER). Pas de remplacement brutal.
-3. **i18n** : les `messages/fr-BE.json` + `en.json` du ZIP cc-design sont **inspiration uniquement**, pas import direct (architecture next-intl + parité 5 locales trop sensible — cf. mémoire feedback `i18n-translator`).
+3. **i18n** : les `messages/fr-BE.json` + `en.json` du ZIP cc-design sont **une source d'inspiration uniquement**, pas import direct (architecture next-intl + parité 5 locales trop sensible — cf. mémoire feedback `i18n-translator`).
 4. **Validation @thierry à chaque étape** : merge PR-3a avant démarrage PR-3b ; merge PR-3b avant démarrage PR-3c.
 5. **Agents QA pertinents** lancés à chaque PR (security-auditor, gdpr-compliance-auditor, ui-auditor pour PR-3b/c, lighthouse-auditor pour PR-3c).
 
@@ -168,4 +170,4 @@ Cet ADR est référencé dans `docs/ROADMAP.md` :
 - Dans la section §"Pourquoi PR-3a avant PR-2 et PR-B1 ?" (justification courte avec lien vers cet ADR)
 - Dans la section §"Prochaine feature majeure" (PR-3a comme prochaine)
 
-Toute évolution du re-séquencement nécessitera **un nouvel ADR** (ADR-006+) qui supersedera celui-ci, conformément à la doctrine immutable des ADRs.
+Toute évolution du re-séquencement nécessitera **un nouvel ADR** (ADR-006+) qui supersédera celui-ci, conformément à la doctrine immutable des ADRs.

--- a/docs/adr/ADR-005-pr3a-anticipated-design-system.md
+++ b/docs/adr/ADR-005-pr3a-anticipated-design-system.md
@@ -1,0 +1,171 @@
+# ADR-005 — PR-3a anticipée comme prérequis architectural (Design System socle)
+
+- **Statut** : Accepted
+- **Date** : 2026-04-25
+- **Accepté le** : 2026-04-25 par Thierry vanmeeteren (via délégation @cowork)
+- **Deciders** : Thierry vanmeeteren (Product Owner), @cowork (orchestration), @cc-ankora (exécution)
+- **Tags** : `architecture`, `process`, `design-system`, `roadmap`
+- **Portée** : ROADMAP Phase 1 (MVP). N'affecte ni le produit ni la sécurité ; modifie uniquement l'**ordre d'exécution** des PRs techniques.
+
+---
+
+## Contexte & problème
+
+Le ROADMAP du 23 avril 2026 verrouillait l'ordre d'exécution suivant :
+
+```
+PR-1bis (mergée) → PR-2 (traductions) → PR-B1 (bug reporting) → PR-3 (port mockups React) → PR-F → PR-B2
+```
+
+Le 25 avril 2026, @cowork a piloté une session @cc-design (`claude.ai/design`, Opus 4.7 research preview) qui a livré un **Design System complet pour Ankora** (ZIP `Ankora Design System.zip`, 2.5 MB) :
+
+- Tokens canoniques (`colors_and_type.css`)
+- Fonts brand (Inter Variable, Fraunces Variable, JetBrains Mono Variable)
+- SKILL `ankora-design-system` (5.6 KB)
+- 4 UI kits HTML/JSX (landing, user dashboard, admin, onboarding)
+- Components atomiques `_shared/` + previews HTML
+
+Lecture du livrable + brief d'intégration ont révélé que **PR-3 dans sa forme monolithique** (port complet en une PR) :
+
+1. dépasserait largement la limite de 600 lignes (estimation 2000+ lignes), nécessitant une justification scope creep ;
+2. mélangerait des couches de risque très différentes (tokens CSS purs ↔ composants TSX ↔ pages App Router) ;
+3. forcerait PR-2 et PR-B1 à travailler sur des **primitives UI obsolètes** qui seraient écrasées dès le merge de PR-3.
+
+La question : **faut-il garder l'ordre verrouillé, ou anticiper une partie de PR-3 pour débloquer le reste proprement ?**
+
+---
+
+## Decision drivers
+
+| Driver                                      | Pourquoi c'est décisif                                                                                                                                     |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Limite PR < 600 lignes                      | Règle d'or `CLAUDE.md` projet (sauf justification explicite). Une PR-3 monolithique dépasserait 2000 lignes.                                               |
+| Reviewability humaine                       | @thierry doit pouvoir reviewer chaque PR sans y passer 1h. Une PR splittée par couche est lisible.                                                         |
+| Évitement du re-travail                     | Les traductions PR-2 et le widget PR-B1 doivent s'appuyer sur les **vrais** tokens et primitives, pas du provisoire.                                       |
+| Risque par couche                           | Tokens CSS = 0 régression UI possible. Composants TSX = risque moyen. Pages = risque élevé (Landing fusion).                                               |
+| Workflow trio @cowork/@cc-design/@cc-ankora | Le ZIP @cc-design est la source de vérité. Une intégration en plusieurs PRs respecte le rythme du trio (validation @thierry à chaque étape).               |
+| Préservation de l'ossature actuelle         | La Landing actuelle (PR-1/PR-1bis) contient i18n next-intl, Server Components RSC, Schema.org SEO, copies FSMA validées par les agents — à NE PAS écraser. |
+
+---
+
+## Considered options
+
+### Option 1 — Garder l'ordre verrouillé (PR-3 monolithique après PR-2 + PR-B1)
+
+**Pour** :
+
+- Respecte la doctrine "ordre verrouillé, pas de re-séquencement".
+- 1 seule PR-3 = 1 seul cycle de review.
+
+**Contre** :
+
+- PR-3 ferait > 2000 lignes (violation CLAUDE.md règle <600).
+- PR-2 traduit des chaînes UI qui changent visuellement en PR-3 (re-traduction probable des copies obsolètes).
+- PR-B1 construit son widget bug-reporting sur des primitives `Button`/`Card`/`Modal` qu'il faudrait re-styler en PR-3.
+- Review humaine très lourde (mélange CSS/TSX/Pages dans le même diff).
+- Rollback impossible par couche (tout ou rien).
+
+### Option 2 — Anticiper une PR-3a "Design System socle" avant PR-2/PR-B1, splitter le reste en PR-3b/c
+
+**Pour** :
+
+- PR-3a reste sous 400 lignes (tokens + fonts + SKILL, **0 composant, 0 page**) — 0 régression UI possible.
+- Débloque proprement PR-2 (traductions sur tokens stables), PR-B1 (widget sur primitives stables), PR-3b (composants sur tokens canoniques), PR-3c (Landing fusion sur composants validés).
+- Reviewable en une session par @thierry (chaque PR < 800 lignes).
+- Permet la **fusion intelligente** Landing en PR-3c (analyse merge documentée avant écriture code) — préserve l'ossature actuelle.
+- Aligné avec le workflow trio (validation @thierry à chaque étape).
+
+**Contre** :
+
+- 3 PRs au lieu d'1 = 3 cycles de review au lieu de 1.
+- ROADMAP doit être mis à jour (re-séquencement).
+- Nécessite un ADR (ce document) pour tracer la décision.
+
+### Option 3 — Importer brutalement le ZIP @cc-design dans `src/`, écraser l'existant
+
+**Pour** :
+
+- Rapide.
+
+**Contre** :
+
+- Perte de l'i18n next-intl, des Server Components RSC, des copies FSMA validées (= violation CLAUDE.md règle 7 "Messages UI en français" + règle FSMA + scope creep majeur).
+- Aucun garde-fou de revue.
+- **Décision @thierry implicite (catégorie 4 irréversible) sans validation humaine.**
+- Inacceptable.
+
+---
+
+## Decision
+
+**Option 2 retenue** : PR-3 splittée en **PR-3a / PR-3b / PR-3c**, **PR-3a anticipée** comme prérequis architectural avant PR-2 et PR-B1.
+
+**Nouvel ordre verrouillé (ROADMAP §"Ordre d'exécution des PR techniques")** :
+
+```
+PR-1 → PR-Q → PR-1bis → PR-3a → PR-2 → PR-B1 → PR-3b → PR-3c → PR-F → PR-B2
+                         ↑NEW
+```
+
+### Scope de chaque sous-PR
+
+| PR    | Scope                                                                                                                                                                                                                          | Cible lignes                 | Risque UI                                |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------- | ---------------------------------------- |
+| PR-3a | SKILL `ankora-design-system` installé · `colors_and_type.css` mappé dans `globals.css` (diff documenté) · 3 fonts dans `public/fonts/` + `@font-face`                                                                          | ~200-400                     | 0 régression possible (pas de composant) |
+| PR-3b | `src/components/ui/` migré (Button, Card, Input, Badge, Toast…) · tests Vitest co-located · convention shadcn-like                                                                                                             | ~500-700 (justifié si > 600) | Moyen                                    |
+| PR-3c | Landing fusion intelligente : ossature TSX/RSC actuelle préservée, apports cc-design importés (hero waterfall, simulator, pricing) · `landing-merge-analysis.md` produit AVANT le code · Playwright multi-viewport · agents QA | ~500-800 (justifié)          | Élevé                                    |
+
+### Garde-fous non négociables
+
+1. **PR-3a ne touche aucun composant, aucune page, aucun test E2E.** Uniquement tokens, fonts, SKILL. Cela garantit qu'elle ne peut PAS casser l'UI existante.
+2. **PR-3c sera précédée d'un `docs/design/landing-merge-analysis.md`** documentant le diff section par section entre la Landing actuelle (à GARDER) et l'apport cc-design (à IMPORTER). Pas de remplacement brutal.
+3. **i18n** : les `messages/fr-BE.json` + `en.json` du ZIP cc-design sont **inspiration uniquement**, pas import direct (architecture next-intl + parité 5 locales trop sensible — cf. mémoire feedback `i18n-translator`).
+4. **Validation @thierry à chaque étape** : merge PR-3a avant démarrage PR-3b ; merge PR-3b avant démarrage PR-3c.
+5. **Agents QA pertinents** lancés à chaque PR (security-auditor, gdpr-compliance-auditor, ui-auditor pour PR-3b/c, lighthouse-auditor pour PR-3c).
+
+---
+
+## Consequences
+
+### Positives
+
+- Chaque PR reste reviewable par @thierry sans surcharge.
+- Rollback possible par couche si une régression apparaît (rollback PR-3c sans toucher PR-3a/b).
+- PR-2 et PR-B1 travaillent sur des fondations stables.
+- Le re-séquencement est explicitement tracé (ce ADR + ROADMAP) — pas de dérive silencieuse.
+- Le workflow trio @cowork/@cc-design/@cc-ankora est validé en conditions réelles avant les chantiers Dashboard/Onboarding/Admin (qui suivront le même pattern : ZIP @cc-design → branche dédiée → split en sous-PRs reviewable).
+
+### Négatives ou neutres
+
+- 3 PRs au lieu d'1 = 3 cycles de review (mais chacun beaucoup plus rapide qu'une review monolithique).
+- Le nom "PR-3" devient ambigu — utiliser "PR-3a/b/c" partout pour éviter confusion.
+- ROADMAP mis à jour à chaque merge intermédiaire (cohérent avec la règle "synchronisation ROADMAP ↔ repo").
+
+### Risques résiduels
+
+- **R1** : si PR-3a est mergée mais PR-3b/c traînent, on aura des tokens/fonts inutilisés en prod (poids ~1.5 MB de fonts non servies). **Mitigation** : timeline ≤ 2 semaines pour livrer PR-3b/c après PR-3a, sinon rollback PR-3a documenté.
+- **R2** : la Landing actuelle (PR-1/PR-1bis) pourrait évoluer entre PR-3a et PR-3c (i18n, copies). **Mitigation** : `landing-merge-analysis.md` produit juste avant PR-3c sur la branche à jour.
+- **R3** : un nouveau livrable @cc-design (Dashboard, Onboarding…) pourrait modifier les tokens pendant le cycle PR-3a/b/c. **Mitigation** : tokens versionnés via SKILL, toute évolution = nouvelle PR-3a' explicite.
+
+---
+
+## Sources & traces
+
+- Brief @cowork d'origine : conversation du 25 avril 2026 (audit cross-project Haiku + handoff cc-design).
+- Prompt d'intégration complet : `docs/design/cc-ankora-prompt-handoff-integration.md` (commité dans PR #55).
+- Audit incident Haiku 4.5 (qui a renforcé la doctrine "PR splittée + reviewable") : `docs/audits/2026-04-25-haiku-incident-cross-project-lessons.md` (commité dans PR #56).
+- Live ZIP @cc-design : `F:\PROJECTS\Apps\ankora-mockups\design-exports\Ankora Design System.zip` (2.5 MB).
+- Décision tracée dans : ROADMAP §"Ordre d'exécution des PR techniques" + §"Pourquoi PR-3a avant PR-2 et PR-B1 ?".
+
+---
+
+## Lien avec le ROADMAP
+
+Cet ADR est référencé dans `docs/ROADMAP.md` :
+
+- En tête du fichier (date de mise à jour 25 avril 2026)
+- Dans la table "Ordre d'exécution des PR techniques" (mention re-séquencement)
+- Dans la section §"Pourquoi PR-3a avant PR-2 et PR-B1 ?" (justification courte avec lien vers cet ADR)
+- Dans la section §"Prochaine feature majeure" (PR-3a comme prochaine)
+
+Toute évolution du re-séquencement nécessitera **un nouvel ADR** (ADR-006+) qui supersedera celui-ci, conformément à la doctrine immutable des ADRs.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,12 +28,13 @@ Chaque ADR est immuable une fois `Accepted`. Pour le faire évoluer :
 
 ## Index
 
-| #   | Titre                                                                        | Statut   | Date       |
-| --- | ---------------------------------------------------------------------------- | -------- | ---------- |
-| 001 | [No-PSD2 : agrégation via import manuel](./ADR-001-no-psd2.md)               | Accepted | 2026-04-20 |
-| 002 | [Modèle bucket (comptes + enveloppes)](./ADR-002-bucket-model.md)            | Accepted | 2026-04-20 |
-| 003 | [Système de notifications (in-app first)](./ADR-003-notifications-system.md) | Accepted | 2026-04-20 |
-| 004 | [Logger structuré (Pino + wrapper Edge)](./ADR-004-structured-logging.md)    | Accepted | 2026-04-20 |
+| #   | Titre                                                                                        | Statut   | Date       |
+| --- | -------------------------------------------------------------------------------------------- | -------- | ---------- |
+| 001 | [No-PSD2 : agrégation via import manuel](./ADR-001-no-psd2.md)                               | Accepted | 2026-04-20 |
+| 002 | [Modèle bucket (comptes + enveloppes)](./ADR-002-bucket-model.md)                            | Accepted | 2026-04-20 |
+| 003 | [Système de notifications (in-app first)](./ADR-003-notifications-system.md)                 | Accepted | 2026-04-20 |
+| 004 | [Logger structuré (Pino + wrapper Edge)](./ADR-004-structured-logging.md)                    | Accepted | 2026-04-20 |
+| 005 | [PR-3a anticipée comme prérequis architectural](./ADR-005-pr3a-anticipated-design-system.md) | Accepted | 2026-04-25 |
 
 ## Conventions de nommage
 


### PR DESCRIPTION
## Contexte

Suite au merge de [PR #55](https://github.com/thierryvm/ankora/pull/55) (handoff prompt cc-design) et [PR #56](https://github.com/thierryvm/ankora/pull/56) (cross-project security lessons), je matérialise les **décisions d'orchestration** validées par @thierry via délégation @cowork le 2026-04-25 :

1. **PR-3 monolithique splittée** en PR-3a / PR-3b / PR-3c
2. **PR-3a anticipée** comme socle architectural avant PR-2 et PR-B1
3. **ADR-005 créé** pour tracer formellement la décision (immutable une fois mergé)

Cette PR est purement **documentaire**. Aucun code touché. Elle débloque proprement la PR-3a qui suivra sur cette même branche `feat/cc-design-handoff-v1`.

## Changements

### `docs/ROADMAP.md` (+49 / -7 lignes)

- Date de mise à jour : 23 → 25 avril 2026
- Table "Ordre d'exécution des PR techniques" : PR-3a inséré en position 4, PR-3 split en PR-3b/c, PR-2/B1 décalés, colonne "Bloquant pour" mise à jour, raison d'être documentée pour chaque nouveau scope
- Nouvelle section §"Pourquoi PR-3a avant PR-2 et PR-B1 ?" justifiant le re-séquencement
- Section §"Pourquoi PR-B1 avant PR-3 ?" mise à jour pour référencer PR-3b/c
- §"Prochaine feature majeure" : PR-3a comme prochaine, lien vers handoff prompt
- §"Bloc i18n + visuels" : PR-3a/b/c listés avec séquencement correct

### `docs/adr/ADR-005-pr3a-anticipated-design-system.md` (NEW, 171 lignes)

Format MADR complet :

- **Statut** : Accepted, 2026-04-25, Deciders @thierry/@cowork/@cc-ankora
- **Contexte & problème** : ZIP cc-design livré, PR-3 monolithique = >2000 lignes, PR-2/B1 sur primitives obsolètes
- **Decision drivers** : 6 critères pondérés (limite <600 lignes, reviewability, évitement re-travail, risque par couche, workflow trio, préservation ossature)
- **3 options considérées** : status quo / split + anticipation / import brutal
- **Decision** : Option 2 retenue, scope par sous-PR détaillé, **5 garde-fous non négociables**
- **Conséquences** : positives, négatives, **risques résiduels R1/R2/R3 avec mitigations**
- **Sources & traces** : références croisées PR #55, #56, claude-config #4

### `docs/adr/README.md` (+1 ligne)

ADR-005 ajouté à l'index.

## Posture partenaire

- Aucune modification de code, aucune dépendance, aucune migration. Pur cadrage doc.
- ADR-005 **immutable** une fois Accepted (conformément à la doctrine MADR documentée dans `docs/adr/README.md`). Toute évolution future = ADR-006+ qui supersedera celui-ci.
- 3 fichiers, 211 insertions / 22 deletions = bien sous la limite 600 lignes.

## Pourquoi sur la branche `feat/cc-design-handoff-v1` (et pas une branche docs séparée)

Cette branche est destinée à accueillir **toute la séquence PR-3a** (commits suivants après merge de cette PR). Le re-séquencement ROADMAP + ADR-005 sont les **prérequis documentaires** de PR-3a — il est cohérent qu'ils vivent sur la même branche, mergés ensemble ou en commits successifs au choix de @thierry.

Si tu préfères que ROADMAP+ADR soit sur une branche docs séparée et merge avant PR-3a code, dis-le et je split.

## Définition de DONE

- [x] Pre-commit hook lint:use-server clean
- [x] Prettier appliqué (3 fichiers .md)
- [x] Pas de modification code, pas de risque CI
- [ ] CI verte (à confirmer après push)
- [ ] Sourcery silencieux
- [ ] Review @thierry approuvée
- [ ] Merge → débloquera l'écriture de PR-3a sur cette même branche

## Étapes suivantes (selon plan @cowork)

Une fois cette PR mergée :

1. **ÉTAPE 3** : créer issue Linear parent "PR-3 Design System integration" + 3 sous-issues PR-3a/b/c
2. **ÉTAPE 4** : démarrer PR-3a sur cette même branche `feat/cc-design-handoff-v1` :
   - Extraction ZIP `Ankora Design System.zip` (Étapes 2-5 du prompt original)
   - Installation SKILL `ankora-design-system` dans `.claude/skills/`
   - Mapping tokens `colors_and_type.css` → `globals.css` (diff documenté)
   - Fonts `.ttf` dans `public/fonts/` + `@font-face`
   - Tests Vitest minimum sur tokens
   - Agents QA : security-auditor, gdpr-compliance-auditor, test-runner
   - Rapport dans `docs/prs/PR-3a-tokens-fonts-skill-report.md`

@thierry — review demandée.
@cowork — décisions trio matérialisées, prêt pour ÉTAPES 3+4 après merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Documenter le re-séquençage des pull requests techniques en scindant le PR-3 original en PR-3a/3b/3c et en faisant de PR-3a un prérequis architectural avant les travaux de traduction et de rapport de bugs.

Documentation :
- Mettre à jour le ROADMAP pour refléter le nouvel ordre d’exécution des PRs techniques, en positionnant PR-3a comme la prochaine étape de fondation du design system et en ajustant en conséquence les éléments qui en dépendent.
- Ajouter ADR-005 pour consigner formellement la décision de scinder et d’anticiper PR-3a comme socle du design system, y compris le contexte, les options, les moteurs de décision et les conséquences.
- Étendre l’index des ADR pour référencer ADR-005 et garder les décisions architecturales faciles à retrouver.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document the resequencing of technical pull requests by splitting the original PR-3 into PR-3a/3b/3c and making PR-3a an architectural prerequisite ahead of translations and bug-reporting work.

Documentation:
- Update ROADMAP to reflect the new execution order of technical PRs, positioning PR-3a as the next design-system foundation step and adjusting dependent items accordingly.
- Add ADR-005 to formally record the decision to split and anticipate PR-3a as the design system socle, including context, options, decision drivers, and consequences.
- Extend the ADR index to reference ADR-005 and keep architectural decisions discoverable.

</details>