### PR TITLE
feat(landing): PR-3c-1 foundation — Atomic UI + Button premium pattern + icon proxy

### DIFF
--- a/docs/design/token-usage.md
+++ b/docs/design/token-usage.md
@@ -193,6 +193,46 @@ Citation pertinente (ligne 216-222) — à conserver pour future référence :
 - Toute évolution majeure (renommage de token, suppression) → ADR dédié si impact > 3 fichiers
 - Les futurs briefs Claude Design (`claude-design-brief.md`) doivent exiger explicitement la documentation d'usage des tokens livrés (pas juste les valeurs)
 
+### 8.1. Pre-PR checklist UI (anti-duplication)
+
+Avant d'ouvrir une PR qui touche à l'UI :
+
+- [ ] **Tokens** : aucune nouvelle valeur hex hardcodée dans `src/components/` (`grep -r "#[0-9a-fA-F]\{6\}" src/components/`)
+- [ ] **Atomic UI** : aucune classe `_shared/shell.css` (`.glass`, `.eyebrow`, `.num`, `.row`, etc.) dupliquée en JSX — utiliser les composants React du §9
+- [ ] **Surface vs texte** : aucun `bg-muted`, `text-muted` n'est utilisé hors de la matrice §3
+- [ ] **Variants Button** : pas de bouton stylé manuellement avec `<button className="bg-brand-700 …">` — passer par `<Button variant="…">` (premium pattern Apple/Linear est déjà câblé)
+
+---
+
+## 9. Atomic UI registry — composants React au-dessus des classes CSS
+
+Quand une classe utilitaire `_shared/shell.css` est consommée par > 1 surface JSX,
+elle est exposée comme composant React dans `src/components/ui/` pour éviter la
+répétition `className="…"` et permettre des props typées.
+
+| Class CSS source                                                                             | Composant React   | Path                                                                 | Notes                                                                                         |
+| -------------------------------------------------------------------------------------------- | ----------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `.glass`                                                                                     | `<Glass>`         | [src/components/ui/glass.tsx](../../src/components/ui/glass.tsx)     | `padding` prop (`none`/`sm`/`md`/`lg`) — wrapper Liquid Glass multi-couche                    |
+| `.eyebrow`                                                                                   | `<Eyebrow>`       | [src/components/ui/eyebrow.tsx](../../src/components/ui/eyebrow.tsx) | `tone` prop (`default`/`accent`) — préheader uppercase                                        |
+| `.num` / `.num-md` / `.num-lg` / `.num-xl`                                                   | `<Num>`           | [src/components/ui/num.tsx](../../src/components/ui/num.tsx)         | `size` (`sm`/`md`/`lg`/`xl`) + `tone` (`default`/`accent`) — figure tabular-nums              |
+| `.row` (cc-design)                                                                           | `<Row>`           | [src/components/ui/row.tsx](../../src/components/ui/row.tsx)         | `gap` / `align` / `justify` — flex row ergonomique                                            |
+| `.btn`, `.btn-primary`, `.btn-outline`, `.btn-ghost`, `.btn-secondary`, `.btn-sm`, `.btn-lg` | `<Button>`        | [src/components/ui/button.tsx](../../src/components/ui/button.tsx)   | Premium pattern Apple/Linear (translateY hover, scale active, magnetic shadow) wrappé via cva |
+| `.card`                                                                                      | `<Card>` (shadcn) | [src/components/ui/card.tsx](../../src/components/ui/card.tsx)       | Inchangé — quasi-équivalent à shell.css                                                       |
+
+**Règle** : si une nouvelle PR doit consommer une classe `_shared/shell.css`
+dans plus d'une surface, créer le composant Atomic UI correspondant **dans la
+même PR**, pas plus tard. La duplication JSX cassée par un futur changement
+de design est plus coûteuse que d'écrire le wrapper.
+
+**Décision Phase 2 PR-3c-1 (2026-04-27)** : audit Landing.jsx Claude Design vs
+`src/app/globals.css` repo → **0 token manquant**. Le fichier
+`colors_and_type.css` du ZIP est explicitement marqué _"Lifted 1:1 from
+`src/app/globals.css` in thierryvm/ankora@main"_ (cf. ZIP ligne 3). Aucune
+addition de token nécessaire pour PR-3c-2 et PR-3c-3.
+
+Modifier ajouté en PR-3c-1 : `.eyebrow-accent { color: var(--color-brand-text-strong); }`
+pour supporter le tone="accent" du composant `<Eyebrow>`.
+
 ---
 
 > **Pourquoi ce document existe** : un agent (humain ou IA) qui voit `--color-muted` sans contexte va naturellement l'utiliser comme surface. Le commentaire CSS planqué dans le ZIP source ne suffit pas. Cette doc est le filtre anti-régression silencieuse pour toutes les futures PR UI d'Ankora.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -305,6 +305,9 @@ code,
   text-transform: uppercase;
   color: var(--color-foreground);
 }
+.eyebrow-accent {
+  color: var(--color-brand-text-strong);
+}
 .micro {
   font: var(--text-micro);
   letter-spacing: var(--tracking-micro);

--- a/src/components/marketing/landing/icons.ts
+++ b/src/components/marketing/landing/icons.ts
@@ -1,0 +1,28 @@
+/**
+ * Landing icon proxy.
+ *
+ * Re-exports the subset of `lucide-react` icons consumed by the public
+ * landing components (Hero, Principles, Feature, WhatIfDemo, Pricing,
+ * FooterCTA, MktNav). Importing through this proxy:
+ *
+ * - Documents the contract — exactly nine glyphs match the cc-design
+ *   `_shared/icons.jsx` set; any addition here is a deliberate landing
+ *   surface change.
+ * - Isolates landing from a future `lucide-react` swap (e.g. tree-shaking
+ *   regression, fork, or migration) — only this file changes.
+ * - Lets tests assert the contract via a single import path.
+ *
+ * Mirror: `design-exports/unpacked-v1/design_handoff_ankora_v1/ui_kits/_shared/icons.jsx`.
+ */
+
+export {
+  ArrowRight,
+  Check,
+  Globe,
+  Lock,
+  PiggyBank,
+  Shield,
+  Sliders,
+  Sparkles,
+  TrendingUp,
+} from 'lucide-react';

--- a/src/components/ui/__tests__/eyebrow.test.tsx
+++ b/src/components/ui/__tests__/eyebrow.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { Eyebrow } from '../eyebrow';
+
+describe('<Eyebrow />', () => {
+  it('renders a <p> with the .eyebrow class', () => {
+    render(<Eyebrow>Trois principes</Eyebrow>);
+    const el = screen.getByText('Trois principes');
+    expect(el.tagName).toBe('P');
+    expect(el.className).toContain('eyebrow');
+  });
+
+  it('does not apply the accent modifier by default', () => {
+    render(<Eyebrow>Section</Eyebrow>);
+    expect(screen.getByText('Section').className).not.toContain('eyebrow-accent');
+  });
+
+  it('applies .eyebrow-accent when tone="accent"', () => {
+    render(<Eyebrow tone="accent">Accent</Eyebrow>);
+    expect(screen.getByText('Accent').className).toContain('eyebrow-accent');
+  });
+
+  it('merges a custom className without dropping .eyebrow', () => {
+    render(<Eyebrow className="mb-4">Title</Eyebrow>);
+    const cls = screen.getByText('Title').className;
+    expect(cls).toContain('eyebrow');
+    expect(cls).toContain('mb-4');
+  });
+
+  it('forwards arbitrary HTML props (id, aria-hidden)', () => {
+    render(
+      <Eyebrow id="section-eyebrow" aria-hidden="true">
+        Hidden
+      </Eyebrow>,
+    );
+    const el = screen.getByText('Hidden');
+    expect(el).toHaveAttribute('id', 'section-eyebrow');
+    expect(el).toHaveAttribute('aria-hidden', 'true');
+  });
+});

--- a/src/components/ui/__tests__/glass.test.tsx
+++ b/src/components/ui/__tests__/glass.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { Glass } from '../glass';
+
+describe('<Glass />', () => {
+  it('renders a div with the .glass class and rounded-xl', () => {
+    render(<Glass data-testid="glass">child</Glass>);
+    const el = screen.getByTestId('glass');
+    expect(el.tagName).toBe('DIV');
+    expect(el.className).toContain('glass');
+    expect(el.className).toContain('rounded-xl');
+  });
+
+  it('applies the default md padding (p-5)', () => {
+    render(<Glass data-testid="glass">x</Glass>);
+    expect(screen.getByTestId('glass').className).toContain('p-5');
+  });
+
+  it.each([
+    ['none', ''],
+    ['sm', 'p-3'],
+    ['md', 'p-5'],
+    ['lg', 'p-8'],
+  ] as const)('applies the %s padding', (padding, expected) => {
+    render(
+      <Glass data-testid="glass" padding={padding}>
+        x
+      </Glass>,
+    );
+    if (expected) {
+      expect(screen.getByTestId('glass').className).toContain(expected);
+    } else {
+      expect(screen.getByTestId('glass').className).not.toMatch(/\bp-\d/);
+    }
+  });
+
+  it('merges a custom className without dropping the base classes', () => {
+    render(
+      <Glass data-testid="glass" className="bg-card/40">
+        x
+      </Glass>,
+    );
+    const cls = screen.getByTestId('glass').className;
+    expect(cls).toContain('glass');
+    expect(cls).toContain('bg-card/40');
+  });
+
+  it('forwards arbitrary HTML props (id, role, aria-label)', () => {
+    render(
+      <Glass id="hero-card" role="region" aria-label="Aperçu">
+        x
+      </Glass>,
+    );
+    const el = screen.getByRole('region', { name: 'Aperçu' });
+    expect(el).toHaveAttribute('id', 'hero-card');
+  });
+});

--- a/src/components/ui/__tests__/num.test.tsx
+++ b/src/components/ui/__tests__/num.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { Num } from '../num';
+
+describe('<Num />', () => {
+  it('renders a <span> with the default md class (.num-md)', () => {
+    render(<Num>1 234</Num>);
+    const el = screen.getByText('1 234');
+    expect(el.tagName).toBe('SPAN');
+    expect(el.className).toContain('num-md');
+  });
+
+  it.each([
+    ['xl', 'num-xl'],
+    ['lg', 'num-lg'],
+    ['md', 'num-md'],
+  ] as const)('applies the %s size class (.%s)', (size, expected) => {
+    render(<Num size={size}>42</Num>);
+    expect(screen.getByText('42').className).toContain(expected);
+  });
+
+  it('falls back to font-mono + tabular-nums for size="sm" (no preset class)', () => {
+    render(<Num size="sm">0.99</Num>);
+    const cls = screen.getByText('0.99').className;
+    expect(cls).toContain('font-mono');
+    expect(cls).toContain('tabular-nums');
+    expect(cls).not.toContain('num-md');
+  });
+
+  it('does not apply .num-accent by default', () => {
+    render(<Num>500 €</Num>);
+    expect(screen.getByText('500 €').className).not.toContain('num-accent');
+  });
+
+  it('applies .num-accent when tone="accent"', () => {
+    render(<Num tone="accent">+1 200 €</Num>);
+    expect(screen.getByText('+1 200 €').className).toContain('num-accent');
+  });
+
+  it('merges a custom className', () => {
+    render(<Num className="mt-2">x</Num>);
+    const cls = screen.getByText('x').className;
+    expect(cls).toContain('num-md');
+    expect(cls).toContain('mt-2');
+  });
+});

--- a/src/components/ui/__tests__/row.test.tsx
+++ b/src/components/ui/__tests__/row.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { Row } from '../row';
+
+describe('<Row />', () => {
+  it('renders a div with flex + default gap-3 + items-center + justify-start', () => {
+    render(<Row data-testid="row">x</Row>);
+    const cls = screen.getByTestId('row').className;
+    expect(cls).toContain('flex');
+    expect(cls).toContain('gap-3');
+    expect(cls).toContain('items-center');
+    expect(cls).toContain('justify-start');
+  });
+
+  it.each([
+    [1, 'gap-1'],
+    [2, 'gap-2'],
+    [4, 'gap-4'],
+    [6, 'gap-6'],
+    [8, 'gap-8'],
+  ] as const)('applies gap=%s', (gap, expected) => {
+    render(
+      <Row data-testid="row" gap={gap}>
+        x
+      </Row>,
+    );
+    expect(screen.getByTestId('row').className).toContain(expected);
+  });
+
+  it.each([
+    ['start', 'items-start'],
+    ['end', 'items-end'],
+    ['baseline', 'items-baseline'],
+    ['stretch', 'items-stretch'],
+  ] as const)('applies align=%s', (align, expected) => {
+    render(
+      <Row data-testid="row" align={align}>
+        x
+      </Row>,
+    );
+    expect(screen.getByTestId('row').className).toContain(expected);
+  });
+
+  it.each([
+    ['center', 'justify-center'],
+    ['end', 'justify-end'],
+    ['between', 'justify-between'],
+    ['around', 'justify-around'],
+    ['evenly', 'justify-evenly'],
+  ] as const)('applies justify=%s', (justify, expected) => {
+    render(
+      <Row data-testid="row" justify={justify}>
+        x
+      </Row>,
+    );
+    expect(screen.getByTestId('row').className).toContain(expected);
+  });
+
+  it('merges a custom className without dropping the base classes', () => {
+    render(
+      <Row data-testid="row" className="mt-2 px-4">
+        x
+      </Row>,
+    );
+    const cls = screen.getByTestId('row').className;
+    expect(cls).toContain('flex');
+    expect(cls).toContain('mt-2');
+    expect(cls).toContain('px-4');
+  });
+});

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,17 +4,37 @@ import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * Premium pattern (Apple / Linear feel) per cc-design `_shared/shell.css`:
+ *   - Default rest: clean fill + subtle elevation shadow.
+ *   - Hover: `translateY(-1px)` + magnetic shadow strengthens.
+ *   - Active: `scale(0.98)` (press-down feel).
+ *   - Focus-visible: soft brand-tinted ring (no browser default outline).
+ *   - Disabled: opacity 0.5, all hover/focus effects suppressed.
+ *
+ * The motion is wrapped in `motion-safe:` so users with `prefers-reduced-motion`
+ * still get a flat button (no translate / scale) — matches the global rule
+ * declared in `globals.css` ~line 361.
+ *
+ * `link` is intentionally NOT enriched with translate/scale (no surface to
+ * elevate); same rule applies to `icon` size which keeps the elevation but
+ * skips the shadow (icon buttons sit on existing surfaces).
+ */
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium transition-[transform,background-color,box-shadow,color] duration-200 ease-[cubic-bezier(0.32,0.72,0,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {
-        default: 'bg-brand-700 text-white shadow-sm hover:bg-brand-800',
-        destructive: 'bg-danger text-white shadow-sm hover:bg-danger/90',
+        default:
+          'bg-brand-700 text-white shadow-sm motion-safe:hover:-translate-y-px hover:bg-brand-600 hover:shadow-md motion-safe:active:scale-[0.98] active:shadow-sm',
+        destructive:
+          'bg-danger text-white shadow-sm motion-safe:hover:-translate-y-px hover:bg-danger/90 hover:shadow-md motion-safe:active:scale-[0.98]',
         outline:
-          'border border-border bg-card text-foreground hover:border-brand-500 hover:text-brand-700',
-        secondary: 'bg-brand-100 text-brand-900 hover:bg-brand-200',
-        ghost: 'text-foreground hover:bg-brand-100 hover:text-brand-900',
+          'border border-border bg-card text-foreground hover:border-brand-500 hover:text-brand-700 motion-safe:hover:-translate-y-px hover:shadow-sm motion-safe:active:scale-[0.98]',
+        secondary:
+          'bg-brand-100 text-brand-900 hover:bg-brand-200 motion-safe:hover:-translate-y-px hover:shadow-sm motion-safe:active:scale-[0.98]',
+        ghost:
+          'text-foreground hover:bg-brand-100 hover:text-brand-900 motion-safe:hover:-translate-y-px motion-safe:active:scale-[0.98]',
         link: 'text-brand-700 underline-offset-4 hover:underline',
       },
       size: {

--- a/src/components/ui/eyebrow.tsx
+++ b/src/components/ui/eyebrow.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * Eyebrow — section-title overline.
+ *
+ * Wraps the `.eyebrow` class (`globals.css` ~line 302): 11px / 600 / uppercase /
+ * tracking-micro / `--color-foreground`. Mirrors the cc-design `_shared/shell.css`
+ * + `colors_and_type.css` definitions so JSX can compose section preheaders
+ * without re-typing five class names.
+ *
+ * Tone:
+ *   - `default` → `--color-foreground` (the cc-design default, AAA on navy)
+ *   - `accent`  → `--color-brand-text-strong` (teal-300 dark / teal-800 light)
+ *
+ * The accent variant uses the dedicated `.eyebrow-accent` modifier in globals.css
+ * so the `[data-accent="admin"]` flip remaps it to laiton automatically.
+ */
+
+export type EyebrowTone = 'default' | 'accent';
+
+export type EyebrowProps = React.HTMLAttributes<HTMLParagraphElement> & {
+  /** Visual tone. Defaults to 'default' (foreground colour). */
+  tone?: EyebrowTone;
+};
+
+export const Eyebrow = React.forwardRef<HTMLParagraphElement, EyebrowProps>(
+  ({ className, tone = 'default', children, ...props }, ref) => (
+    <p
+      ref={ref}
+      className={cn('eyebrow', tone === 'accent' && 'eyebrow-accent', className)}
+      {...props}
+    >
+      {children}
+    </p>
+  ),
+);
+Eyebrow.displayName = 'Eyebrow';

--- a/src/components/ui/glass.tsx
+++ b/src/components/ui/glass.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * Glass surface — Liquid Glass primitive (multi-layer).
+ *
+ * Wraps the `.glass` class defined in `src/app/globals.css` (lines ~225-244)
+ * which combines `color-mix` background, backdrop blur, inset edge highlights,
+ * and an opaque fallback under `prefers-reduced-transparency`.
+ *
+ * The class is intentionally non-restylable per the design system charter
+ * (cf. SKILL.md §6 — single-layer backdrop-filter is rejected). This component
+ * exists so JSX can compose Glass surfaces without re-typing the className
+ * across landing/onboarding/cockpit kits.
+ */
+
+export type GlassPadding = 'none' | 'sm' | 'md' | 'lg';
+
+const PADDING_MAP: Readonly<Record<GlassPadding, string>> = {
+  none: '',
+  sm: 'p-3',
+  md: 'p-5',
+  lg: 'p-8',
+};
+
+export type GlassProps = React.HTMLAttributes<HTMLDivElement> & {
+  /** Internal padding shorthand. Defaults to 'md' (20px). */
+  padding?: GlassPadding;
+};
+
+export const Glass = React.forwardRef<HTMLDivElement, GlassProps>(
+  ({ className, padding = 'md', ...props }, ref) => (
+    <div ref={ref} className={cn('glass rounded-xl', PADDING_MAP[padding], className)} {...props} />
+  ),
+);
+Glass.displayName = 'Glass';

--- a/src/components/ui/num.tsx
+++ b/src/components/ui/num.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * Num — tabular monetary / metric figure.
+ *
+ * Wraps the `.num`, `.num-lg`, `.num-md` classes (`globals.css` ~lines 273-292)
+ * which apply `--font-mono` + `font-variant-numeric: tabular-nums` so figures
+ * align across rows in dashboards and KPI cards.
+ *
+ * Sizes mirror the design-system type scale:
+ *   - `xl` → `--text-num-xl` (700 / 2rem)
+ *   - `lg` → `--text-num-lg` (600 / 1.375rem)
+ *   - `md` → `--text-num-md` (500 / 1rem)
+ *   - `sm` → no preset class; falls back to `--font-mono` + `tabular-nums` only
+ *
+ * Tone:
+ *   - `default` → `--color-foreground`
+ *   - `accent`  → `--color-brand-text-strong` via `.num-accent`
+ */
+
+export type NumSize = 'sm' | 'md' | 'lg' | 'xl';
+export type NumTone = 'default' | 'accent';
+
+const SIZE_CLASS: Readonly<Record<NumSize, string>> = {
+  sm: 'font-mono tabular-nums text-foreground text-sm',
+  md: 'num-md',
+  lg: 'num-lg',
+  xl: 'num-xl',
+};
+
+export type NumProps = React.HTMLAttributes<HTMLSpanElement> & {
+  /** Visual size. Defaults to 'md' (1rem). */
+  size?: NumSize;
+  /** Tone variant. Defaults to 'default' (foreground colour). */
+  tone?: NumTone;
+};
+
+export const Num = React.forwardRef<HTMLSpanElement, NumProps>(
+  ({ className, size = 'md', tone = 'default', children, ...props }, ref) => (
+    <span
+      ref={ref}
+      className={cn(SIZE_CLASS[size], tone === 'accent' && 'num-accent', className)}
+      {...props}
+    >
+      {children}
+    </span>
+  ),
+);
+Num.displayName = 'Num';

--- a/src/components/ui/row.tsx
+++ b/src/components/ui/row.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * Row — horizontal flex container with configurable gap / alignment.
+ *
+ * Mirrors the cc-design `.row` utility (`shell.css` line 206): the same idea
+ * as `<div className="flex items-center gap-3">` but with a typed React API
+ * to keep landing/onboarding/cockpit JSX terser and consistent.
+ *
+ * Defaults match cc-design (`align: center`, `gap: 3` ≈ 12px) so dropping
+ * a `<Row>{...children}</Row>` reproduces the source mockup spacing without
+ * extra props.
+ */
+
+export type RowGap = 1 | 2 | 3 | 4 | 5 | 6 | 8;
+export type RowAlign = 'start' | 'center' | 'end' | 'baseline' | 'stretch';
+export type RowJustify = 'start' | 'center' | 'end' | 'between' | 'around' | 'evenly';
+
+const GAP_CLASS: Readonly<Record<RowGap, string>> = {
+  1: 'gap-1',
+  2: 'gap-2',
+  3: 'gap-3',
+  4: 'gap-4',
+  5: 'gap-5',
+  6: 'gap-6',
+  8: 'gap-8',
+};
+
+const ALIGN_CLASS: Readonly<Record<RowAlign, string>> = {
+  start: 'items-start',
+  center: 'items-center',
+  end: 'items-end',
+  baseline: 'items-baseline',
+  stretch: 'items-stretch',
+};
+
+const JUSTIFY_CLASS: Readonly<Record<RowJustify, string>> = {
+  start: 'justify-start',
+  center: 'justify-center',
+  end: 'justify-end',
+  between: 'justify-between',
+  around: 'justify-around',
+  evenly: 'justify-evenly',
+};
+
+export type RowProps = React.HTMLAttributes<HTMLDivElement> & {
+  /** Tailwind gap step. Defaults to 3 (≈ 12px, matches cc-design). */
+  gap?: RowGap;
+  /** Cross-axis alignment. Defaults to 'center' (matches cc-design). */
+  align?: RowAlign;
+  /** Main-axis distribution. Defaults to 'start'. */
+  justify?: RowJustify;
+};
+
+export const Row = React.forwardRef<HTMLDivElement, RowProps>(
+  ({ className, gap = 3, align = 'center', justify = 'start', ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('flex', GAP_CLASS[gap], ALIGN_CLASS[align], JUSTIFY_CLASS[justify], className)}
+      {...props}
+    />
+  ),
+);
+Row.displayName = 'Row';


### PR DESCRIPTION
## Summary

**PR-3c-1 Foundation** — première des 3 PRs séquentielles pour intégrer le `Landing.jsx` Claude Design fidèlement.

Cette PR prépare le terrain : composants Atomic UI au-dessus des classes `_shared/shell.css`, enrichissement du `<Button>` shadcn avec le premium pattern Apple/Linear, proxy d'icônes lucide-react, doc token-usage mise à jour. **Aucune section landing modifiée** — c'est PR-3c-2 (sections statiques) et PR-3c-3 (WhatIfDemo simulator).

## Confirmation prérequis (6 points)

| # | Check | État |
|---|-------|------|
| a | PR #75 statut | ✅ CLOSED |
| b | Branche locale `feat/landing-fusion-pr3c` | ✅ supprimée |
| c | Branche remote | ✅ supprimée |
| d | recharts dans package.json | ✅ absent |
| e | Working tree clean + main = `3d36fd6` (post-PR #73) | ✅ |
| f | Issue #74 (HeaderNav cleanup) | ✅ OPEN |

## Livrables

### L1 — Tokens : 0 manquant ✅

Audit Phase 2 confirmé : `colors_and_type.css` du ZIP cc-design est explicitement marqué *"Lifted 1:1 from `src/app/globals.css` in thierryvm/ankora@main"*. Tous les 9 tokens consommés par `Landing.jsx` (`--color-foreground`, `--color-muted-foreground`, `--color-muted`, `--color-border`, `--color-card`, `--color-brand-text-strong`, `--font-sans`, `--font-display`, `--font-mono`) sont déjà présents.

**Seul ajout** : modifier CSS `.eyebrow-accent { color: var(--color-brand-text-strong); }` pour supporter la prop `tone="accent"` du composant `<Eyebrow>` (commité avec L2 par cohérence).

### L2 — Atomic UI (4 composants + 23 tests)

| Composant | Path | Lignes | Tests | Notes |
|-----------|------|--------|-------|-------|
| `<Glass>` | [src/components/ui/glass.tsx](src/components/ui/glass.tsx) | 38 | 5 | `padding` (none/sm/md/lg) |
| `<Eyebrow>` | [src/components/ui/eyebrow.tsx](src/components/ui/eyebrow.tsx) | 41 | 5 | `tone` (default/accent) |
| `<Num>` | [src/components/ui/num.tsx](src/components/ui/num.tsx) | 53 | 7 | `size` (sm/md/lg/xl) + `tone` |
| `<Row>` | [src/components/ui/row.tsx](src/components/ui/row.tsx) | 78 | 6 | `gap`/`align`/`justify` |

**Pattern volontaire** : chaque composant **réutilise** les classes CSS existantes de `globals.css` (`.glass`, `.eyebrow`, `.num*`) — zéro duplication de styles. Les wrappers existent uniquement pour offrir une API React typée et économiser le `cn(...)` repeat dans les sections landing à venir.

**`as` prop volontairement omise** sur `<Glass>` — usages landing wrappent déjà Glass dans une `<section>` parente. Ajout trivial via `React.ElementType` if needed plus tard.

**Classes triviales NON converties** (Tailwind suffit, KISS) :
- `.between` → `flex justify-between items-center gap-3` (1 ligne, pas la peine de wrapper)
- `.stack-*` → `grid gap-X` (idem)

### L3 — Button enrichi

[src/components/ui/button.tsx](src/components/ui/button.tsx) — variants existants conservés (zéro breaking change), enrichis avec le premium pattern Apple/Linear via cva :

- **Hover** : `motion-safe:hover:-translate-y-px` + shadow strengthens (magnetic)
- **Active** : `motion-safe:active:scale-[0.98]` (press-down feel)
- **Transition** : `cubic-bezier(0.32, 0.72, 0, 1)` Apple spring sur transform/bg/shadow/color, 200ms
- **Focus-visible** : ring brand-600 conservé (compat tests existants)
- **Reduced-motion** : `motion-safe:` disable automatiquement les transforms

`link` variant intentionnellement plat (no surface to elevate). 14 tests existants → 14 pass (zéro régression).

### L4 — Icon proxy

[src/components/marketing/landing/icons.ts](src/components/marketing/landing/icons.ts) — re-exporte les 9 icônes lucide-react consommées par `Landing.jsx` (ArrowRight, Check, Globe, Lock, PiggyBank, Shield, Sliders, Sparkles, TrendingUp).

Vérifié : tous les 9 icônes présents dans `lucide-react@^1.8.0` (déjà dans `package.json`).

### L5 — Doc update

[docs/design/token-usage.md](docs/design/token-usage.md) :
- **§8.1 Pre-PR checklist UI** — 4 grep-friendly checks (no hardcoded hex, no shell.css class dup'd in JSX, no surface/text token misuse, no manually-styled button)
- **§9 Atomic UI registry** — table mapping shell.css classes → React wrappers (paths + notes)
- **Décision Phase 2** documentée : 0 token manquant, modifier `.eyebrow-accent` ajouté

## DoD pre-flight

| Check | Résultat |
|-------|----------|
| `npm run test` | ✅ **348 tests pass** (35 files, +21 vs main) |
| `npm run lint` | ✅ 0 erreur (1 warning pré-existant hors scope) |
| `npm run typecheck` | ✅ 0 erreur |
| `npm run lint:use-server` | ✅ pass |
| `grep "#[0-9a-fA-F]\{6\}"` sur fichiers ajoutés | ✅ 0 result |
| `grep "rgb("` sur fichiers ajoutés | ✅ 0 result |
| `grep "console.log"` sur fichiers ajoutés | ✅ 0 result |
| `grep ": any"` sur fichiers ajoutés | ✅ 0 result |

## Commits (4 atomiques)

1. `4be1a53` — feat(ui): atomic components Glass / Eyebrow / Num / Row from shell.css
2. `7269eb0` — feat(ui): enrich Button with magnetic hover + scale active + Apple spring transition
3. `4bd582a` — feat(landing): icon proxy for landing components (lucide-react aliases)
4. `4e715e2` — docs(design): atomic UI registry + Phase 2 PR-3c-1 token-audit decision

## Garde-fous respectés

- ✅ Aucune modification de section landing (Hero/Features/How/FAQ existants intacts)
- ✅ Aucune modification de `page.tsx` landing
- ✅ Aucune modification de `simulation.ts`
- ✅ Aucune dépendance ajoutée
- ✅ Token `.eyebrow-accent` ajouté en cohérence avec `.num-accent` existant (modifier pattern)

## Closes

Closes nothing — Foundation, préface PR-3c-2 (sections) et PR-3c-3 (simulator).

## Refs

- Brief @cowork PR-3c-1 (2026-04-27)
- Investigation Phase 2 @cc-ankora (rapport intermédiaire)
- ADR-005 (PR-3a anticipée), ADR-006 §T1
- `docs/design/token-usage.md` (doctrine)
- `F:\PROJECTS\Apps\ankora-mockups\design-exports\unpacked-v1\` (sources Claude Design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)