### PR TITLE
docs(claude-md): squash-merge branch cleanup doctrine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,29 @@ Si output non vide → corriger avant de déclarer DONE.
 explicitement vérifié les 5 critères ci-dessus. Un push sans vérif Sourcery
 = tâche incomplète, point.
 
+## Cleanup branches locales
+
+Ankora utilise **squash merge** comme stratégie GitHub. Conséquence :
+`git branch -d` (lowercase) refuse les branches mergées via squash car les
+commits originaux ne sont pas dans l'historique linéaire de main (aplatis
+en un seul squash commit).
+
+Procédure cleanup canonique :
+
+1. `git fetch --prune origin` — synchronise les statuts `[gone]`
+2. `git branch -d <branche>` — tente d'abord la version safe (catch les
+   vrais merges sans squash, et les branches déjà rebased/fast-forwardées)
+3. Si refus → cross-check via :
+   ```bash
+   gh pr list --state merged --limit 100 --json headRefName \
+     --jq '.[] | .headRefName' | grep <branche>
+   ```
+4. Si une PR mergée correspond exactement → `git branch -D <branche>` safe
+5. Si aucune PR mergée trouvée → STOP, investiguer avec @cowork
+
+Branches marquées `[gone]` après prune sont 100% safe à supprimer avec `-D`
+(remote déjà supprimée par GitHub après merge ou close).
+
 ## Posture : ingénieur partenaire d'abord, exécutant ensuite
 
 Avant d'exécuter un prompt (PR planifiée OU hotfix urgent), relis-le avec un œil critique. La discipline d'exécution détaillée ci-après dans "Orchestration des PR" ne doit jamais écraser ta discipline de pensée.


### PR DESCRIPTION
## Summary

Documents in `CLAUDE.md` why `git branch -d` (lowercase) refuses branches that have been merged via squash-merge, and provides a canonical 5-step cleanup procedure (with `gh pr list` cross-check before resorting to `-D`).

Doctrine extraite de la session cleanup 2026-04-27 où 14 branches locales obsolètes ont été identifiées post-merge PR #69 + PR #72. Future agents (et humains) éviteront de perdre des cycles à se demander pourquoi `-d` refuse des branches manifestement mergées.

## Why now

Pendant la cleanup pré-PR-3c, j'ai dû escalader à @cowork à la Phase 2 du brief parce que `git branch -d` refusait toutes les 4 cibles initiales (squash merge → commits aplatis hors historique linéaire de main). @cowork a validé la procédure adaptée (`-D` après cross-check `gh pr list`), méritant d'être gravée pour ne plus avoir à refaire l'aller-retour.

## Test plan

- [x] Lecture de la nouvelle section dans CLAUDE.md
- [x] Vérification du positionnement (juste après "Définition de DONE", avant "Posture")
- [x] Procédure validée empiriquement sur 14 branches supprimées en session
- [ ] Sourcery review (CI)
- [ ] Lint markdown (CI)

## Refs

- Brief @cowork 2026-04-27 — Cleanup branches obsolètes (Phase pré-PR-3c)
- Session cleanup : 14 branches supprimées (vague 1 + vague 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)