### PR TITLE
feat(test): atomic UI kit Vitest tests + AnkoraLogo laiton accent (PR-3b)

### DIFF
--- a/docs/prs/PR-3a-tokens-fonts-skill-report.md
+++ b/docs/prs/PR-3a-tokens-fonts-skill-report.md
@@ -256,17 +256,19 @@ Aucun bug bloquant. 2 findings low (cf. section "Agents QA" → 2 findings low n
 
 ## Notes pour PR-3b (issue #60)
 
-Préparer pour PR-3b :
+> **Mise à jour 2026-04-26** — Audit pré-démarrage PR-3b a révélé que **toutes les 4 deps**, **`cn()` helper**, et **les 8 composants TSX** étaient **déjà présents sur main** (importés/copiés lors d'un setup antérieur, date inconnue, antérieur à la convention trio @cowork/@cc-ankora). Le scope « migration » initial de PR-3b était factuellement no-op.
+>
+> **Re-cadrage @cowork** : PR-3b se recentre sur le vrai gap = **tests Vitest co-located absents** pour les 8 composants atomiques + fix `AnkoraLogo` (`#F59E0B` → `#d4a017`).
+>
+> Référence ADR-006 §matrice tests : composants UI = unit tests obligatoires, et PR-3c (Landing fusion) consommera ces composants intensément — sans tests, toute régression silencieuse passe en prod.
 
-1. Ajouter dans `package.json` :
-   - `@radix-ui/react-slot`
-   - `@radix-ui/react-label`
-   - `@radix-ui/react-select`
-   - `class-variance-authority` (cva)
-2. Vérifier ou créer `src/lib/utils.ts` avec `cn()` helper (clsx + tailwind-merge)
-3. Updater `AnkoraLogo.tsx` lors de la migration : `#F59E0B` → `#d4a017` (laiton)
+Préparer pour PR-3b (scope re-cadré) :
+
+1. ~~Ajouter dans `package.json`~~ (déjà fait sur main : @radix-ui slot/label/select + cva)
+2. ~~Vérifier ou créer `src/lib/utils.ts` avec `cn()` helper~~ (déjà présent sur main)
+3. Updater `AnkoraLogo.tsx` : `#F59E0B` → `#d4a017` (laiton) — **scope verrouillé PR-3b**
 4. Adapter SKILL section 1 (paths `colors_and_type.css` → `src/app/globals.css` Ankora — Finding 1 sécurité)
-5. Migrer les 8 TSX du ZIP avec tests Vitest co-located
+5. ~~Migrer les 8 TSX du ZIP~~ → composants déjà sur main, à la place : **ajouter 8 fichiers `*.test.tsx` co-located** (Button variants, Card composition, Input controlled, Label asProp, Select Radix interaction, AnkoraLogo wordmark + laiton anti-régression, Header/Footer server async + getTranslations mock)
 6. Source : `F:\PROJECTS\Apps\ankora-mockups\design-exports\unpacked-v1\src\components\` (8 fichiers, 533 lignes total)
 
 ---

--- a/src/components/brand/AnkoraLogo.tsx
+++ b/src/components/brand/AnkoraLogo.tsx
@@ -9,7 +9,7 @@ interface AnkoraLogoProps extends React.SVGProps<SVGSVGElement> {
 }
 
 /**
- * Ankora brand mark. Teal background + amber eyelet + white anchor.
+ * Ankora brand mark. Teal background + laiton (brass) eyelet + white anchor.
  * Inline SVG so it inherits `currentColor` for focus styles and can be
  * sized with Tailwind height/width utilities.
  */
@@ -29,7 +29,7 @@ export function AnkoraLogo({
         {...props}
       >
         <rect width="64" height="64" rx="14" fill="#0F766E" />
-        <circle cx="32" cy="17" r="4.5" stroke="#F59E0B" strokeWidth="2.5" fill="none" />
+        <circle cx="32" cy="17" r="4.5" stroke="#d4a017" strokeWidth="2.5" fill="none" />
         <line
           x1="32"
           y1="22"
@@ -80,7 +80,7 @@ export function AnkoraLogo({
       {...props}
     >
       <rect width="64" height="64" rx="14" fill="#0F766E" />
-      <circle cx="32" cy="17" r="4.5" stroke="#F59E0B" strokeWidth="2.5" fill="none" />
+      <circle cx="32" cy="17" r="4.5" stroke="#d4a017" strokeWidth="2.5" fill="none" />
       <line
         x1="32"
         y1="22"

--- a/src/components/brand/__tests__/AnkoraLogo.test.tsx
+++ b/src/components/brand/__tests__/AnkoraLogo.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { AnkoraLogo } from '../AnkoraLogo';
+
+describe('<AnkoraLogo />', () => {
+  it('renders an SVG with role="img" and accessible aria-label', () => {
+    render(<AnkoraLogo />);
+    const svg = screen.getByRole('img', { name: 'Ankora' });
+    expect(svg.tagName).toBe('svg');
+  });
+
+  it('renders the wordmark variant by default (viewBox 280×64)', () => {
+    render(<AnkoraLogo />);
+    const svg = screen.getByRole('img', { name: 'Ankora' });
+    expect(svg.getAttribute('viewBox')).toBe('0 0 280 64');
+  });
+
+  it('renders the compact variant when wordmark={false} (viewBox 64×64)', () => {
+    render(<AnkoraLogo wordmark={false} />);
+    const svg = screen.getByRole('img', { name: 'Ankora' });
+    expect(svg.getAttribute('viewBox')).toBe('0 0 64 64');
+  });
+
+  it('forwards className while keeping the select-none default', () => {
+    render(<AnkoraLogo className="custom-test h-8 w-auto" />);
+    const svg = screen.getByRole('img', { name: 'Ankora' });
+    // SVG className is SVGAnimatedString; getAttribute is the cleanest cross-runtime accessor
+    const cls = svg.getAttribute('class') ?? '';
+    expect(cls).toContain('h-8');
+    expect(cls).toContain('select-none');
+  });
+
+  it('uses the locked Laiton accent (#d4a017) on the eyelet circle (regression guard)', () => {
+    // ADR-005 + design-principles-2026.md §6 lock the brand accent to
+    // Laiton nautique #d4a017. Any future palette refactor that drops
+    // this value back to amber #F59E0B (or any other) must be intentional
+    // and update this assertion.
+    const { container } = render(<AnkoraLogo />);
+    const circle = container.querySelector('circle[stroke="#d4a017"]');
+    expect(circle).not.toBeNull();
+    // Negative regression: the legacy amber must not reappear silently
+    const amberCircle = container.querySelector('circle[stroke="#F59E0B"]');
+    expect(amberCircle).toBeNull();
+  });
+});

--- a/src/components/layout/__tests__/Footer.test.tsx
+++ b/src/components/layout/__tests__/Footer.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import messages from '../../../../messages/fr-BE.json';
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: async (namespace: string) => {
+    const ns = (messages as Record<string, Record<string, unknown>>)[namespace] ?? {};
+    return (key: string, params?: Record<string, unknown>) => {
+      const parts = key.split('.');
+      let value: unknown = ns;
+      for (const part of parts) {
+        if (typeof value === 'object' && value !== null && part in value) {
+          value = (value as Record<string, unknown>)[part];
+        } else {
+          return key;
+        }
+      }
+      if (typeof value === 'string' && params) {
+        return Object.entries(params).reduce(
+          (acc, [k, v]) => acc.replace(`{${k}}`, String(v)),
+          value,
+        );
+      }
+      return typeof value === 'string' ? value : key;
+    };
+  },
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+import { Footer } from '../Footer';
+
+async function renderFooter() {
+  const ui = await Footer();
+  return render(ui);
+}
+
+describe('<Footer />', () => {
+  it('renders the four legal links (CGU, Privacy, Cookies, FAQ)', async () => {
+    await renderFooter();
+    // Footer-specific link labels come from the `footer` namespace
+    const cgu = screen.getByRole('link', { name: messages.footer.cgu });
+    const privacy = screen.getByRole('link', { name: messages.footer.privacy });
+    const cookies = screen.getByRole('link', { name: messages.footer.cookies });
+    const faq = screen.getByRole('link', { name: messages.footer.faq });
+
+    expect(cgu).toHaveAttribute('href', '/legal/cgu');
+    expect(privacy).toHaveAttribute('href', '/legal/privacy');
+    expect(cookies).toHaveAttribute('href', '/legal/cookies');
+    expect(faq).toHaveAttribute('href', '/faq');
+  });
+
+  it('renders the copyright with the current year interpolated', async () => {
+    await renderFooter();
+    const year = new Date().getFullYear();
+    // copyrightNotice template contains "{year}" — assert the resolved value appears
+    expect(screen.getByText((content) => content.includes(String(year)))).toBeInTheDocument();
+  });
+
+  it('exposes the AnkoraLogo for brand recognition', async () => {
+    await renderFooter();
+    expect(screen.getByRole('img', { name: 'Ankora' })).toBeInTheDocument();
+  });
+
+  it('uses an aria-labelled <nav> for the legal navigation', async () => {
+    await renderFooter();
+    const nav = screen.getByRole('navigation', { name: messages.common.nav.footerLabel });
+    expect(nav).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/__tests__/Header.test.tsx
+++ b/src/components/layout/__tests__/Header.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import messages from '../../../../messages/fr-BE.json';
+
+/**
+ * Header is an async Server Component using `next-intl/server` and the
+ * locale-aware Link from `@/i18n/navigation`. We mock both at module level
+ * so we can render the resolved JSX directly under jsdom.
+ */
+vi.mock('next-intl/server', () => ({
+  getTranslations: async (namespace: string) => {
+    const ns = (messages as Record<string, Record<string, unknown>>)[namespace] ?? {};
+    return (key: string) => {
+      // Walk dot-separated keys like "nav.features"
+      const parts = key.split('.');
+      let value: unknown = ns;
+      for (const part of parts) {
+        if (typeof value === 'object' && value !== null && part in value) {
+          value = (value as Record<string, unknown>)[part];
+        } else {
+          return key; // fallback to key for missing entries
+        }
+      }
+      return typeof value === 'string' ? value : key;
+    };
+  },
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('../HeaderNav', () => ({
+  HeaderNav: ({ variant }: { variant: string }) => (
+    <div data-testid="header-nav-mock" data-variant={variant} />
+  ),
+}));
+
+import { Header } from '../Header';
+
+async function renderHeader(props: Parameters<typeof Header>[0] = {}) {
+  const ui = await Header(props);
+  return render(ui);
+}
+
+describe('<Header />', () => {
+  it('renders the marketing variant by default with login + signup CTAs', async () => {
+    await renderHeader();
+    // Marketing nav links
+    expect(screen.getByRole('link', { name: 'Fonctionnalités' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'FAQ' })).toBeInTheDocument();
+    // Auth CTAs
+    expect(screen.getByRole('link', { name: 'Se connecter' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Créer un compte' })).toBeInTheDocument();
+  });
+
+  it('marketing variant + isAuthenticated shows the cockpit CTA instead of login/signup', async () => {
+    await renderHeader({ variant: 'marketing', isAuthenticated: true });
+    expect(screen.queryByRole('link', { name: 'Se connecter' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Créer un compte' })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Mon cockpit' })).toBeInTheDocument();
+  });
+
+  it('app variant shows the in-app navigation (dashboard, accounts, charges, settings)', async () => {
+    await renderHeader({ variant: 'app', isAuthenticated: true });
+    expect(screen.getByRole('link', { name: 'Tableau de bord' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Comptes' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Charges' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Paramètres' })).toBeInTheDocument();
+  });
+
+  it('home link points to / when unauthenticated, /app when authenticated', async () => {
+    const { unmount } = await renderHeader({ variant: 'marketing', isAuthenticated: false });
+    expect(screen.getByLabelText('Accueil Ankora')).toHaveAttribute('href', '/');
+    unmount();
+
+    await renderHeader({ variant: 'marketing', isAuthenticated: true });
+    expect(screen.getByLabelText('Accueil Ankora')).toHaveAttribute('href', '/app');
+  });
+});

--- a/src/components/ui/__tests__/button.test.tsx
+++ b/src/components/ui/__tests__/button.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { Button, buttonVariants } from '../button';
+
+describe('<Button />', () => {
+  it('renders a <button> by default', () => {
+    render(<Button>Click me</Button>);
+    const button = screen.getByRole('button', { name: 'Click me' });
+    expect(button.tagName).toBe('BUTTON');
+  });
+
+  it('applies the default variant + size classes', () => {
+    render(<Button>Default</Button>);
+    const button = screen.getByRole('button');
+    // default variant = brand-700 background; default size = h-10 px-4
+    expect(button.className).toContain('bg-brand-700');
+    expect(button.className).toContain('h-10');
+  });
+
+  it.each([
+    ['default', 'bg-brand-700'],
+    ['destructive', 'bg-danger'],
+    ['outline', 'border-border'],
+    ['secondary', 'bg-brand-100'],
+    ['ghost', 'text-foreground'],
+    ['link', 'underline-offset-4'],
+  ] as const)('applies the %s variant', (variant, expectedClass) => {
+    render(<Button variant={variant}>Test</Button>);
+    expect(screen.getByRole('button').className).toContain(expectedClass);
+  });
+
+  it.each([
+    ['sm', 'h-9'],
+    ['lg', 'h-12'],
+    ['icon', 'w-10'],
+  ] as const)('applies the %s size', (size, expectedClass) => {
+    render(<Button size={size}>Test</Button>);
+    expect(screen.getByRole('button').className).toContain(expectedClass);
+  });
+
+  it('respects disabled and prevents click handlers', () => {
+    const handleClick = vi.fn();
+    render(
+      <Button disabled onClick={handleClick}>
+        Disabled
+      </Button>,
+    );
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it('renders as a slotted child when asChild is true', () => {
+    render(
+      <Button asChild>
+        {/* External href so @next/next/no-html-link-for-pages doesn't flag this test */}
+        <a href="https://example.com/external">Open cockpit</a>
+      </Button>,
+    );
+    const link = screen.getByRole('link', { name: 'Open cockpit' });
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('href', 'https://example.com/external');
+    // cva variant classes still applied to the slotted element
+    expect(link.className).toContain('bg-brand-700');
+  });
+
+  it('exposes buttonVariants as a class generator', () => {
+    expect(typeof buttonVariants).toBe('function');
+    expect(buttonVariants({ variant: 'destructive', size: 'sm' })).toContain('bg-danger');
+  });
+});

--- a/src/components/ui/__tests__/card.test.tsx
+++ b/src/components/ui/__tests__/card.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '../card';
+
+describe('<Card /> composition', () => {
+  it('renders a complete card with header, title, description, content, and footer', () => {
+    render(
+      <Card data-testid="card">
+        <CardHeader>
+          <CardTitle>Provision santé</CardTitle>
+          <CardDescription>Lissée sur 12 mois</CardDescription>
+        </CardHeader>
+        <CardContent>250 € / mois</CardContent>
+        <CardFooter>Prochaine échéance : avril</CardFooter>
+      </Card>,
+    );
+
+    expect(screen.getByTestId('card')).toBeInTheDocument();
+    expect(screen.getByText('Provision santé')).toBeInTheDocument();
+    expect(screen.getByText('Lissée sur 12 mois')).toBeInTheDocument();
+    expect(screen.getByText('250 € / mois')).toBeInTheDocument();
+    expect(screen.getByText('Prochaine échéance : avril')).toBeInTheDocument();
+  });
+
+  it('Card forwards className while keeping default tokens', () => {
+    render(
+      <Card className="custom-card-class" data-testid="card">
+        content
+      </Card>,
+    );
+    const card = screen.getByTestId('card');
+    expect(card.className).toContain('custom-card-class');
+    expect(card.className).toContain('rounded-xl');
+  });
+
+  it('CardDescription renders as a <p> for semantic clarity', () => {
+    render(<CardDescription>Description text</CardDescription>);
+    expect(screen.getByText('Description text').tagName).toBe('P');
+  });
+});

--- a/src/components/ui/__tests__/input.test.tsx
+++ b/src/components/ui/__tests__/input.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useState } from 'react';
+
+import { Input } from '../input';
+
+describe('<Input />', () => {
+  it('renders an input element with the given type', () => {
+    render(<Input type="email" placeholder="Email" />);
+    const input = screen.getByPlaceholderText('Email');
+    expect(input).toBeInTheDocument();
+    expect(input.tagName).toBe('INPUT');
+    expect(input).toHaveAttribute('type', 'email');
+  });
+
+  it('respects the disabled prop', () => {
+    render(<Input disabled placeholder="Disabled" />);
+    const input = screen.getByPlaceholderText('Disabled');
+    expect(input).toBeDisabled();
+  });
+
+  it('flags invalid state via aria-invalid', () => {
+    render(<Input aria-invalid placeholder="Invalid" />);
+    const input = screen.getByPlaceholderText('Invalid');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('updates as a controlled component', () => {
+    function Controlled() {
+      const [value, setValue] = useState('');
+      return (
+        <Input
+          aria-label="controlled"
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+        />
+      );
+    }
+    render(<Controlled />);
+    const input = screen.getByLabelText('controlled') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'hello' } });
+    expect(input.value).toBe('hello');
+  });
+});

--- a/src/components/ui/__tests__/label.test.tsx
+++ b/src/components/ui/__tests__/label.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { Label } from '../label';
+
+describe('<Label />', () => {
+  it('renders the label text', () => {
+    render(<Label>Email address</Label>);
+    expect(screen.getByText('Email address')).toBeInTheDocument();
+  });
+
+  it('forwards htmlFor to associate with an input', () => {
+    render(
+      <>
+        <Label htmlFor="email">Email</Label>
+        <input id="email" type="email" />
+      </>,
+    );
+    const label = screen.getByText('Email');
+    expect(label).toHaveAttribute('for', 'email');
+  });
+
+  it('merges custom className with default classes', () => {
+    render(<Label className="custom-test-class">Test</Label>);
+    const label = screen.getByText('Test');
+    expect(label.className).toContain('custom-test-class');
+    expect(label.className).toContain('text-sm');
+  });
+});

--- a/src/components/ui/__tests__/select.test.tsx
+++ b/src/components/ui/__tests__/select.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../select';
+
+/**
+ * Radix Select uses a portal + pointer events that don't fully work under
+ * jsdom. We test the trigger surface (always rendered) and assert the
+ * composition is wired correctly. Open/close behavior is covered by
+ * Playwright E2E (not Vitest).
+ */
+describe('<Select /> composition', () => {
+  it('renders the trigger with the placeholder when no value is selected', () => {
+    render(
+      <Select>
+        <SelectTrigger aria-label="Compte">
+          <SelectValue placeholder="Choisir un compte" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="courant">Compte courant</SelectItem>
+          <SelectItem value="epargne">Compte épargne</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+    const trigger = screen.getByLabelText('Compte');
+    expect(trigger).toBeInTheDocument();
+    expect(trigger.textContent).toContain('Choisir un compte');
+  });
+
+  it('renders the selected value when defaultValue is set', () => {
+    render(
+      <Select defaultValue="epargne">
+        <SelectTrigger aria-label="Compte">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="courant">Compte courant</SelectItem>
+          <SelectItem value="epargne">Compte épargne</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+    const trigger = screen.getByLabelText('Compte');
+    expect(trigger.textContent).toContain('Compte épargne');
+  });
+
+  it('respects the disabled prop on the trigger', () => {
+    render(
+      <Select disabled>
+        <SelectTrigger aria-label="Disabled select">
+          <SelectValue placeholder="Indisponible" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="x">x</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+    const trigger = screen.getByLabelText('Disabled select');
+    expect(trigger).toBeDisabled();
+  });
+});


### PR DESCRIPTION
Closes #60
Part of #58

## TL;DR — REBRAND post-audit

Le scope original PR-3b (« migration 8 atomic components from cc-design ZIP ») s'est révélé **factuellement no-op au démarrage** : les 4 deps, le helper `cn()`, et les 8 composants TSX étaient **déjà sur main** (importés/copiés lors d'un setup antérieur, antérieur à la convention trio).

**Re-cadrage @cowork** : PR-3b se recentre sur le **vrai gap identifié à l'audit** = absence totale de tests Vitest co-located pour les 8 composants UI atomiques. Référence ADR-006 §matrice tests : composants UI = unit tests obligatoires, et PR-3c (Landing fusion) va les consommer intensément.

## Scope final

| Type | Fichier | Détails |
|---|---|---|
| **Fix** | `src/components/brand/AnkoraLogo.tsx` | `#F59E0B` (legacy amber) → `#d4a017` (Laiton verrouillé ADR-005). 2 occurrences (wordmark + compact) + JSDoc mise à jour `amber eyelet` → `laiton (brass) eyelet` |
| **Test** | `src/components/ui/__tests__/label.test.tsx` | 3 tests (render, htmlFor, className merge) |
| **Test** | `src/components/ui/__tests__/input.test.tsx` | 4 tests (type, disabled, aria-invalid, controlled) |
| **Test** | `src/components/ui/__tests__/card.test.tsx` | 3 tests (full composition, className merge, Description as `<p>`) |
| **Test** | `src/components/ui/__tests__/button.test.tsx` | 10 tests (default render, 6 variants, 4 sizes, disabled no-click, asChild Slot, buttonVariants helper) |
| **Test** | `src/components/ui/__tests__/select.test.tsx` | 3 tests (trigger placeholder, defaultValue, disabled). Open/close = E2E (jsdom + Radix portal limit) |
| **Test** | `src/components/brand/__tests__/AnkoraLogo.test.tsx` | 5 tests (role+aria-label, wordmark variant, compact variant, className forwarding, **regression guard laiton anti-amber**) |
| **Test** | `src/components/layout/__tests__/Header.test.tsx` | 4 tests (marketing CTAs, isAuthenticated, app variant nav, home href routing). Mock `next-intl/server` + `@/i18n/navigation` |
| **Test** | `src/components/layout/__tests__/Footer.test.tsx` | 4 tests (4 legal links, copyright year interpolation, AnkoraLogo, aria-labelled nav) |
| **Doc** | `docs/prs/PR-3a-tokens-fonts-skill-report.md` | Section "Notes pour PR-3b" mise à jour avec rebrand explication + strikethrough sur items déjà faits |

**Total** : 1 fix + 8 fichiers test (40 tests) + 1 update doc = ~10 fichiers, **+~600 lignes**, dans le budget cible.

## Validation

| Vérification | Résultat |
|---|---|
| `npm run test` | ✅ **282/282 pass** (40 nouveaux + 242 existants, 0 régression) |
| Tests nouveaux ciblés (`src/components/`) | ✅ **40/40 pass** (8 fichiers) |
| `npm run typecheck` | ✅ Clean (après fix `svg.className.baseVal` → `getAttribute('class')`) |
| `npm run lint` | ✅ 0 erreur (1 warning préexistant `glossaire/page.tsx`, hors scope) |
| `npm run lint:use-server` | ✅ Clean |
| Pre-commit hook (Prettier + ESLint --fix) | ✅ Appliqué |
| Agent `ui-auditor` | ✅ **PASS_WITH_NOTES** (cf. backlog ci-dessous) |
| Agent `gdpr-compliance-auditor` | ✅ **GO - COMPLIANT** (0 finding) |

## Findings ui-auditor — détail + actions backlog

### Pré-existants HORS diff PR-3b (à tracker en backlog UI dédié)

| Ref | Fichier | Sévérité | Description |
|---|---|---|---|
| F1 | `ui/button.tsx:22` | **a11y-high** | `h-10` = 40px touch target, sous le seuil WCAG 2.5.8 (44px sur mobile). Variante `lg` = 48px conforme ✅ |
| F2 | `ui/input.tsx:11` | **a11y-high** | Même observation `h-10`. Pré-existant |
| F3 | `ui/select.tsx:20` | **a11y-high** | `SelectTrigger h-10`. Pré-existant |

**Recommandation** : créer issue backlog `chore(ui): bump default size of Button/Input/SelectTrigger to h-11 (44px) for WCAG 2.5.8 mobile touch target compliance`. Variante `lg` reste à `h-12`. Out of scope PR-3b (changement comportement runtime visuel — décision @cowork).

### Documentaire

| Ref | Fichier | Sévérité | Description |
|---|---|---|---|
| F4 | `brand/AnkoraLogo.tsx:31,82` | **low** | Hex SVG inline `fill="#0F766E"` (teal brand) + `stroke="#F8FAFC"` (white). Dérogation consciente justifiable pour un logo (marque immutable, ne participe pas au flip admin), mais pas documentée dans le code. Pourrait être amélioré par un commentaire explicatif. **Pas bloquant** |

### Test quality (information)

| Ref | Fichier | Sévérité | Description |
|---|---|---|---|
| F5 | `button.test.tsx` (it.each) | **medium / test-quality** | Assertions sur noms de classes CVA (`bg-brand-700`, `h-10`, etc.). Pattern acceptable et courant pour un kit de tokens, mais légèrement couplé à l'implémentation. Tradeoff conscient : ces classes sont le **contrat token** du composant, pas du style arbitraire. **Pas bloquant** |

## Décisions @cowork explicites appliquées

1. ✅ Option (c) re-cadrage tests + AnkoraLogo (vs migration no-op)
2. ✅ Tests focus sur invariants, pas snapshot HTML
3. ✅ Co-located dans `__tests__/` (convention `src/lib/domain/__tests__/`)
4. ✅ Mock `next-intl/server` + `@/i18n/navigation` pour Header/Footer server async
5. ✅ Regression guard explicite sur laiton AnkoraLogo (assert présent + assert ancien amber absent)
6. ✅ Deps installées en `dependencies` (convention shadcn) — observation seulement, no-op (déjà sur main)

## Notes pour PR-3c

PR-3c (Landing fusion intelligente — issue #61) consommera ces 8 composants intensément :
- `Button` : tous variants (primary CTAs, secondary subscribers, ghost nav)
- `Card` : pricing, features, FAQ items
- `AnkoraLogo` : Header + Footer (déjà câblés)
- `Input` + `Label` : signup form, contact
- `Header` + `Footer` : layout principal

**Garantie de non-régression apportée par cette PR** : toute future modification de ces composants déclenchera les 40 tests Vitest avant merge — couvre les invariants principaux (variants visuels, accessibility roles, copy interpolation, accent laiton, etc.).

## Definition of DONE

- [x] Tests Vitest 100 % pass (40 nouveaux + 242 existants)
- [x] Lint + typecheck + lint:use-server clean
- [x] Pre-commit hook Husky appliqué
- [x] Agents QA : ui-auditor PASS_WITH_NOTES + gdpr COMPLIANT
- [x] Doc rapport PR-3a mise à jour avec rebrand explanation
- [ ] CI verte (à confirmer après push)
- [ ] Sourcery silencieux
- [ ] Review @thierry approuvée

## References

- ADR-005 (PR-3a anticipée + Laiton verrouillé)
- ADR-006 (testing strategy v1.0 — composants UI = unit tests obligatoires)
- PR #62 (PR-3a Design System socle, mergée `8b98188`) — fournit tokens consommés par les 8 composants
- PR #65 (docs design + testing strategy) — base théorique de cette PR
- Memory `feedback_dod_sequence_canonical.md` — pattern DoD 5-step

@thierry — review demandée.
@cowork — escalades : aucune. Tous les findings sont soit pré-existants (F1-F3 backlog), soit documentaires (F4-F5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ajouter une couverture de tests unitaires pour les composants d’interface utilisateur atomiques et de mise en page, et aligner le logo Ankora sur le jeton de couleur de marque brass.

Corrections de bugs :
- Mettre à jour le symbole de marque AnkoraLogo pour qu’il utilise la couleur d’accent brass verrouillée (#d4a017) au lieu de l’ancienne valeur amber, et ajuster sa documentation en conséquence.

Documentation :
- Réviser le rapport de compétences PR-3a pour documenter le périmètre mis à jour de PR-3b, en notant la migration précédente sans effet (no-op) et le nouveau focus sur les tests ainsi que la correction de couleur d’AnkoraLogo.

Tests :
- Ajouter des tests Vitest co-localisés pour les composants d’interface utilisateur atomiques (Button, Card, Input, Label, Select) couvrant le rendu, les variantes, le comportement contrôlé et les attentes en matière d’accessibilité.
- Ajouter des tests Vitest pour les composants de mise en page Header et Footer, incluant la navigation authentifiée/non authentifiée, les liens légaux, le routage et l’interpolation des textes internationalisés.
- Ajouter des tests de régression pour les variantes d’AnkoraLogo afin de vérifier les rôles d’accessibilité et de protéger la couleur d’accent brass contre les régressions.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add unit test coverage for atomic UI and layout components and align the Ankora logo with the brass brand color token.

Bug Fixes:
- Update AnkoraLogo brand mark to use the locked brass (#d4a017) accent color instead of the legacy amber value and adjust its documentation accordingly.

Documentation:
- Revise the PR-3a skill report to document the updated PR-3b scope, noting the prior no-op migration and the new focus on tests plus the AnkoraLogo color correction.

Tests:
- Add co-located Vitest tests for atomic UI components (Button, Card, Input, Label, Select) covering rendering, variants, controlled behavior, and accessibility expectations.
- Add Vitest tests for layout components Header and Footer, including authenticated/unauthenticated navigation, legal links, routing, and internationalized copy interpolation.
- Add regression tests for AnkoraLogo variants to assert accessibility roles and guard the brass accent color against regressions.

</details>