### PR TITLE
fix(ci): sourcery-gate workflow — check thread isResolved via GraphQL

### DIFF
--- a/.github/workflows/sourcery-gate.yml
+++ b/.github/workflows/sourcery-gate.yml
@@ -11,24 +11,76 @@ jobs:
   check-sourcery-resolved:
     runs-on: ubuntu-latest
     steps:
-      - name: Check for active Sourcery comments on latest commit
+      - name: Check for unresolved Sourcery review threads
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          # Fetch Sourcery inline comments on the PR (with pagination to handle large PRs)
-          # Use escaped shell variable within jq filter to safely compare commit_id
-          filter='[.[] | select(.user.login == "sourcery-ai[bot]") | select(.commit_id == "'$HEAD_SHA'")] | length'
-          comments=$(gh api --paginate "repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments" --jq "$filter")
+          # Why GraphQL instead of REST /comments:
+          # GitHub auto-updates a review comment's `commit_id` to the current HEAD
+          # whenever the comment can be re-anchored to a still-existing line. As a
+          # result, filtering the REST `/pulls/{n}/comments` endpoint by
+          # `commit_id == HEAD_SHA` flags resolved threads as "active" — the REST
+          # payload has no `isResolved` flag.
+          #
+          # GraphQL `pullRequest.reviewThreads` exposes the canonical `isResolved`
+          # field that GitHub UI uses to enforce branch protection. We treat a
+          # thread as actionable iff:
+          #   - the original commenter is `sourcery-ai`
+          #   - `isResolved` is false
+          #
+          # See PR #62 incident report for the bug this replaces.
 
-          echo "Active Sourcery comments on HEAD (${HEAD_SHA}): $comments"
+          owner="${REPOSITORY%/*}"
+          name="${REPOSITORY#*/}"
 
-          if [ "$comments" -gt 0 ]; then
-            echo "::error::Sourcery has $comments active comments on the latest commit. Resolve them before merging."
-            detail_filter='[.[] | select(.user.login == "sourcery-ai[bot]") | select(.commit_id == "'$HEAD_SHA'") | {path, line, body}]'
-            gh api --paginate "repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments" --jq "$detail_filter"
+          query='
+            query($owner: String!, $name: String!, $number: Int!) {
+              repository(owner: $owner, name: $name) {
+                pullRequest(number: $number) {
+                  reviewThreads(first: 100) {
+                    nodes {
+                      isResolved
+                      comments(first: 1) {
+                        nodes {
+                          author { login }
+                          path
+                          body
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          '
+
+          response=$(gh api graphql \
+            -f query="$query" \
+            -F owner="$owner" \
+            -F name="$name" \
+            -F number="$PR_NUMBER")
+
+          unresolved_filter='
+            [.data.repository.pullRequest.reviewThreads.nodes[]
+              | select(.comments.nodes[0].author.login == "sourcery-ai")
+              | select(.isResolved == false)] | length
+          '
+          unresolved=$(echo "$response" | jq "$unresolved_filter")
+
+          echo "Unresolved Sourcery review threads on PR #${PR_NUMBER}: $unresolved"
+
+          if [ "$unresolved" -gt 0 ]; then
+            echo "::error::Sourcery has $unresolved unresolved review threads. Resolve them in the PR Files Changed view before merging."
+            detail_filter='
+              [.data.repository.pullRequest.reviewThreads.nodes[]
+                | select(.comments.nodes[0].author.login == "sourcery-ai")
+                | select(.isResolved == false)
+                | {path: .comments.nodes[0].path, body: .comments.nodes[0].body}]
+            '
+            echo "$response" | jq "$detail_filter"
             exit 1
           fi
 
-          echo "✅ No active Sourcery comments on HEAD."
+          echo "✅ No unresolved Sourcery review threads."


### PR DESCRIPTION
## TL;DR

Replace the `commit_id == HEAD_SHA` filter (REST) in `.github/workflows/sourcery-gate.yml` with a GraphQL query on `pullRequest.reviewThreads.nodes` filtered by `isResolved: false`. Fixes a false-positive class of failure where resolved Sourcery threads kept blocking merge.

**Unblocks** : [PR #62](https://github.com/thierryvm/ankora/pull/62) (cc-design Design System integration v1) which has all 4 Sourcery threads resolved côté GraphQL but is currently blocked by this workflow bug.

## Bug observed (PR #62)

Steps to reproduce:

1. Sourcery posts an inline comment on `globals.css` line 186 (admin flip incomplet)
2. Author commits a fix that re-orders nearby lines (admin flip extension)
3. Author resolves the thread via GraphQL `resolveReviewThread` mutation → `isResolved: true` confirmed
4. CI runs `check-sourcery-resolved` workflow → **FAIL** despite resolution

Cause: GitHub auto-updates the `commit_id` of an inline comment to point to the current HEAD whenever the comment can be re-anchored to a still-existing line position (even after resolution). The previous filter:

```bash
filter='[.[] | select(.user.login == "sourcery-ai[bot]") | select(.commit_id == "'$HEAD_SHA'")] | length'
```

…flagged these resolved-but-re-anchored comments as "active on HEAD". The REST `/comments` payload has no `isResolved` field, so the filter could never tell.

## Fix

GraphQL `pullRequest.reviewThreads` exposes `isResolved` directly. New filter:

```bash
unresolved_filter='
  [.data.repository.pullRequest.reviewThreads.nodes[]
    | select(.comments.nodes[0].author.login == "sourcery-ai")
    | select(.isResolved == false)] | length
'
```

Counts only threads where:
- the original commenter is `sourcery-ai`
- AND the thread is not resolved

This matches GitHub's own UI logic for branch protection ("All comments must be resolved").

## Mental test cases

| Case | Threads state | Expected | New behavior |
|---|---|---|---|
| 1 | No Sourcery threads at all | ✅ pass | `unresolved == 0` → pass |
| 2 | Sourcery threads, all resolved (human or bot) | ✅ pass | `unresolved == 0` → pass |
| 3 | Sourcery threads, some unresolved | ❌ fail (correct) | `unresolved > 0` → fail with details listed |

YAML workflow has no logic to unit-test, but the GraphQL query is canonical (used by GitHub UI itself for the same purpose).

## Permissions

`pull-requests: read` is sufficient for both the previous REST endpoint and the new GraphQL endpoint. **No permission changes needed.**

## Diff size

```
.github/workflows/sourcery-gate.yml | 76 +++++++++++++++++++--------------
1 file changed, 64 insertions(+), 12 deletions(-)
```

(The growth comes mostly from the explanatory comment block at the top of the script — same business logic as the previous version, just with the canonical signal.)

## Why not alternatives

- **Bypass branch protection** (Merge without waiting for requirements) — explicitly forbidden by `CLAUDE.md` DoD doctrine. Pas d'exception.
- **Empty commit hack on PR #62** — would only mask the bug for PR #62 and let it re-emerge on every future PR with Sourcery threads.
- **Disable the workflow** — would lose the protection entirely.

## Definition of DONE

- [x] Workflow YAML syntactically valid (no tabs, line count consistent)
- [x] Pre-commit hook passed (Prettier on YAML)
- [ ] CI verte sur cette PR (Lint + standard checks — workflow change shouldn't trigger our own gate failing on itself since this PR has no Sourcery threads yet)
- [ ] Sourcery silent on this PR
- [ ] Review @thierry approuvée
- [ ] Merge → unblock PR #62

## Tagging

@thierry — **revue prioritaire (~5-10 min) demandée** parce que cette PR débloque PR #62 qui a tout son code review fait, juste en attente du fix workflow. Une fois mergée, je relance la CI sur PR #62 et finalise le DoD.

## References

- PR #62 (PR-3a Design System socle) — actuellement bloquée par ce bug
- ADR-005 — re-séquencement architectural ayant amené PR-3a
- Memory entry `feedback_dod_sequence_canonical.md` — pattern DoD 5-step qui a exposé ce bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Résumé par Sourcery

Met à jour le workflow CI de la porte Sourcery pour qu’il s’appuie sur l’état de résolution des fils de revue GitHub GraphQL plutôt que sur les vérifications de commentaires basées sur les commits via l’API REST.

Corrections de bugs :
- Empêche les fils de revue Sourcery résolus de bloquer incorrectement les fusions en vérifiant le champ `isResolved` via GraphQL au lieu de filtrer les commentaires par SHA de commit.

Améliorations :
- Améliore la journalisation du workflow CI et la sortie des erreurs pour indiquer le nombre et les détails des fils de revue Sourcery non résolus.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the Sourcery gate CI workflow to rely on GitHub GraphQL review thread resolution status instead of REST commit-based comment checks.

Bug Fixes:
- Prevent resolved Sourcery review threads from incorrectly blocking merges by checking the `isResolved` flag via GraphQL rather than filtering comments by commit SHA.

Enhancements:
- Improve CI workflow logging and error output to report the count and details of unresolved Sourcery review threads.

</details>