### PR TITLE
feat(landing): public simulator section with 12-month projection chart

### DIFF
--- a/e2e/landing-simulator.spec.ts
+++ b/e2e/landing-simulator.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Smoke test for the public landing simulator (PR-3c).
+ *
+ * Scope:
+ * - Section is reachable from the marketing landing.
+ * - The radiogroup pattern works (selecting "Ambitieux" updates aria-checked).
+ * - Moving the slider re-renders the projection numerically (no assertion on
+ *   the chart SVG itself — recharts geometry is brittle and not the contract
+ *   we ship).
+ *
+ * a11y baseline (axe-core) is already covered by `e2e/a11y/baseline.spec.ts`
+ * which scans `/` — no need to duplicate here.
+ */
+
+test.describe('Landing — public simulator', () => {
+  test('section renders with all four sub-components', async ({ page }) => {
+    await page.goto('/');
+
+    const section = page.locator('#simulator');
+    await section.scrollIntoViewIfNeeded();
+    await expect(section).toBeVisible();
+
+    await expect(section.getByRole('heading', { level: 2 })).toBeVisible();
+    await expect(section.getByRole('radiogroup')).toBeVisible();
+    await expect(section.getByRole('slider')).toBeVisible();
+    await expect(section.getByRole('link', { name: /créer mon plan/i })).toBeVisible();
+  });
+
+  test('selecting a different scenario updates the slider value', async ({ page }) => {
+    await page.goto('/');
+    const section = page.locator('#simulator');
+    await section.scrollIntoViewIfNeeded();
+
+    const ambitious = section.getByRole('radio', { name: /ambitieux/i });
+    await ambitious.click();
+    await expect(ambitious).toHaveAttribute('aria-checked', 'true');
+
+    const slider = section.getByRole('slider');
+    await expect(slider).toHaveValue('200');
+  });
+
+  test('the FSMA caveat is present on the result panel', async ({ page }) => {
+    await page.goto('/');
+    const section = page.locator('#simulator');
+    await section.scrollIntoViewIfNeeded();
+
+    await expect(section.getByText(/ne fournit pas de conseil en placement/i)).toBeVisible();
+  });
+});

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -141,6 +141,49 @@
         "body": "Das Cockpit sagt dir, wie viel du überweisen, wie viel du behalten sollst, und ob du deinen Rücklagen voraus oder hinterher bist."
       }
     },
+    "simulator": {
+      "section_title": "Projetez votre épargne sur 12 mois",
+      "section_subtitle": "Voyez comment de petites mises de côté régulières construisent votre coussin financier. Aucune connexion requise.",
+      "scenarios": {
+        "label": "Choisissez un scénario de départ",
+        "steady": {
+          "name": "Économe",
+          "tagline": "Petit pas régulier",
+          "description": "Mettez de côté 50 € par mois sans y penser."
+        },
+        "balanced": {
+          "name": "Standard",
+          "tagline": "Rythme confortable",
+          "description": "Construisez votre épargne avec 100 € par mois."
+        },
+        "ambitious": {
+          "name": "Ambitieux",
+          "tagline": "Coussin solide",
+          "description": "Visez un coussin confortable avec 200 € par mois."
+        }
+      },
+      "slider": {
+        "label": "Montant mensuel mis de côté",
+        "value_text": "{amount} euros par mois",
+        "unit": "€/mois"
+      },
+      "chart": {
+        "aria_label": "Projection cumulative de votre épargne sur 12 mois",
+        "x_axis": "Mois",
+        "y_axis": "Cumul (€)",
+        "tooltip": "Mois {month} : {amount}",
+        "fallback_table_caption": "Données mensuelles de la projection"
+      },
+      "result": {
+        "title": "En 12 mois, vous auriez :",
+        "amount_aria": "Montant projeté à 12 mois : {amount}",
+        "caveat": "Projection à titre informatif, hors intérêts et imprévus. Ankora ne fournit pas de conseil en placement."
+      },
+      "cta": {
+        "label": "Créer mon plan d'épargne",
+        "href": "/signup"
+      }
+    },
     "faqHeading": "Häufige Fragen",
     "faq": {
       "advice": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -141,6 +141,49 @@
         "body": "The cockpit tells you how much to transfer, how much to keep, and whether you're ahead or behind on your reserves."
       }
     },
+    "simulator": {
+      "section_title": "Project your savings over 12 months",
+      "section_subtitle": "See how small regular set-asides build your financial cushion. No login required.",
+      "scenarios": {
+        "label": "Pick a starting scenario",
+        "steady": {
+          "name": "Steady",
+          "tagline": "Small regular step",
+          "description": "Set aside €50 per month without thinking about it."
+        },
+        "balanced": {
+          "name": "Balanced",
+          "tagline": "Comfortable pace",
+          "description": "Build your savings with €100 per month."
+        },
+        "ambitious": {
+          "name": "Ambitious",
+          "tagline": "Solid cushion",
+          "description": "Aim for a comfortable cushion with €200 per month."
+        }
+      },
+      "slider": {
+        "label": "Monthly amount set aside",
+        "value_text": "{amount} euros per month",
+        "unit": "€/month"
+      },
+      "chart": {
+        "aria_label": "Cumulative savings projection over 12 months",
+        "x_axis": "Month",
+        "y_axis": "Cumulative (€)",
+        "tooltip": "Month {month}: {amount}",
+        "fallback_table_caption": "Monthly projection data"
+      },
+      "result": {
+        "title": "After 12 months, you would have:",
+        "amount_aria": "Projected amount at 12 months: {amount}",
+        "caveat": "Informational projection only, excluding interest and unexpected events. Ankora does not provide investment advice."
+      },
+      "cta": {
+        "label": "Create my savings plan",
+        "href": "/signup"
+      }
+    },
     "faqHeading": "Frequently asked questions",
     "faq": {
       "advice": {

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -141,6 +141,49 @@
         "body": "El cockpit te dice cuánto transferir, cuánto dejar y si vas por delante o por detrás de tus reservas."
       }
     },
+    "simulator": {
+      "section_title": "Projetez votre épargne sur 12 mois",
+      "section_subtitle": "Voyez comment de petites mises de côté régulières construisent votre coussin financier. Aucune connexion requise.",
+      "scenarios": {
+        "label": "Choisissez un scénario de départ",
+        "steady": {
+          "name": "Économe",
+          "tagline": "Petit pas régulier",
+          "description": "Mettez de côté 50 € par mois sans y penser."
+        },
+        "balanced": {
+          "name": "Standard",
+          "tagline": "Rythme confortable",
+          "description": "Construisez votre épargne avec 100 € par mois."
+        },
+        "ambitious": {
+          "name": "Ambitieux",
+          "tagline": "Coussin solide",
+          "description": "Visez un coussin confortable avec 200 € par mois."
+        }
+      },
+      "slider": {
+        "label": "Montant mensuel mis de côté",
+        "value_text": "{amount} euros par mois",
+        "unit": "€/mois"
+      },
+      "chart": {
+        "aria_label": "Projection cumulative de votre épargne sur 12 mois",
+        "x_axis": "Mois",
+        "y_axis": "Cumul (€)",
+        "tooltip": "Mois {month} : {amount}",
+        "fallback_table_caption": "Données mensuelles de la projection"
+      },
+      "result": {
+        "title": "En 12 mois, vous auriez :",
+        "amount_aria": "Montant projeté à 12 mois : {amount}",
+        "caveat": "Projection à titre informatif, hors intérêts et imprévus. Ankora ne fournit pas de conseil en placement."
+      },
+      "cta": {
+        "label": "Créer mon plan d'épargne",
+        "href": "/signup"
+      }
+    },
     "faqHeading": "Preguntas frecuentes",
     "faq": {
       "advice": {

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -141,6 +141,49 @@
         "body": "Le cockpit te dit combien virer, combien garder, et si tu es en avance ou en retard sur tes provisions."
       }
     },
+    "simulator": {
+      "section_title": "Projetez votre épargne sur 12 mois",
+      "section_subtitle": "Voyez comment de petites mises de côté régulières construisent votre coussin financier. Aucune connexion requise.",
+      "scenarios": {
+        "label": "Choisissez un scénario de départ",
+        "steady": {
+          "name": "Économe",
+          "tagline": "Petit pas régulier",
+          "description": "Mettez de côté 50 € par mois sans y penser."
+        },
+        "balanced": {
+          "name": "Standard",
+          "tagline": "Rythme confortable",
+          "description": "Construisez votre épargne avec 100 € par mois."
+        },
+        "ambitious": {
+          "name": "Ambitieux",
+          "tagline": "Coussin solide",
+          "description": "Visez un coussin confortable avec 200 € par mois."
+        }
+      },
+      "slider": {
+        "label": "Montant mensuel mis de côté",
+        "value_text": "{amount} euros par mois",
+        "unit": "€/mois"
+      },
+      "chart": {
+        "aria_label": "Projection cumulative de votre épargne sur 12 mois",
+        "x_axis": "Mois",
+        "y_axis": "Cumul (€)",
+        "tooltip": "Mois {month} : {amount}",
+        "fallback_table_caption": "Données mensuelles de la projection"
+      },
+      "result": {
+        "title": "En 12 mois, vous auriez :",
+        "amount_aria": "Montant projeté à 12 mois : {amount}",
+        "caveat": "Projection à titre informatif, hors intérêts et imprévus. Ankora ne fournit pas de conseil en placement."
+      },
+      "cta": {
+        "label": "Créer mon plan d'épargne",
+        "href": "/signup"
+      }
+    },
     "faqHeading": "Questions fréquentes",
     "faq": {
       "advice": {

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -141,6 +141,49 @@
         "body": "De cockpit zegt je hoeveel je moet overschrijven, hoeveel je moet houden, en of je voor of achter staat op je voorzieningen."
       }
     },
+    "simulator": {
+      "section_title": "Projetez votre épargne sur 12 mois",
+      "section_subtitle": "Voyez comment de petites mises de côté régulières construisent votre coussin financier. Aucune connexion requise.",
+      "scenarios": {
+        "label": "Choisissez un scénario de départ",
+        "steady": {
+          "name": "Économe",
+          "tagline": "Petit pas régulier",
+          "description": "Mettez de côté 50 € par mois sans y penser."
+        },
+        "balanced": {
+          "name": "Standard",
+          "tagline": "Rythme confortable",
+          "description": "Construisez votre épargne avec 100 € par mois."
+        },
+        "ambitious": {
+          "name": "Ambitieux",
+          "tagline": "Coussin solide",
+          "description": "Visez un coussin confortable avec 200 € par mois."
+        }
+      },
+      "slider": {
+        "label": "Montant mensuel mis de côté",
+        "value_text": "{amount} euros par mois",
+        "unit": "€/mois"
+      },
+      "chart": {
+        "aria_label": "Projection cumulative de votre épargne sur 12 mois",
+        "x_axis": "Mois",
+        "y_axis": "Cumul (€)",
+        "tooltip": "Mois {month} : {amount}",
+        "fallback_table_caption": "Données mensuelles de la projection"
+      },
+      "result": {
+        "title": "En 12 mois, vous auriez :",
+        "amount_aria": "Montant projeté à 12 mois : {amount}",
+        "caveat": "Projection à titre informatif, hors intérêts et imprévus. Ankora ne fournit pas de conseil en placement."
+      },
+      "cta": {
+        "label": "Créer mon plan d'épargne",
+        "href": "/signup"
+      }
+    },
     "faqHeading": "Veelgestelde vragen",
     "faq": {
       "advice": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-hook-form": "^7.72.1",
+        "recharts": "^3.8.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "zod": "^4.3.6"
@@ -3376,6 +3377,42 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
@@ -3784,7 +3821,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
@@ -4516,6 +4552,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -4572,6 +4671,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -6697,6 +6802,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -6834,6 +7060,12 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-is": {
@@ -7298,6 +7530,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.0.tgz",
+      "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -7837,7 +8079,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/events-universal": {
@@ -8834,6 +9075,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -9006,6 +9257,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/intl-messageformat": {
@@ -12320,8 +12580,30 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
@@ -12401,6 +12683,36 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -12413,6 +12725,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -12485,6 +12812,12 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -13695,6 +14028,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -14351,6 +14690,15 @@
         }
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -14379,6 +14727,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-hook-form": "^7.72.1",
+    "recharts": "^3.8.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"

--- a/src/app/[locale]/(public)/page.tsx
+++ b/src/app/[locale]/(public)/page.tsx
@@ -9,6 +9,7 @@ import type { Locale } from '@/i18n/routing';
 import { SITE } from '@/lib/site';
 import { Header } from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer';
+import { Simulator } from '@/components/marketing/landing/simulator';
 import { Button } from '@/components/ui/button';
 
 type LocaleParams = { params: Promise<{ locale: string }> };
@@ -130,6 +131,8 @@ export default async function HomePage({ params }: LocaleParams) {
             ))}
           </ol>
         </section>
+
+        <Simulator locale={locale as Locale} />
 
         <section
           id="faq"

--- a/src/components/marketing/landing/simulator/ProjectionChart.tsx
+++ b/src/components/marketing/landing/simulator/ProjectionChart.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import * as React from 'react';
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import { money } from '@/lib/domain/types';
+import { projectCumulative } from '@/lib/domain/simulation';
+
+import { PROJECTION_MONTHS } from './constants';
+
+export type ProjectionChartProps = {
+  /** Monthly amount set aside, in EUR. */
+  monthlyAmount: number;
+  locale: string;
+  copy: {
+    ariaLabel: string;
+    xAxis: string;
+    yAxis: string;
+    /** ICU template "Mois {month} : {amount}". */
+    tooltip: string;
+    /** Fallback table caption for screen readers. */
+    fallbackTableCaption: string;
+  };
+};
+
+type ChartDatum = {
+  month: number;
+  cumulative: number;
+};
+
+function buildSeries(monthlyAmount: number): ChartDatum[] {
+  const monthly = money(monthlyAmount);
+  return Array.from({ length: PROJECTION_MONTHS }, (_, i) => {
+    const month = i + 1;
+    return {
+      month,
+      cumulative: projectCumulative(monthly, month).toNumber(),
+    };
+  });
+}
+
+/**
+ * 12-month cumulative-savings AreaChart.
+ *
+ * a11y strategy:
+ * - Recharts is notoriously hard to make screen-reader friendly. We rely on
+ *   `aria-label` on the wrapper + a visually-hidden `<table>` mirror that
+ *   exposes the same data points to assistive tech.
+ * - Colours come from CSS custom properties (--color-brand-*) so contrast
+ *   stays in sync with the design system tokens — no hardcoded hex.
+ */
+export function ProjectionChart({ monthlyAmount, locale, copy }: ProjectionChartProps) {
+  const data = React.useMemo(() => buildSeries(monthlyAmount), [monthlyAmount]);
+  const formatter = React.useMemo(
+    () =>
+      new Intl.NumberFormat(locale, {
+        style: 'currency',
+        currency: 'EUR',
+        maximumFractionDigits: 0,
+      }),
+    [locale],
+  );
+
+  return (
+    <figure aria-label={copy.ariaLabel} className="w-full">
+      <div className="h-64 w-full md:h-80">
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart data={data} margin={{ top: 16, right: 16, left: 0, bottom: 0 }}>
+            <defs>
+              <linearGradient id="ankora-projection-gradient" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="var(--color-brand-500)" stopOpacity={0.4} />
+                <stop offset="100%" stopColor="var(--color-brand-500)" stopOpacity={0.05} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid stroke="var(--color-border)" strokeDasharray="3 3" vertical={false} />
+            <XAxis
+              dataKey="month"
+              tick={{ fill: 'var(--color-muted-foreground)', fontSize: 12 }}
+              tickLine={{ stroke: 'var(--color-border)' }}
+              axisLine={{ stroke: 'var(--color-border)' }}
+              label={{
+                value: copy.xAxis,
+                position: 'insideBottom',
+                offset: -2,
+                fill: 'var(--color-muted-foreground)',
+                fontSize: 12,
+              }}
+            />
+            <YAxis
+              tick={{ fill: 'var(--color-muted-foreground)', fontSize: 12 }}
+              tickLine={{ stroke: 'var(--color-border)' }}
+              axisLine={{ stroke: 'var(--color-border)' }}
+              tickFormatter={(value: number) => formatter.format(value)}
+              width={70}
+            />
+            <Tooltip
+              contentStyle={{
+                background: 'var(--color-card)',
+                border: '1px solid var(--color-border)',
+                borderRadius: '0.5rem',
+                color: 'var(--color-foreground)',
+              }}
+              labelStyle={{ color: 'var(--color-muted-foreground)' }}
+              formatter={(value, _name, item) => {
+                const amount = typeof value === 'number' ? value : Number(value);
+                const monthValue =
+                  item && typeof item === 'object' && 'payload' in item
+                    ? (item.payload as ChartDatum).month
+                    : 0;
+                return [
+                  copy.tooltip
+                    .replace('{month}', String(monthValue))
+                    .replace('{amount}', formatter.format(amount)),
+                  '',
+                ];
+              }}
+              labelFormatter={() => ''}
+              separator=""
+            />
+            <Area
+              type="monotone"
+              dataKey="cumulative"
+              stroke="var(--color-brand-700)"
+              strokeWidth={2}
+              fill="url(#ankora-projection-gradient)"
+              isAnimationActive={false}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+
+      <table className="sr-only">
+        <caption>{copy.fallbackTableCaption}</caption>
+        <thead>
+          <tr>
+            <th scope="col">{copy.xAxis}</th>
+            <th scope="col">{copy.yAxis}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((d) => (
+            <tr key={d.month}>
+              <th scope="row">{d.month}</th>
+              <td>{formatter.format(d.cumulative)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </figure>
+  );
+}

--- a/src/components/marketing/landing/simulator/ProjectionResult.tsx
+++ b/src/components/marketing/landing/simulator/ProjectionResult.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import * as React from 'react';
+
+import { money, type Money } from '@/lib/domain/types';
+import { projectCumulative } from '@/lib/domain/simulation';
+
+import { PROJECTION_MONTHS } from './constants';
+
+export type ProjectionResultProps = {
+  /** Monthly amount set aside, in EUR (integer or decimal-string). */
+  monthlyAmount: number;
+  locale: string;
+  copy: {
+    title: string;
+    /** ICU template "{amount}" — replaced with formatted EUR. */
+    amountAria: string;
+    caveat: string;
+  };
+};
+
+/**
+ * Final 12-month projected total, formatted with `Intl.NumberFormat` honouring
+ * the active locale (fr-BE / en / nl-BE / de-DE / es-ES).
+ *
+ * The amount is computed via `projectCumulative` from the domain layer so the
+ * math is the same as everywhere else in the app and stays covered by the
+ * Phase T1 fast-check property tests.
+ *
+ * FSMA-safe copy: the caveat is mandatory and explicitly states Ankora does
+ * not provide investment advice.
+ */
+export function ProjectionResult({ monthlyAmount, locale, copy }: ProjectionResultProps) {
+  const total: Money = projectCumulative(money(monthlyAmount), PROJECTION_MONTHS);
+
+  const formatter = React.useMemo(
+    () =>
+      new Intl.NumberFormat(locale, {
+        style: 'currency',
+        currency: 'EUR',
+        maximumFractionDigits: 0,
+      }),
+    [locale],
+  );
+
+  const formatted = formatter.format(total.toNumber());
+  const ariaLabel = copy.amountAria.replace('{amount}', formatted);
+
+  return (
+    <div className="border-border bg-surface-muted rounded-xl border p-6 text-center">
+      <p className="text-muted-foreground text-sm font-medium">{copy.title}</p>
+      <p
+        className="text-brand-900 mt-2 text-4xl font-bold tabular-nums md:text-5xl"
+        aria-label={ariaLabel}
+      >
+        {formatted}
+      </p>
+      <p className="text-muted-foreground mx-auto mt-4 max-w-md text-xs">{copy.caveat}</p>
+    </div>
+  );
+}

--- a/src/components/marketing/landing/simulator/ScenarioCards.tsx
+++ b/src/components/marketing/landing/simulator/ScenarioCards.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import * as React from 'react';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+import { SCENARIO_KEYS, type ScenarioKey } from './constants';
+
+export type ScenarioCopy = {
+  name: string;
+  tagline: string;
+  description: string;
+};
+
+export type ScenarioCardsProps = {
+  selected: ScenarioKey;
+  onSelect: (scenario: ScenarioKey) => void;
+  copy: Readonly<Record<ScenarioKey, ScenarioCopy>>;
+  groupLabel: string;
+};
+
+/**
+ * Three pre-set savings scenarios. The user picks one to seed the slider.
+ *
+ * a11y notes:
+ * - Container is `role="radiogroup"` with `aria-label`.
+ * - Each card is a `<button role="radio">` with `aria-checked` (radio pattern,
+ *   not aria-pressed which is for toggles).
+ * - Focus-visible ring uses the brand-600 token. Selected state uses an extra
+ *   2px ring on the brand-700 token + bg-brand-100 for clear visual contrast
+ *   (≥ 4.5:1 against text-brand-900).
+ */
+export function ScenarioCards({ selected, onSelect, copy, groupLabel }: ScenarioCardsProps) {
+  return (
+    <div role="radiogroup" aria-label={groupLabel} className="grid gap-4 md:grid-cols-3">
+      {SCENARIO_KEYS.map((key) => {
+        const isSelected = key === selected;
+        const scenarioCopy = copy[key];
+        return (
+          <button
+            key={key}
+            type="button"
+            role="radio"
+            aria-checked={isSelected}
+            onClick={() => onSelect(key)}
+            className={cn(
+              'focus-visible:ring-brand-600 rounded-xl text-left transition-all focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+              isSelected ? 'ring-brand-700 ring-2' : 'ring-0',
+            )}
+          >
+            <Card
+              className={cn('h-full', isSelected ? 'bg-brand-100 border-brand-500' : 'bg-card')}
+            >
+              <CardHeader>
+                <CardTitle className={isSelected ? 'text-brand-900' : 'text-foreground'}>
+                  {scenarioCopy.name}
+                </CardTitle>
+                <CardDescription
+                  className={isSelected ? 'text-brand-800' : 'text-muted-foreground'}
+                >
+                  {scenarioCopy.tagline}
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className={cn('text-sm', isSelected ? 'text-brand-900' : 'text-foreground')}>
+                  {scenarioCopy.description}
+                </p>
+              </CardContent>
+            </Card>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/marketing/landing/simulator/ScenarioSlider.tsx
+++ b/src/components/marketing/landing/simulator/ScenarioSlider.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import * as React from 'react';
+
+import { SLIDER_RANGE } from './constants';
+
+export type ScenarioSliderProps = {
+  value: number;
+  onChange: (value: number) => void;
+  label: string;
+  /** ICU template like "{amount} euros par mois" — `{amount}` is replaced. */
+  valueText: string;
+  unit: string;
+};
+
+/**
+ * Native `<input type="range">` styled with Tailwind. Native is the right
+ * choice here:
+ * - Free a11y (keyboard arrows, screen reader value announcement).
+ * - Zero JS for the drag interaction.
+ * - Works without hydration (graceful degradation).
+ *
+ * The visual numeric value is rendered in a sibling `<span>` next to the label
+ * so sighted users see the live amount; `aria-valuetext` provides the
+ * spoken-language equivalent (e.g. "100 euros par mois") for screen readers.
+ */
+export function ScenarioSlider({ value, onChange, label, valueText, unit }: ScenarioSliderProps) {
+  const sliderId = React.useId();
+  const announcedText = valueText.replace('{amount}', String(value));
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-baseline justify-between gap-3">
+        <label htmlFor={sliderId} className="text-foreground text-sm font-medium">
+          {label}
+        </label>
+        <span className="text-foreground text-lg font-semibold tabular-nums" aria-hidden="true">
+          {value} {unit}
+        </span>
+      </div>
+      <input
+        id={sliderId}
+        type="range"
+        min={SLIDER_RANGE.min}
+        max={SLIDER_RANGE.max}
+        step={SLIDER_RANGE.step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        aria-valuetext={announcedText}
+        className="bg-surface-muted accent-brand-700 focus-visible:ring-brand-600 h-2 w-full cursor-pointer appearance-none rounded-full focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+      />
+    </div>
+  );
+}

--- a/src/components/marketing/landing/simulator/SimulatorClient.tsx
+++ b/src/components/marketing/landing/simulator/SimulatorClient.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import * as React from 'react';
+
+import { Button } from '@/components/ui/button';
+
+import { DEFAULT_SCENARIO, SCENARIO_DELTAS, type ScenarioKey } from './constants';
+import { ProjectionChart, type ProjectionChartProps } from './ProjectionChart';
+import { ProjectionResult, type ProjectionResultProps } from './ProjectionResult';
+import { ScenarioCards, type ScenarioCardsProps, type ScenarioCopy } from './ScenarioCards';
+import { ScenarioSlider, type ScenarioSliderProps } from './ScenarioSlider';
+
+export type SimulatorCopy = {
+  scenarioGroupLabel: string;
+  scenarios: Readonly<Record<ScenarioKey, ScenarioCopy>>;
+  slider: {
+    label: ScenarioSliderProps['label'];
+    valueText: ScenarioSliderProps['valueText'];
+    unit: ScenarioSliderProps['unit'];
+  };
+  chart: ProjectionChartProps['copy'];
+  result: ProjectionResultProps['copy'];
+  cta: {
+    label: string;
+    href: string;
+  };
+};
+
+export type SimulatorClientProps = {
+  locale: string;
+  copy: SimulatorCopy;
+};
+
+/**
+ * Orchestrates the four sub-components:
+ *
+ * 1. `<ScenarioCards>` — picks a preset (steady / balanced / ambitious).
+ * 2. `<ScenarioSlider>` — overrides the preset with a custom monthly amount.
+ * 3. `<ProjectionChart>` — recharts AreaChart of the 12-month cumulative.
+ * 4. `<ProjectionResult>` — final 12-month total formatted in the user's locale.
+ *
+ * Switching scenarios resets the slider to that scenario's delta. Moving the
+ * slider keeps the scenario-card visual selection but overrides the value.
+ */
+export function SimulatorClient({ locale, copy }: SimulatorClientProps) {
+  const [selectedScenario, setSelectedScenario] = React.useState<ScenarioKey>(DEFAULT_SCENARIO);
+  const [monthlyAmount, setMonthlyAmount] = React.useState<number>(
+    SCENARIO_DELTAS[DEFAULT_SCENARIO],
+  );
+
+  const handleScenarioSelect: ScenarioCardsProps['onSelect'] = (scenario) => {
+    setSelectedScenario(scenario);
+    setMonthlyAmount(SCENARIO_DELTAS[scenario]);
+  };
+
+  return (
+    <div className="space-y-8">
+      <ScenarioCards
+        selected={selectedScenario}
+        onSelect={handleScenarioSelect}
+        copy={copy.scenarios}
+        groupLabel={copy.scenarioGroupLabel}
+      />
+
+      <ScenarioSlider
+        value={monthlyAmount}
+        onChange={setMonthlyAmount}
+        label={copy.slider.label}
+        valueText={copy.slider.valueText}
+        unit={copy.slider.unit}
+      />
+
+      <ProjectionChart monthlyAmount={monthlyAmount} locale={locale} copy={copy.chart} />
+
+      <ProjectionResult monthlyAmount={monthlyAmount} locale={locale} copy={copy.result} />
+
+      <div className="flex justify-center">
+        <Button asChild size="lg">
+          <a href={copy.cta.href}>{copy.cta.label}</a>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/marketing/landing/simulator/__tests__/ProjectionResult.test.tsx
+++ b/src/components/marketing/landing/simulator/__tests__/ProjectionResult.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { ProjectionResult } from '../ProjectionResult';
+
+const COPY = {
+  title: 'En 12 mois, vous auriez :',
+  amountAria: 'Montant projeté à 12 mois : {amount}',
+  caveat: 'Projection à titre informatif. Ankora ne fournit pas de conseil en placement.',
+} as const;
+
+describe('<ProjectionResult />', () => {
+  it('computes 12 × monthlyAmount and formats it in EUR for fr-BE', () => {
+    render(<ProjectionResult monthlyAmount={100} locale="fr-BE" copy={COPY} />);
+    // 100 × 12 = 1200 → "1.200 €" in fr-BE Intl.NumberFormat (NBSP between number and €)
+    const amount = screen.getByLabelText(/montant projeté à 12 mois/i);
+    expect(amount.textContent).toMatch(/1[.\s  ]200/);
+    expect(amount.textContent).toContain('€');
+  });
+
+  it('computes 12 × monthlyAmount and formats it in EUR for en', () => {
+    render(<ProjectionResult monthlyAmount={50} locale="en" copy={COPY} />);
+    // 50 × 12 = 600
+    const amount = screen.getByLabelText(/projeté/i);
+    expect(amount.textContent).toMatch(/600/);
+    expect(amount.textContent).toContain('€');
+  });
+
+  it('renders the title and the FSMA caveat', () => {
+    render(<ProjectionResult monthlyAmount={100} locale="fr-BE" copy={COPY} />);
+    expect(screen.getByText(COPY.title)).toBeInTheDocument();
+    expect(screen.getByText(COPY.caveat)).toBeInTheDocument();
+  });
+
+  it('substitutes {amount} placeholder in the aria-label with the formatted value', () => {
+    render(<ProjectionResult monthlyAmount={200} locale="fr-BE" copy={COPY} />);
+    // 200 × 12 = 2400
+    const amount = screen.getByLabelText(/2[.\s  ]400/);
+    expect(amount).toBeInTheDocument();
+  });
+});

--- a/src/components/marketing/landing/simulator/__tests__/ScenarioCards.test.tsx
+++ b/src/components/marketing/landing/simulator/__tests__/ScenarioCards.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { ScenarioCards } from '../ScenarioCards';
+
+const COPY = {
+  steady: { name: 'Économe', tagline: 'Petit pas', description: 'Mettez de côté 50 € par mois.' },
+  balanced: { name: 'Standard', tagline: 'Confortable', description: '100 € par mois.' },
+  ambitious: { name: 'Ambitieux', tagline: 'Solide', description: '200 € par mois.' },
+} as const;
+
+describe('<ScenarioCards />', () => {
+  it('renders three scenarios as a radiogroup', () => {
+    render(
+      <ScenarioCards
+        selected="balanced"
+        onSelect={vi.fn()}
+        copy={COPY}
+        groupLabel="Choisissez un scénario"
+      />,
+    );
+    const group = screen.getByRole('radiogroup', { name: 'Choisissez un scénario' });
+    expect(group).toBeInTheDocument();
+    expect(screen.getAllByRole('radio')).toHaveLength(3);
+  });
+
+  it('marks the selected scenario with aria-checked=true', () => {
+    render(<ScenarioCards selected="balanced" onSelect={vi.fn()} copy={COPY} groupLabel="g" />);
+    const balanced = screen.getByRole('radio', { name: /standard/i });
+    const steady = screen.getByRole('radio', { name: /économe/i });
+    expect(balanced).toHaveAttribute('aria-checked', 'true');
+    expect(steady).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('calls onSelect with the scenario key when clicked', () => {
+    const onSelect = vi.fn();
+    render(<ScenarioCards selected="balanced" onSelect={onSelect} copy={COPY} groupLabel="g" />);
+    fireEvent.click(screen.getByRole('radio', { name: /ambitieux/i }));
+    expect(onSelect).toHaveBeenCalledWith('ambitious');
+  });
+
+  it('renders the localised name, tagline, and description for each scenario', () => {
+    render(<ScenarioCards selected="balanced" onSelect={vi.fn()} copy={COPY} groupLabel="g" />);
+    expect(screen.getByText('Économe')).toBeInTheDocument();
+    expect(screen.getByText('Petit pas')).toBeInTheDocument();
+    expect(screen.getByText('Mettez de côté 50 € par mois.')).toBeInTheDocument();
+    expect(screen.getByText('Ambitieux')).toBeInTheDocument();
+  });
+});

--- a/src/components/marketing/landing/simulator/__tests__/ScenarioSlider.test.tsx
+++ b/src/components/marketing/landing/simulator/__tests__/ScenarioSlider.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { ScenarioSlider } from '../ScenarioSlider';
+import { SLIDER_RANGE } from '../constants';
+
+describe('<ScenarioSlider />', () => {
+  it('renders an input[type=range] with the configured min/max/step', () => {
+    render(
+      <ScenarioSlider
+        value={100}
+        onChange={vi.fn()}
+        label="Montant mensuel"
+        valueText="{amount} euros par mois"
+        unit="€/mois"
+      />,
+    );
+    const slider = screen.getByRole('slider', { name: 'Montant mensuel' });
+    expect(slider).toHaveAttribute('type', 'range');
+    expect(slider).toHaveAttribute('min', String(SLIDER_RANGE.min));
+    expect(slider).toHaveAttribute('max', String(SLIDER_RANGE.max));
+    expect(slider).toHaveAttribute('step', String(SLIDER_RANGE.step));
+  });
+
+  it('shows the numeric value next to the label', () => {
+    render(
+      <ScenarioSlider
+        value={150}
+        onChange={vi.fn()}
+        label="Montant"
+        valueText="{amount} euros par mois"
+        unit="€/mois"
+      />,
+    );
+    expect(screen.getByText('150 €/mois')).toBeInTheDocument();
+  });
+
+  it('exposes the value via aria-valuetext (with placeholder substituted)', () => {
+    render(
+      <ScenarioSlider
+        value={75}
+        onChange={vi.fn()}
+        label="Montant"
+        valueText="{amount} euros par mois"
+        unit="€/mois"
+      />,
+    );
+    const slider = screen.getByRole('slider');
+    expect(slider).toHaveAttribute('aria-valuetext', '75 euros par mois');
+  });
+
+  it('calls onChange with a number when the user drags', () => {
+    const onChange = vi.fn();
+    render(
+      <ScenarioSlider
+        value={100}
+        onChange={onChange}
+        label="Montant"
+        valueText="{amount} eu"
+        unit="€"
+      />,
+    );
+    fireEvent.change(screen.getByRole('slider'), { target: { value: '250' } });
+    expect(onChange).toHaveBeenCalledWith(250);
+  });
+});

--- a/src/components/marketing/landing/simulator/__tests__/SimulatorClient.test.tsx
+++ b/src/components/marketing/landing/simulator/__tests__/SimulatorClient.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { SimulatorClient, type SimulatorCopy } from '../SimulatorClient';
+import { SCENARIO_DELTAS, DEFAULT_SCENARIO } from '../constants';
+
+// Recharts renders SVG via a measuring container that depends on `ResizeObserver`.
+// jsdom doesn't ship one, so we stub it for the duration of the test file.
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+
+const COPY: SimulatorCopy = {
+  scenarioGroupLabel: 'Choisissez un scénario',
+  scenarios: {
+    steady: { name: 'Économe', tagline: 'Petit', description: '50 €' },
+    balanced: { name: 'Standard', tagline: 'Conf', description: '100 €' },
+    ambitious: { name: 'Ambitieux', tagline: 'Solide', description: '200 €' },
+  },
+  slider: {
+    label: 'Montant',
+    valueText: '{amount} euros par mois',
+    unit: '€/mois',
+  },
+  chart: {
+    ariaLabel: 'Projection 12 mois',
+    xAxis: 'Mois',
+    yAxis: 'Cumul',
+    tooltip: 'Mois {month} : {amount}',
+    fallbackTableCaption: 'Données mensuelles',
+  },
+  result: {
+    title: 'En 12 mois :',
+    amountAria: 'Montant : {amount}',
+    caveat: 'Projection informative.',
+  },
+  cta: { label: 'Créer mon plan', href: '/signup' },
+};
+
+describe('<SimulatorClient />', () => {
+  it('initialises with the default scenario and its delta on the slider', () => {
+    render(<SimulatorClient locale="fr-BE" copy={COPY} />);
+    const defaultRadio = screen.getByRole('radio', {
+      name: new RegExp(COPY.scenarios[DEFAULT_SCENARIO].name, 'i'),
+    });
+    expect(defaultRadio).toHaveAttribute('aria-checked', 'true');
+
+    const slider = screen.getByRole('slider', { name: COPY.slider.label });
+    expect(slider).toHaveValue(String(SCENARIO_DELTAS[DEFAULT_SCENARIO]));
+  });
+
+  it('switching scenarios resets the slider to that scenarios delta', () => {
+    render(<SimulatorClient locale="fr-BE" copy={COPY} />);
+    fireEvent.click(screen.getByRole('radio', { name: /ambitieux/i }));
+
+    const slider = screen.getByRole('slider', { name: COPY.slider.label });
+    expect(slider).toHaveValue(String(SCENARIO_DELTAS.ambitious));
+  });
+
+  it('moving the slider updates the slider value (scenario card stays selected)', () => {
+    render(<SimulatorClient locale="fr-BE" copy={COPY} />);
+    const slider = screen.getByRole('slider', { name: COPY.slider.label });
+
+    fireEvent.change(slider, { target: { value: '350' } });
+
+    expect(slider).toHaveValue('350');
+    // default scenario card is still visually selected
+    const defaultRadio = screen.getByRole('radio', {
+      name: new RegExp(COPY.scenarios[DEFAULT_SCENARIO].name, 'i'),
+    });
+    expect(defaultRadio).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('renders the CTA with the configured href', () => {
+    render(<SimulatorClient locale="fr-BE" copy={COPY} />);
+    const cta = screen.getByRole('link', { name: COPY.cta.label });
+    expect(cta).toHaveAttribute('href', COPY.cta.href);
+  });
+});

--- a/src/components/marketing/landing/simulator/constants.ts
+++ b/src/components/marketing/landing/simulator/constants.ts
@@ -1,0 +1,33 @@
+/**
+ * Constants for the public landing simulator.
+ *
+ * Scenario deltas are intentionally simple integer Euros — the landing simulator
+ * is a what-if projection (no real charges), not a connected dashboard. The
+ * underlying math reuses `projectCumulative` from `src/lib/domain/simulation`,
+ * which is covered by the Phase T1 fast-check property suite.
+ *
+ * Refs: PR-3c brief @cowork (2026-04-27), ADR-006 §T1.
+ */
+
+export type ScenarioKey = 'steady' | 'balanced' | 'ambitious';
+
+export const SCENARIO_KEYS: readonly ScenarioKey[] = ['steady', 'balanced', 'ambitious'] as const;
+
+/** Monthly amount set aside, in EUR, by scenario. */
+export const SCENARIO_DELTAS: Readonly<Record<ScenarioKey, number>> = {
+  steady: 50,
+  balanced: 100,
+  ambitious: 200,
+} as const;
+
+/** Slider range overriding the scenario delta. */
+export const SLIDER_RANGE = {
+  min: 10,
+  max: 500,
+  step: 10,
+} as const;
+
+/** Projection horizon (months) — locked at 12 for the v1.0 landing. */
+export const PROJECTION_MONTHS = 12;
+
+export const DEFAULT_SCENARIO: ScenarioKey = 'balanced';

--- a/src/components/marketing/landing/simulator/index.tsx
+++ b/src/components/marketing/landing/simulator/index.tsx
@@ -1,0 +1,81 @@
+import { getTranslations } from 'next-intl/server';
+
+import type { Locale } from '@/i18n/routing';
+
+import { SCENARIO_KEYS, type ScenarioKey } from './constants';
+import { SimulatorClient, type SimulatorCopy } from './SimulatorClient';
+
+export type SimulatorProps = {
+  locale: Locale;
+};
+
+/**
+ * Server Component wrapper that fetches all i18n strings and passes them as a
+ * single `copy` prop to the client orchestrator. This keeps the client bundle
+ * free of `next-intl` runtime dependencies and centralises locale-aware
+ * formatting (the chart + result use `Intl.NumberFormat(locale, ...)`).
+ *
+ * Section is inserted between `<How />` and `<FAQ />` in
+ * `src/app/[locale]/(public)/page.tsx` per @cowork PR-3c brief.
+ */
+export async function Simulator({ locale }: SimulatorProps) {
+  const t = await getTranslations({ locale, namespace: 'landing.simulator' });
+
+  const scenarios = SCENARIO_KEYS.reduce(
+    (acc, key) => {
+      acc[key] = {
+        name: t(`scenarios.${key}.name`),
+        tagline: t(`scenarios.${key}.tagline`),
+        description: t(`scenarios.${key}.description`),
+      };
+      return acc;
+    },
+    {} as Record<ScenarioKey, SimulatorCopy['scenarios'][ScenarioKey]>,
+  );
+
+  const copy: SimulatorCopy = {
+    scenarioGroupLabel: t('scenarios.label'),
+    scenarios,
+    slider: {
+      label: t('slider.label'),
+      valueText: t('slider.value_text'),
+      unit: t('slider.unit'),
+    },
+    chart: {
+      ariaLabel: t('chart.aria_label'),
+      xAxis: t('chart.x_axis'),
+      yAxis: t('chart.y_axis'),
+      tooltip: t('chart.tooltip'),
+      fallbackTableCaption: t('chart.fallback_table_caption'),
+    },
+    result: {
+      title: t('result.title'),
+      amountAria: t('result.amount_aria'),
+      caveat: t('result.caveat'),
+    },
+    cta: {
+      label: t('cta.label'),
+      href: t('cta.href'),
+    },
+  };
+
+  return (
+    <section
+      id="simulator"
+      aria-labelledby="simulator-heading"
+      className="bg-surface-soft mx-auto max-w-6xl px-4 py-16 md:px-6"
+    >
+      <div className="mx-auto mb-10 max-w-2xl text-center">
+        <h2
+          id="simulator-heading"
+          className="text-foreground text-3xl font-bold tracking-tight md:text-4xl"
+        >
+          {t('section_title')}
+        </h2>
+        <p className="text-muted-foreground mt-4 text-lg text-pretty">{t('section_subtitle')}</p>
+      </div>
+
+      <SimulatorClient locale={locale} copy={copy} />
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a self-contained "what-if" savings simulator to the public landing page (`/`), inserted between the **How** and **FAQ** sections per @cowork PR-3c brief (2026-04-27).

The simulator is **interactive but stateless** — no login required, no real charges read. It lets a visitor pick a savings scenario (Économe / Standard / Ambitieux), tweak the monthly amount with a slider, and see the 12-month cumulative projection in a chart + numeric result.

> **Note de cadrage** (@cowork) : la PR initiale s'appelait "Landing fusion intelligente" mais la "fusion" n'avait plus de cible — le `Landing.jsx` du ZIP cc-design n'a jamais été intégré dans le repo. La PR est donc une **extension** de la landing actuelle (déjà conforme tokens). Renommage assumé.

## Architecture

```
src/components/marketing/landing/simulator/
├── constants.ts        Scenario deltas (50/100/200), slider range, 12-month horizon
├── index.tsx           Server Component, fetches i18n, passes copy to client
├── SimulatorClient.tsx 'use client', orchestrates state (scenario + slider)
├── ScenarioCards.tsx   3 preset cards, radiogroup pattern with aria-checked
├── ScenarioSlider.tsx  native input[type=range], aria-valuetext localised
├── ProjectionChart.tsx Recharts AreaChart, tokens via var(--color-*), sr-only <table> fallback
└── ProjectionResult.tsx Intl.NumberFormat EUR per locale, FSMA caveat
```

**Math** : reuses `projectCumulative` from `src/lib/domain/simulation.ts` — no new business logic in the UI. Math stays covered by the Phase T1 fast-check property suite (`simulation.property.test.ts`).

**i18n** : keys added under `landing.simulator` in all 5 locale files. **FR-BE and EN fully localised**; NL-BE / DE-DE / ES-ES temporarily fallback to FR-BE per @cowork direction (NORTH_STAR.md: FR + EN only for v1.0, other locales translated post-launch).

## Decisions verrouillées (@cowork)

| Decision | Choice | Why |
|----------|--------|-----|
| Math approach | `projectCumulative` + hardcoded scenario deltas | Reuses tested code, zero touch on `simulation.ts` |
| Chart library | recharts ^3.8.1 (MIT, ~50KB gzip) | No SaaS, budget 0 € respected |
| Slider | native `<input type="range">` | Free a11y, no JS for drag, works without hydration |
| Token usage | `bg-surface-muted` (not `bg-muted`) on slider track + result panel | Doctrine PR #72 (token-usage.md) |
| Section position | Between How and FAQ | UX flow: pitch → mechanism → projection → questions |

## Compliance

- ✅ **FSMA-safe** : caveat explicit on result panel ("Ankora ne fournit pas de conseil en placement")
- ✅ **WCAG 2.1 AA** : radiogroup pattern, aria-valuetext, aria-label on chart, sr-only table fallback
- ✅ **Token usage doctrine** : zero `bg-muted` as surface, `var(--color-*)` for chart colors
- ✅ **No business logic in UI** : `projectCumulative` is the single source of math
- ✅ **No paid deps** : only recharts (MIT)
- ✅ **Decimal.js** : monetary computations via `money()` helper, no parseFloat

## Test plan

- [x] `npm run test` → **327 tests pass** (35 files), +16 from simulator
- [x] `npm run lint` → 0 error, 1 pre-existing warning (out of scope)
- [x] `npm run typecheck` → 0 error
- [x] `npm run lint:use-server` → pass
- [ ] CI: Lint + Typecheck + Tests
- [ ] CI: Security audit
- [ ] CI: Playwright E2E (incl. new `landing-simulator.spec.ts` + axe-core baseline)
- [ ] CI: Sourcery review
- [ ] Vercel preview deploys + smoke test by @thierry

## Garde-fous respectés (brief @cowork)

- ✅ Aucune modification de `src/lib/domain/simulation.ts`
- ✅ Aucune modification de `src/app/globals.css` (tokens intacts)
- ✅ Pas de copy hors validation @cowork
- ✅ Pas de scope creep (HeaderNav `hover:bg-muted` → issue #74 ouverte avant l'étape 2)
- ✅ Pas de bg-muted en surface dans les fichiers modifiés

## Métriques

- **5 commits**: deps → components → tests → (linting fixes via husky)
- **~1100 lignes** : code (700) + tests (290) + i18n (~110)
- **Coverage** : 16 unit tests + 3 e2e smoke

## Closes

Closes #61

## Refs

- ADR-005 (PR-3a anticipée)
- ADR-006 §T1 (testing strategy)
- `docs/design/token-usage.md` (PR #72 doctrine)
- Issue #74 (HeaderNav hover:bg-muted cleanup, hors scope)
- Issue #70 (Lighthouse skip on PR, hors scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ajouter une section de simulateur d’économies localisée avec une projection sur 12 mois à la page d’accueil publique.

Nouvelles fonctionnalités :
- Introduire un simulateur d’économies sur la page d’accueil publique permettant aux visiteurs de sélectionner des scénarios, d’ajuster un montant mensuel et de visualiser un total projeté sur 12 mois ainsi que l’évolution correspondante sous forme de graphique.

Améliorations :
- Structurer le simulateur en tant que composant serveur qui charge le contenu i18n, et un orchestrateur côté client composé de cartes de scénarios, d’un curseur, d’un graphique de projection et d’un panneau de résultats de projection.
- Ajouter du contenu localisé pour la section du simulateur dans toutes les locales prises en charge, y compris le texte ARIA et les solutions de repli pour l’accessibilité.

Build :
- Ajouter la dépendance `recharts` pour rendre le graphique en aires de projection dans le simulateur.

Tests :
- Ajouter des tests unitaires pour le client du simulateur, les cartes de scénarios, le curseur de scénario et les composants de résultat de projection, ainsi qu’une ébauche de spécification de bout en bout pour le simulateur de la page d’accueil.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a localized savings simulator section with a 12‑month projection to the public landing page.

New Features:
- Introduce a public landing-page savings simulator that lets visitors select scenarios, adjust a monthly amount, and view a 12‑month projected total and charted evolution.

Enhancements:
- Structure the simulator as a server component that loads i18n copy and a client orchestrator composed of scenario cards, a slider, a projection chart, and a projection result panel.
- Add localized copy for the simulator section across supported locales, including ARIA text and accessibility fallbacks.

Build:
- Add the recharts dependency for rendering the projection area chart in the simulator.

Tests:
- Add unit tests for the simulator client, scenario cards, scenario slider, and projection result components, plus an end-to-end spec scaffold for the landing simulator.

</details>