### PR TITLE
feat(landing): Claude Design sections (PR-3c-2 WIP — checkpoint MktNav + Hero)

### DIFF
--- a/docs/cowork-handoff-conventions.md
+++ b/docs/cowork-handoff-conventions.md
@@ -1,0 +1,270 @@
+# Cowork ↔ CC Ankora Handoff Conventions
+
+> **Source canonique** des conventions de collaboration entre @cowork (Cowork desktop, Opus 4.7), @cc-ankora (Claude Code terminal, Opus 4.7 pinné) et @thierry (humain validateur). Tout prompt CC Ankora doit référencer ce document plutôt que de répéter ces conventions inline.
+
+**Verrouillé** : 2026-04-27. Modification = PR dédiée + ADR si changement structurel.
+
+---
+
+## 1. Rôles trio agents
+
+- **@cowork** : tranche les arbitrages techniques, rédige les prompts CC Ankora prêts-à-coller, valide les rapports, met à jour docs design / ADR / stratégie. Autonomie maximale sauf escalades @thierry pour business.
+- **@cc-ankora** : exécute le code, ouvre les PR, gère Sourcery, remonte les blocages structurels à @cowork.
+- **@thierry** : valide les décisions business (budget, scope, FSMA, design), clique les merges, supervise sans intervenir techniquement sauf demande explicite.
+
+**Escalade @thierry** uniquement pour :
+
+- Ajout dépendance payante (budget 0 € à respecter)
+- Modification scope feature
+- Conflit FSMA
+- Choix architecturaux majeurs
+- Faille sécurité détectée
+- Décision design visuelle non triviale
+
+---
+
+## 2. Definition of Done canonique (5-step)
+
+Un push, un commit ou une PR ouverte ne signifie PAS "terminé". Une tâche n'est DONE qu'après TOUS ces critères satisfaits :
+
+1. **CI verts** : Lint, Typecheck, Tests, E2E, Security audit, Build, Lighthouse CI (si configuré sur le scope).
+2. **Sourcery silencieux** sur le DERNIER commit de la PR (aucun commentaire inline actif, aucune review non résolue). Vérification :
+   ```bash
+   gh api repos/thierryvm/ankora/pulls/<N>/comments \
+     --jq '.[] | select(.user.login == "sourcery-ai[bot]") | .body'
+   ```
+   Si Sourcery est en skip rate limit hebdo → c'est bénin si le bot publie le skip avec raison explicite (ex: "weekly rate limit"). Documenter dans le rapport final.
+3. **Reviews humaines approuvées et résolues** (si reviewers ajoutés à la PR).
+4. **Pas de conflit avec main** : `mergeStateStatus = CLEAN`, `mergeable = MERGEABLE`.
+5. **Rapport final livré à @thierry** avec preuve de chaque critère.
+
+**Règle de refus** : ne JAMAIS déclarer une tâche terminée sans avoir explicitement vérifié les 5 critères ci-dessus. Un push sans vérif Sourcery = tâche incomplète, point.
+
+---
+
+## 3. Format rapport intermédiaire (checkpoint @cowork)
+
+À utiliser quand un prompt CC Ankora demande explicitement un checkpoint @cowork avant de continuer :
+
+```markdown
+## [Nom de la PR / Étape] — Rapport intermédiaire
+
+### Confirmation prérequis
+
+[tableau ou liste confirmant chaque prérequis du brief]
+
+### Livraisons
+
+[Liste structurée des fichiers/composants livrés avec path, lignes, tests]
+
+### Tokens / classes utilisés
+
+[Inventaire grep-friendly]
+
+### URL preview Vercel
+
+[URL pour validation visuelle @cowork]
+
+### Questions ouvertes pour @cowork
+
+[Liste si applicable, sinon "aucune"]
+
+### Risques identifiés
+
+[Techniques, visuels, a11y, FSMA]
+
+### STOP — Attente validation @cowork
+```
+
+---
+
+## 4. Format rapport final (post-DoD)
+
+À livrer après que les 5 critères DoD soient satisfaits :
+
+```markdown
+## [Nom de la PR] — Rapport final DoD
+
+**PR** : #XX
+**Branche** : <name>
+**Commits** : N atomiques
+**Lignes** : +XXXX / -YYY
+
+### Confirmation prérequis
+
+[tableau confirmant chaque prérequis]
+
+### DoD 5-step
+
+1. ✅ CI : [liste checks verts avec durée]
+2. ✅ Sourcery : 0 commentaire actif (preuve via gh api ou skip rate limit documenté)
+3. ✅ Reviews : N/A ou résolues
+4. ✅ mergeStateStatus : CLEAN
+5. ✅ Rapport livré (ce document)
+
+### Livrables
+
+[Récapitulatif structuré par livrable]
+
+### Métriques
+
+- Tests : N pass (+M vs main)
+- Coverage : XX% sur nouveaux fichiers
+- Lighthouse : perf XX, a11y XX, BP XX, SEO XX (si applicable)
+- axe-core violations : 0
+
+### Clean code grep results
+
+[Tableau zéro tolérance — voir §7]
+
+### Issues touchées / créées
+
+[Liste avec numéros]
+
+### Closes
+
+- Closes #XX (si applicable)
+
+### Préface PR suivante
+
+[Description courte de la prochaine PR si séquence en cours]
+```
+
+---
+
+## 5. Garde-fous transverses (non négociables)
+
+Ces règles s'appliquent à TOUTE PR Ankora sauf override explicite @cowork :
+
+- **ZÉRO touch sur `src/lib/domain/simulation.ts`** sans validation @cowork (logique métier testée T1, hors scope par défaut).
+- **ZÉRO touch sur Atomic UI mergée** (Glass, Eyebrow, Num, Row, Button enrichi) sans validation @cowork.
+- **ZÉRO ajout de dépendance** sans validation @cowork. Toute dep doit être : MIT/Apache compatible, pas de SaaS gratuite avec compte requis, pas de payante en prod tant qu'Ankora n'a pas de revenus (cf. budget 0 € NORTH_STAR.md).
+- **ZÉRO modification de tokens CSS prod** sans audit (cf. `docs/design/token-usage.md`).
+- **ZÉRO modification de migration Supabase** sans validation @cowork + agent `rls-flow-tester`.
+- **ZÉRO modification de policy RLS** sans validation @cowork.
+- **ZÉRO copy FSMA-douteuse** : toute formulation suggérant conseil en placement → STOP, remontée @cowork.
+- **ZÉRO scope creep** : si un besoin émergent apparaît hors brief → STOP, remontée @cowork. Ne jamais "tant qu'on y est" sans validation.
+
+Si pendant l'exécution un bloquant équivalent est détecté → **STOP**, rapport intermédiaire à @cowork avec faits + recommandation, pas d'auto-décision.
+
+---
+
+## 6. Posture "push done ≠ task done"
+
+Référence canonique : `CLAUDE.md` projet ligne "Définition de DONE".
+
+Principes :
+
+- Un commit = un changement atomique et descriptif
+- Un push = signal d'activité, **pas** de complétion
+- Un PR ouverte = invitation à review, **pas** de complétion
+- Une PR mergée = task complète **uniquement** si les 5 critères DoD sont vérifiés ET le rapport final livré
+
+**Discipline** : avant de déclarer DONE, exécuter le check Sourcery (cf. §2 critère 2) **et** confirmer mergeStateStatus = CLEAN. Pas d'exception.
+
+---
+
+## 7. Clean code directives @thierry
+
+Vérifications grep zéro tolérance avant push final :
+
+```bash
+# Sur les fichiers ajoutés/modifiés dans la PR
+grep -r "#[0-9a-fA-F]\{6\}" <scope>     # 0 hardcoded color
+grep -r "rgb(" <scope>                  # 0 inline rgb (hors fichiers .css globaux)
+grep -r "console.log" <scope>           # 0 debug oublié
+grep -r ": any" <scope>                 # 0 TypeScript any
+grep -r "hover:bg-muted" <scope>        # 0 violation token-usage doctrine
+```
+
+Quality checks :
+
+```bash
+npm run lint              # 0 erreur
+npm run lint:use-server   # 0 erreur (async-only enforcement)
+npm run typecheck         # 0 erreur (strict + noUncheckedIndexedAccess)
+npm run test              # 100% pass
+npm run e2e               # 100% pass sur parcours critiques
+```
+
+Code review au sens large :
+
+- Pas de duplication : si une logique existe déjà dans le repo, la réutiliser
+- Pas de classes ou composants dupliqués : factoriser dans Atomic UI maximum
+- Tous les imports utilisés (eslint no-unused-imports passe)
+- Conventions de nommage cohérentes avec le repo existant
+- Audit Sourcery digéré sérieusement (pas juste "fix automatique")
+- **Relire son propre diff complet avant push final, comme si on le reviewait pour quelqu'un d'autre**
+
+---
+
+## 8. Convention des prompts CC Ankora
+
+Tout prompt @cowork → @cc-ankora doit :
+
+1. Tenir dans **un seul codeblock copiable** d'un seul geste par @thierry (pas de fragmentation texte + bloc + texte + bloc).
+2. Référencer ce document : _"Cf. `docs/cowork-handoff-conventions.md` §X pour [DoD / format rapport / garde-fous / posture / clean code]"_.
+3. Inclure les éléments **spécifiques** au scope :
+   - Contexte + objectif
+   - Prérequis vérifiables explicitement
+   - Branche à créer
+   - Décisions techniques verrouillées par @cowork
+   - Scope précis (livrables numérotés)
+   - Format rapport attendu (intermédiaire si checkpoint, sinon final)
+4. Indiquer les **checkpoints @cowork** OBLIGATOIRES s'il y en a, avec STOP explicite.
+5. Préciser la **durée estimée** CC Ankora pour le scope.
+
+Le contexte explicatif @cowork (récap, raisonnement, arbitrages) reste **autour** du codeblock, jamais à l'intérieur.
+
+---
+
+## 9. Convention de tags
+
+À utiliser dans TOUT rapport, commit message, commentaire PR, ou note inter-agents :
+
+- `@cowork — …` pour l'agent Cowork
+- `@cc-ankora — …` pour l'agent Claude Code terminal
+- `@cc-design — …` pour l'agent Claude Design (claude.ai/design)
+- `@thierry — …` pour Thierry (validation, décision, merge)
+
+Utilité : traçabilité des décisions et auditabilité des contributions par agent.
+
+---
+
+## 10. Cleanup branches locales (squash merge stratégie)
+
+Ankora utilise **squash merge** comme stratégie GitHub. Procédure cleanup canonique (cf. `CLAUDE.md` §"Cleanup branches locales") :
+
+1. `git fetch --prune origin`
+2. `git branch -d <branche>` (tente la version safe d'abord)
+3. Si refus → cross-check via `gh pr list --state merged --limit 100 --json headRefName --jq '.[] | .headRefName' | grep <branche>`
+4. Si une PR mergée correspond exactement → `git branch -D <branche>` safe
+5. Si aucune PR mergée trouvée → STOP, investiguer avec @cowork
+
+Branches `[gone]` après prune sont 100% safe à supprimer avec `-D` (remote déjà supprimée par GitHub).
+
+---
+
+## 11. Évolution du document
+
+Ce document est versionné dans `docs/`. Toute modification :
+
+- Doit être proposée via PR dédiée (pas glissée dans une PR métier)
+- Doit citer la session @cowork qui a tranché le changement
+- Doit être validée par @thierry avant merge
+
+Modifications structurelles (ex : changement DoD) → ADR associé dans `docs/adr/`.
+
+---
+
+## Référence rapide
+
+| Besoin                              | Section |
+| ----------------------------------- | ------- |
+| Rédiger un prompt CC Ankora         | §8      |
+| Format rapport checkpoint           | §3      |
+| Format rapport final                | §4      |
+| Vérifier les 5 critères DoD         | §2      |
+| Lister les garde-fous transverses   | §5      |
+| Checklist pré-PR                    | §7      |
+| Cleanup branches mergées via squash | §10     |

--- a/e2e/a11y/drawer-mobile-focus-trap.spec.ts
+++ b/e2e/a11y/drawer-mobile-focus-trap.spec.ts
@@ -61,7 +61,11 @@ test.describe('Drawer Mobile Accessibility — Focus Trap (WCAG 2.1 2.4.3)', () 
 
     const checkbox = page.locator('input#menu-toggle');
     const drawer = page.locator('nav[role="dialog"]');
-    await expect(drawer).toHaveClass(/translate-x-0/);
+    // After PR-3c-2 HeaderNav refactor (commit f45da08), the drawer is
+    // mounted/unmounted on `isOpen` (was `translate-x-*` slide pattern).
+    // The semantic intent of these assertions — "drawer reachable when
+    // open / gone after Escape" — stays identical.
+    await expect(drawer).toBeVisible();
 
     // Focus inside drawer to ensure keyboard listener is active
     const drawerLink = drawer.locator('a, button').first();
@@ -70,7 +74,7 @@ test.describe('Drawer Mobile Accessibility — Focus Trap (WCAG 2.1 2.4.3)', () 
     // Press Escape — drawer should close and checkbox should be unchecked
     await page.keyboard.press('Escape');
     await expect(checkbox).not.toBeChecked({ timeout: 500 });
-    await expect(drawer).toHaveClass(/translate-x-full/);
+    await expect(drawer).toHaveCount(0);
   });
 
   test('3. Focus cycles within drawer with Tab (focus trap)', async ({ page }) => {
@@ -79,7 +83,9 @@ test.describe('Drawer Mobile Accessibility — Focus Trap (WCAG 2.1 2.4.3)', () 
     await hamburger.click();
 
     const drawer = page.locator('nav[role="dialog"]');
-    await expect(drawer).toHaveClass(/translate-x-0/);
+    // Drawer is mounted on `isOpen` (PR-3c-2 conditional render) — visibility
+    // is the right semantic check, no longer the translate-x-0 class.
+    await expect(drawer).toBeVisible();
 
     // Focus first element in drawer
     const firstElement = drawer.locator('a, button, [tabindex="0"]').first();

--- a/e2e/landing-sections.spec.ts
+++ b/e2e/landing-sections.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E smoke for the cc-design landing assembly (PR-3c-2).
+ *
+ * Scope:
+ * - 8 sections render on `/` (MktNav, Hero, Principles, Feature, Pricing,
+ *   FAQ, FooterCTA, MktFooter).
+ * - FAQPage JSON-LD schema is emitted, parsable, and valid against
+ *   schema.org structure.
+ * - Mobile viewport (375px) doesn't introduce horizontal overflow.
+ *
+ * a11y is already covered by `e2e/a11y/baseline.spec.ts` which scans `/`
+ * with axe-core (PR #69 baseline). No duplication here.
+ */
+
+test.describe('Landing — cc-design sections smoke', () => {
+  test('renders all 8 sections on /', async ({ page }) => {
+    await page.goto('/');
+
+    // MktNav (header role) — has the site logo + nav landmarks
+    await expect(page.getByRole('banner')).toBeVisible();
+
+    // Hero h1 (the only h1 on the page)
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+
+    // Principles, Feature, Pricing, FAQ — distinct landmarks via id+aria-labelledby
+    await expect(page.locator('section#principles')).toBeVisible();
+    await expect(page.locator('section#feature')).toBeVisible();
+    await expect(page.locator('section#pricing')).toBeVisible();
+    await expect(page.locator('section#faq')).toBeVisible();
+
+    // FooterCTA + MktFooter
+    await expect(
+      page.getByRole('heading', { level: 2, name: /commence par ce qui est/i }),
+    ).toBeVisible();
+    await expect(page.getByRole('contentinfo')).toBeVisible();
+  });
+
+  test('emits a valid FAQPage JSON-LD schema with 3 questions', async ({ page }) => {
+    await page.goto('/');
+
+    const faqJsonLd = await page.locator('script[type="application/ld+json"]#ld-faq').innerHTML();
+
+    expect(faqJsonLd).toBeTruthy();
+    const parsed = JSON.parse(faqJsonLd);
+
+    expect(parsed['@context']).toBe('https://schema.org');
+    expect(parsed['@type']).toBe('FAQPage');
+    expect(parsed.mainEntity).toHaveLength(3);
+
+    for (const q of parsed.mainEntity) {
+      expect(q['@type']).toBe('Question');
+      expect(q.name).toBeTruthy();
+      expect(q.acceptedAnswer['@type']).toBe('Answer');
+      expect(q.acceptedAnswer.text).toBeTruthy();
+    }
+  });
+
+  test('also emits the SoftwareApplication JSON-LD (FinanceApplication)', async ({ page }) => {
+    await page.goto('/');
+
+    const softwareJsonLd = await page
+      .locator('script[type="application/ld+json"]#ld-software')
+      .innerHTML();
+
+    const parsed = JSON.parse(softwareJsonLd);
+    expect(parsed['@type']).toBe('SoftwareApplication');
+    expect(parsed.applicationCategory).toBe('FinanceApplication');
+    expect(parsed.offers.price).toBe('0');
+    expect(parsed.offers.priceCurrency).toBe('EUR');
+  });
+
+  test('mobile viewport (375px) has no horizontal overflow', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 800 });
+    await page.goto('/');
+    await page.waitForLoadState('load');
+
+    const overflow = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }));
+
+    // Allow a 1px tolerance for sub-pixel rounding (browsers report 375.5 etc.)
+    expect(overflow.scrollWidth - overflow.clientWidth).toBeLessThanOrEqual(1);
+  });
+
+  test('disabled MktNav links (Sécurité, Journal) expose aria-disabled on desktop viewport', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto('/');
+
+    const security = page.getByText('Sécurité').first();
+    await expect(security).toHaveAttribute('aria-disabled', 'true');
+
+    const journal = page.getByText('Journal').first();
+    await expect(journal).toHaveAttribute('aria-disabled', 'true');
+  });
+});

--- a/e2e/landing-sections.spec.ts
+++ b/e2e/landing-sections.spec.ts
@@ -40,7 +40,13 @@ test.describe('Landing — cc-design sections smoke', () => {
   test('emits a valid FAQPage JSON-LD schema with 3 questions', async ({ page }) => {
     await page.goto('/');
 
-    const faqJsonLd = await page.locator('script[type="application/ld+json"]#ld-faq').innerHTML();
+    // `<script>` tags are never "visible" to Playwright's locator API on
+    // mobile-safari (its visibility model is stricter than chromium's), so
+    // `locator.innerHTML()` times out. `page.evaluate()` reads the DOM
+    // directly without the visibility check — works in every project.
+    const faqJsonLd = await page.evaluate(
+      () => document.querySelector('script#ld-faq')?.textContent ?? '',
+    );
 
     expect(faqJsonLd).toBeTruthy();
     const parsed = JSON.parse(faqJsonLd);
@@ -60,10 +66,11 @@ test.describe('Landing — cc-design sections smoke', () => {
   test('also emits the SoftwareApplication JSON-LD (FinanceApplication)', async ({ page }) => {
     await page.goto('/');
 
-    const softwareJsonLd = await page
-      .locator('script[type="application/ld+json"]#ld-software')
-      .innerHTML();
+    const softwareJsonLd = await page.evaluate(
+      () => document.querySelector('script#ld-software')?.textContent ?? '',
+    );
 
+    expect(softwareJsonLd).toBeTruthy();
     const parsed = JSON.parse(softwareJsonLd);
     expect(parsed['@type']).toBe('SoftwareApplication');
     expect(parsed.applicationCategory).toBe('FinanceApplication');

--- a/e2e/landing-sections.spec.ts
+++ b/e2e/landing-sections.spec.ts
@@ -43,7 +43,13 @@ test.describe('Landing — cc-design sections smoke', () => {
     // `<script>` tags are never "visible" to Playwright's locator API on
     // mobile-safari (its visibility model is stricter than chromium's), so
     // `locator.innerHTML()` times out. `page.evaluate()` reads the DOM
-    // directly without the visibility check — works in every project.
+    // directly without the visibility check.
+    //
+    // `next/script` with the default `strategy="afterInteractive"` injects
+    // the <script> AFTER hydration — so we must `waitForSelector(state:
+    // 'attached')` before reading, otherwise `page.evaluate` snapshots an
+    // empty `textContent` (no visibility check, but no retry either).
+    await page.waitForSelector('script#ld-faq', { state: 'attached' });
     const faqJsonLd = await page.evaluate(
       () => document.querySelector('script#ld-faq')?.textContent ?? '',
     );
@@ -66,6 +72,9 @@ test.describe('Landing — cc-design sections smoke', () => {
   test('also emits the SoftwareApplication JSON-LD (FinanceApplication)', async ({ page }) => {
     await page.goto('/');
 
+    // Same hydration timing as #ld-faq — wait for the <script> to attach
+    // before evaluating its textContent (prevents anti-flakiness).
+    await page.waitForSelector('script#ld-software', { state: 'attached' });
     const softwareJsonLd = await page.evaluate(
       () => document.querySelector('script#ld-software')?.textContent ?? '',
     );

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -2,9 +2,16 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Marketing — smoke', () => {
   test('home page renders CTA and navigation', async ({ page }) => {
+    // Force a desktop viewport — MktNav (PR-3c-2) hides the Login + Try-free
+    // CTAs below `sm` (640px), exposing them only via the mobile drawer.
+    // This smoke test is about the visible-by-default top-nav CTAs, not the
+    // drawer (which has its own coverage in landing-sections.spec.ts).
+    await page.setViewportSize({ width: 1280, height: 800 });
     await page.goto('/');
     await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
-    await expect(page.getByRole('link', { name: /créer un compte/i }).first()).toBeVisible();
+    // CTA labels updated by PR-3c-2 MktNav: "Créer un compte" → "Essayer
+    // gratuitement"; "Se connecter" stayed identical.
+    await expect(page.getByRole('link', { name: /essayer gratuitement/i }).first()).toBeVisible();
     await expect(page.getByRole('link', { name: /se connecter/i }).first()).toBeVisible();
   });
 

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -141,6 +141,108 @@
         "body": "Das Cockpit sagt dir, wie viel du überweisen, wie viel du behalten sollst, und ob du deinen Rücklagen voraus oder hinterher bist."
       }
     },
+    "mktnav": {
+      "links": {
+        "product": "Produit",
+        "simulator": "Simulateur",
+        "pricing": "Tarifs",
+        "security": "Sécurité",
+        "journal": "Journal"
+      },
+      "ctaLogin": "Se connecter",
+      "ctaSignup": "Essayer gratuitement"
+    },
+    "hero": {
+      "badge": "Nouveau · Simulateur what-if",
+      "h1Lead": "Ton ancrage",
+      "h1Highlight": "financier.",
+      "description": "Ankora sépare tes provisions affectées de ta réserve libre, projette six mois devant, et te laisse simuler l'impact de chaque décision — en clair, sans jargon.",
+      "ctaPrimary": "Ouvrir mon cockpit",
+      "ctaSecondary": "Voir le simulateur",
+      "trust": {
+        "encrypted": "Données chiffrées en Belgique",
+        "noSale": "Aucune vente de données",
+        "languages": "FR · NL · EN"
+      },
+      "mockup": {
+        "eyebrow": "Aperçu cockpit",
+        "browserUrl": "app.ankora.be · cockpit",
+        "kpis": {
+          "netRemaining": { "label": "Net restant", "sub": "avril · après provisions" },
+          "provisions": { "label": "Provisions", "sub": "67 % des 2 480 € planifiés" },
+          "reserve": { "label": "Réserve", "sub": "+120 € vs. mars" }
+        }
+      }
+    },
+    "principles": {
+      "eyebrow": "Trois principes",
+      "h2": "Une façon honnête de parler d'argent.",
+      "description": "Ankora n'essaye pas de te vendre un placement ou une carte. On sépare, on projette, on simule. C'est tout. Toi seul décides.",
+      "items": {
+        "provisions": {
+          "title": "Provisions affectées",
+          "description": "Chaque euro réservé a un nom : mutuelle, taxe circulation, entretien chaudière. Rien ne fuit sans que tu le saches."
+        },
+        "reserve": {
+          "title": "Réserve libre",
+          "description": "Ce qui reste vraiment à toi, après les engagements. Le vrai chiffre — pas l'illusion du solde brut."
+        },
+        "whatIf": {
+          "title": "Simulateur what-if",
+          "description": "Renégocier l'électricité ? Changer de fournisseur ? Ankora te montre l'impact sur 12 mois avant que tu décides."
+        }
+      }
+    },
+    "feature": {
+      "eyebrow": "Cashflow waterfall",
+      "h3Line1": "Du salaire au net disponible.",
+      "h3Line2": "En un seul coup d'œil.",
+      "description": "Plus de mystère sur où va ton argent. Chaque étape est visible : salaire, provisions affectées, vie courante, réserve. Tu vois immédiatement si un poste dérape.",
+      "ctaPrimary": "Voir un exemple",
+      "ctaSecondary": "Comment ça marche ?",
+      "bars": {
+        "salary": "Salaire",
+        "provisions": "Provisions",
+        "life": "Vie",
+        "reserve": "Réserve",
+        "remaining": "Reste"
+      }
+    },
+    "pricing": {
+      "eyebrow": "Transparent dès le départ",
+      "h2": "Gratuit pendant la Phase 1.",
+      "phaseBadge": "Phase 1 · construction",
+      "price": "0 €",
+      "period": "pour l'instant, et sans date limite",
+      "body": "On construit d'abord le cockpit. Pas de carte demandée, pas de limite de temps, pas de fonctionnalité bridée. Export RGPD à tout moment.",
+      "features": {
+        "cockpit": "Cockpit complet, provisions et réserve libre",
+        "simulator": "Simulateur what-if illimité",
+        "manualEntry": "Saisie manuelle · tes données restent en Belgique",
+        "export": "Export RGPD en un clic"
+      },
+      "ctaPrimary": "Ouvrir mon cockpit",
+      "roadmap": {
+        "title": "Tu rejoins Ankora pendant sa Phase 1 ?",
+        "body": "Ton compte garde un accès complet au cockpit core à vie, gratuitement. Une offre Pro avec features avancées (comptes illimités, exports consolidés, support prioritaire) arrivera post-v1.0 — tu auras le choix d'upgrader ou de rester sur ton plan actuel.",
+        "link": "Lire la roadmap →"
+      }
+    },
+    "footerCta": {
+      "h2Lead": "Commence par ce qui est",
+      "h2Highlight": "déjà à toi.",
+      "description": "30 jours d'essai, pas de carte, export RGPD à tout moment. On fait simple parce que c'est déjà assez compliqué comme ça.",
+      "ctaPrimary": "Ouvrir mon cockpit"
+    },
+    "footer": {
+      "links": {
+        "terms": "Conditions",
+        "privacy": "Confidentialité",
+        "security": "Sécurité",
+        "contact": "Contact"
+      },
+      "copyright": "Ankora · éditeur ancré à Bruxelles · 2026"
+    },
     "faqHeading": "Häufige Fragen",
     "faq": {
       "advice": {

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -105,42 +105,6 @@
     }
   },
   "landing": {
-    "badge": "In Entwicklung · Start 2026",
-    "heroCtaPrimary": "Mein Cockpit erstellen",
-    "heroCtaSecondary": "Entdecken",
-    "featuresHeading": "Drei Säulen, null Stress",
-    "features": {
-      "smoothing": {
-        "title": "Automatische Verteilung",
-        "body": "Deine Jahres- oder Quartalsrechnungen werden auf 12 Monate verteilt. Keine bösen Überraschungen mehr am Jahresende."
-      },
-      "assistant": {
-        "title": "Überweisungsassistent",
-        "body": "Jeden Monat sagt dir Ankora genau, wie viel du auf deine Ersparnisse überweisen sollst — und wie viel du auf deinem Girokonto für die Rechnungen des Monats behalten sollst."
-      },
-      "secure": {
-        "title": "Isoliert und sicher",
-        "body": "Deine Daten verlassen deinen privaten Bereich nicht. Verschlüsselung, RLS und Audit-Logs standardmäßig. Hosting in der EU."
-      }
-    },
-    "howHeading": "So funktioniert's",
-    "steps": {
-      "one": {
-        "n": "01",
-        "title": "Trage deine Fixkosten ein",
-        "body": "Miete, Versicherungen, Abos… sortiert nach Kategorie und Frequenz."
-      },
-      "two": {
-        "n": "02",
-        "title": "Ankora verteilt",
-        "body": "Jede Jahresrechnung wird auf 12 Monate verteilt, um deine ideale Rücklage zu berechnen."
-      },
-      "three": {
-        "n": "03",
-        "title": "Steuere deinen Monat",
-        "body": "Das Cockpit sagt dir, wie viel du überweisen, wie viel du behalten sollst, und ob du deinen Rücklagen voraus oder hinterher bist."
-      }
-    },
     "mktnav": {
       "links": {
         "product": "Produit",

--- a/messages/en.json
+++ b/messages/en.json
@@ -105,42 +105,6 @@
     }
   },
   "landing": {
-    "badge": "In development · launching 2026",
-    "heroCtaPrimary": "Create my cockpit",
-    "heroCtaSecondary": "Learn more",
-    "featuresHeading": "Three pillars, zero stress",
-    "features": {
-      "smoothing": {
-        "title": "Automatic smoothing",
-        "body": "Your annual and quarterly bills spread across 12 months. No more nasty surprises at year-end."
-      },
-      "assistant": {
-        "title": "Transfer assistant",
-        "body": "Every month, Ankora tells you exactly how much to transfer to your savings — and how much to keep in your current account for this month's bills."
-      },
-      "secure": {
-        "title": "Isolated and secure",
-        "body": "Your data never leaves your private space. Encryption, RLS and audit logs by default. EU hosting."
-      }
-    },
-    "howHeading": "How it works",
-    "steps": {
-      "one": {
-        "n": "01",
-        "title": "Enter your bills",
-        "body": "Rent, insurance, subscriptions… sorted by category and frequency."
-      },
-      "two": {
-        "n": "02",
-        "title": "Ankora smooths",
-        "body": "Each annual bill is spread across 12 months to calculate your ideal reserve."
-      },
-      "three": {
-        "n": "03",
-        "title": "Steer your month",
-        "body": "The cockpit tells you how much to transfer, how much to keep, and whether you're ahead or behind on your reserves."
-      }
-    },
     "mktnav": {
       "links": {
         "product": "Product",

--- a/messages/en.json
+++ b/messages/en.json
@@ -141,6 +141,108 @@
         "body": "The cockpit tells you how much to transfer, how much to keep, and whether you're ahead or behind on your reserves."
       }
     },
+    "mktnav": {
+      "links": {
+        "product": "Product",
+        "simulator": "Simulator",
+        "pricing": "Pricing",
+        "security": "Security",
+        "journal": "Journal"
+      },
+      "ctaLogin": "Log in",
+      "ctaSignup": "Try for free"
+    },
+    "hero": {
+      "badge": "New · What-if simulator",
+      "h1Lead": "Your financial",
+      "h1Highlight": "anchor.",
+      "description": "Ankora separates your earmarked provisions from your free reserve, projects six months ahead, and lets you simulate the impact of every decision — clearly, without jargon.",
+      "ctaPrimary": "Open my cockpit",
+      "ctaSecondary": "See the simulator",
+      "trust": {
+        "encrypted": "Data encrypted in Belgium",
+        "noSale": "No data selling",
+        "languages": "FR · NL · EN"
+      },
+      "mockup": {
+        "eyebrow": "Cockpit preview",
+        "browserUrl": "app.ankora.be · cockpit",
+        "kpis": {
+          "netRemaining": { "label": "Net remaining", "sub": "April · after provisions" },
+          "provisions": { "label": "Provisions", "sub": "67% of €2,480 planned" },
+          "reserve": { "label": "Reserve", "sub": "+€120 vs. March" }
+        }
+      }
+    },
+    "principles": {
+      "eyebrow": "Three principles",
+      "h2": "An honest way to talk about money.",
+      "description": "Ankora isn't trying to sell you an investment or a card. We separate, we project, we simulate. That's it. You alone decide.",
+      "items": {
+        "provisions": {
+          "title": "Earmarked provisions",
+          "description": "Every reserved euro has a name: insurance, road tax, boiler maintenance. Nothing slips away without you knowing."
+        },
+        "reserve": {
+          "title": "Free reserve",
+          "description": "What's actually yours, after commitments. The real number — not the illusion of a gross balance."
+        },
+        "whatIf": {
+          "title": "What-if simulator",
+          "description": "Renegotiate electricity? Switch provider? Ankora shows you the impact over 12 months before you decide."
+        }
+      }
+    },
+    "feature": {
+      "eyebrow": "Cashflow waterfall",
+      "h3Line1": "From salary to net available.",
+      "h3Line2": "At a single glance.",
+      "description": "No more mystery about where your money goes. Every step is visible: salary, earmarked provisions, daily life, reserve. You see immediately if anything drifts.",
+      "ctaPrimary": "See an example",
+      "ctaSecondary": "How does it work?",
+      "bars": {
+        "salary": "Salary",
+        "provisions": "Provisions",
+        "life": "Life",
+        "reserve": "Reserve",
+        "remaining": "Remaining"
+      }
+    },
+    "pricing": {
+      "eyebrow": "Transparent from the start",
+      "h2": "Free during Phase 1.",
+      "phaseBadge": "Phase 1 · building",
+      "price": "€0",
+      "period": "for now, with no end date",
+      "body": "We're building the cockpit first. No card asked, no time limit, no feature gating. GDPR export anytime.",
+      "features": {
+        "cockpit": "Full cockpit, provisions and free reserve",
+        "simulator": "Unlimited what-if simulator",
+        "manualEntry": "Manual entry · your data stays in Belgium",
+        "export": "GDPR export in one click"
+      },
+      "ctaPrimary": "Open my cockpit",
+      "roadmap": {
+        "title": "Joining Ankora during Phase 1?",
+        "body": "Your account keeps full lifetime access to the core cockpit, free. A Pro tier with advanced features (unlimited accounts, consolidated exports, priority support) will arrive post-v1.0 — you'll choose to upgrade or stay on your current plan.",
+        "link": "Read the roadmap →"
+      }
+    },
+    "footerCta": {
+      "h2Lead": "Start with what's",
+      "h2Highlight": "already yours.",
+      "description": "30-day trial, no card, GDPR export anytime. We keep it simple because it's already complicated enough.",
+      "ctaPrimary": "Open my cockpit"
+    },
+    "footer": {
+      "links": {
+        "terms": "Terms",
+        "privacy": "Privacy",
+        "security": "Security",
+        "contact": "Contact"
+      },
+      "copyright": "Ankora · Brussels-anchored editor · 2026"
+    },
     "faqHeading": "Frequently asked questions",
     "faq": {
       "advice": {

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -141,6 +141,108 @@
         "body": "El cockpit te dice cuánto transferir, cuánto dejar y si vas por delante o por detrás de tus reservas."
       }
     },
+    "mktnav": {
+      "links": {
+        "product": "Produit",
+        "simulator": "Simulateur",
+        "pricing": "Tarifs",
+        "security": "Sécurité",
+        "journal": "Journal"
+      },
+      "ctaLogin": "Se connecter",
+      "ctaSignup": "Essayer gratuitement"
+    },
+    "hero": {
+      "badge": "Nouveau · Simulateur what-if",
+      "h1Lead": "Ton ancrage",
+      "h1Highlight": "financier.",
+      "description": "Ankora sépare tes provisions affectées de ta réserve libre, projette six mois devant, et te laisse simuler l'impact de chaque décision — en clair, sans jargon.",
+      "ctaPrimary": "Ouvrir mon cockpit",
+      "ctaSecondary": "Voir le simulateur",
+      "trust": {
+        "encrypted": "Données chiffrées en Belgique",
+        "noSale": "Aucune vente de données",
+        "languages": "FR · NL · EN"
+      },
+      "mockup": {
+        "eyebrow": "Aperçu cockpit",
+        "browserUrl": "app.ankora.be · cockpit",
+        "kpis": {
+          "netRemaining": { "label": "Net restant", "sub": "avril · après provisions" },
+          "provisions": { "label": "Provisions", "sub": "67 % des 2 480 € planifiés" },
+          "reserve": { "label": "Réserve", "sub": "+120 € vs. mars" }
+        }
+      }
+    },
+    "principles": {
+      "eyebrow": "Trois principes",
+      "h2": "Une façon honnête de parler d'argent.",
+      "description": "Ankora n'essaye pas de te vendre un placement ou une carte. On sépare, on projette, on simule. C'est tout. Toi seul décides.",
+      "items": {
+        "provisions": {
+          "title": "Provisions affectées",
+          "description": "Chaque euro réservé a un nom : mutuelle, taxe circulation, entretien chaudière. Rien ne fuit sans que tu le saches."
+        },
+        "reserve": {
+          "title": "Réserve libre",
+          "description": "Ce qui reste vraiment à toi, après les engagements. Le vrai chiffre — pas l'illusion du solde brut."
+        },
+        "whatIf": {
+          "title": "Simulateur what-if",
+          "description": "Renégocier l'électricité ? Changer de fournisseur ? Ankora te montre l'impact sur 12 mois avant que tu décides."
+        }
+      }
+    },
+    "feature": {
+      "eyebrow": "Cashflow waterfall",
+      "h3Line1": "Du salaire au net disponible.",
+      "h3Line2": "En un seul coup d'œil.",
+      "description": "Plus de mystère sur où va ton argent. Chaque étape est visible : salaire, provisions affectées, vie courante, réserve. Tu vois immédiatement si un poste dérape.",
+      "ctaPrimary": "Voir un exemple",
+      "ctaSecondary": "Comment ça marche ?",
+      "bars": {
+        "salary": "Salaire",
+        "provisions": "Provisions",
+        "life": "Vie",
+        "reserve": "Réserve",
+        "remaining": "Reste"
+      }
+    },
+    "pricing": {
+      "eyebrow": "Transparent dès le départ",
+      "h2": "Gratuit pendant la Phase 1.",
+      "phaseBadge": "Phase 1 · construction",
+      "price": "0 €",
+      "period": "pour l'instant, et sans date limite",
+      "body": "On construit d'abord le cockpit. Pas de carte demandée, pas de limite de temps, pas de fonctionnalité bridée. Export RGPD à tout moment.",
+      "features": {
+        "cockpit": "Cockpit complet, provisions et réserve libre",
+        "simulator": "Simulateur what-if illimité",
+        "manualEntry": "Saisie manuelle · tes données restent en Belgique",
+        "export": "Export RGPD en un clic"
+      },
+      "ctaPrimary": "Ouvrir mon cockpit",
+      "roadmap": {
+        "title": "Tu rejoins Ankora pendant sa Phase 1 ?",
+        "body": "Ton compte garde un accès complet au cockpit core à vie, gratuitement. Une offre Pro avec features avancées (comptes illimités, exports consolidés, support prioritaire) arrivera post-v1.0 — tu auras le choix d'upgrader ou de rester sur ton plan actuel.",
+        "link": "Lire la roadmap →"
+      }
+    },
+    "footerCta": {
+      "h2Lead": "Commence par ce qui est",
+      "h2Highlight": "déjà à toi.",
+      "description": "30 jours d'essai, pas de carte, export RGPD à tout moment. On fait simple parce que c'est déjà assez compliqué comme ça.",
+      "ctaPrimary": "Ouvrir mon cockpit"
+    },
+    "footer": {
+      "links": {
+        "terms": "Conditions",
+        "privacy": "Confidentialité",
+        "security": "Sécurité",
+        "contact": "Contact"
+      },
+      "copyright": "Ankora · éditeur ancré à Bruxelles · 2026"
+    },
     "faqHeading": "Preguntas frecuentes",
     "faq": {
       "advice": {

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -105,42 +105,6 @@
     }
   },
   "landing": {
-    "badge": "En construcción · lanzamiento 2026",
-    "heroCtaPrimary": "Crear mi cockpit",
-    "heroCtaSecondary": "Descubrir",
-    "featuresHeading": "Tres pilares, cero estrés",
-    "features": {
-      "smoothing": {
-        "title": "Distribución automática",
-        "body": "Tus facturas anuales o trimestrales repartidas en 12 meses. Nunca más sorpresas a final de año."
-      },
-      "assistant": {
-        "title": "Asistente de transferencias",
-        "body": "Cada mes, Ankora te dice exactamente cuánto transferir a tu ahorro — y cuánto dejar en tu cuenta corriente para las facturas del mes."
-      },
-      "secure": {
-        "title": "Aislado y seguro",
-        "body": "Tus datos no salen de tu espacio privado. Cifrado, RLS y audit logs por defecto. Hospedaje en la UE."
-      }
-    },
-    "howHeading": "Cómo funciona",
-    "steps": {
-      "one": {
-        "n": "01",
-        "title": "Introduce tus gastos fijos",
-        "body": "Alquiler, seguros, suscripciones… clasificados por categoría y frecuencia."
-      },
-      "two": {
-        "n": "02",
-        "title": "Ankora distribuye",
-        "body": "Cada factura anual se reparte en 12 meses para calcular tu reserva ideal."
-      },
-      "three": {
-        "n": "03",
-        "title": "Pilota tu mes",
-        "body": "El cockpit te dice cuánto transferir, cuánto dejar y si vas por delante o por detrás de tus reservas."
-      }
-    },
     "mktnav": {
       "links": {
         "product": "Produit",

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -105,42 +105,6 @@
     }
   },
   "landing": {
-    "badge": "En construction · lancement 2026",
-    "heroCtaPrimary": "Créer mon cockpit",
-    "heroCtaSecondary": "Découvrir",
-    "featuresHeading": "Trois piliers, zéro angoisse",
-    "features": {
-      "smoothing": {
-        "title": "Lissage automatique",
-        "body": "Tes factures annuelles ou trimestrielles réparties sur 12 mois. Plus jamais de mauvaise surprise en fin d'année."
-      },
-      "assistant": {
-        "title": "Assistant virements",
-        "body": "Chaque mois, Ankora te dit exactement combien virer vers ton épargne — et combien garder sur ton courant pour les factures du mois."
-      },
-      "secure": {
-        "title": "Isolé et sécurisé",
-        "body": "Tes données ne sortent pas de ton espace privé. Chiffrement, RLS et audit logs par défaut. Hébergement UE."
-      }
-    },
-    "howHeading": "Comment ça marche",
-    "steps": {
-      "one": {
-        "n": "01",
-        "title": "Renseigne tes charges",
-        "body": "Loyer, assurances, abonnements… classés par catégorie et fréquence."
-      },
-      "two": {
-        "n": "02",
-        "title": "Ankora lisse",
-        "body": "Chaque facture annuelle est répartie sur les 12 mois pour calculer ta provision idéale."
-      },
-      "three": {
-        "n": "03",
-        "title": "Pilote ton mois",
-        "body": "Le cockpit te dit combien virer, combien garder, et si tu es en avance ou en retard sur tes provisions."
-      }
-    },
     "mktnav": {
       "links": {
         "product": "Produit",

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -141,6 +141,108 @@
         "body": "Le cockpit te dit combien virer, combien garder, et si tu es en avance ou en retard sur tes provisions."
       }
     },
+    "mktnav": {
+      "links": {
+        "product": "Produit",
+        "simulator": "Simulateur",
+        "pricing": "Tarifs",
+        "security": "Sécurité",
+        "journal": "Journal"
+      },
+      "ctaLogin": "Se connecter",
+      "ctaSignup": "Essayer gratuitement"
+    },
+    "hero": {
+      "badge": "Nouveau · Simulateur what-if",
+      "h1Lead": "Ton ancrage",
+      "h1Highlight": "financier.",
+      "description": "Ankora sépare tes provisions affectées de ta réserve libre, projette six mois devant, et te laisse simuler l'impact de chaque décision — en clair, sans jargon.",
+      "ctaPrimary": "Ouvrir mon cockpit",
+      "ctaSecondary": "Voir le simulateur",
+      "trust": {
+        "encrypted": "Données chiffrées en Belgique",
+        "noSale": "Aucune vente de données",
+        "languages": "FR · NL · EN"
+      },
+      "mockup": {
+        "eyebrow": "Aperçu cockpit",
+        "browserUrl": "app.ankora.be · cockpit",
+        "kpis": {
+          "netRemaining": { "label": "Net restant", "sub": "avril · après provisions" },
+          "provisions": { "label": "Provisions", "sub": "67 % des 2 480 € planifiés" },
+          "reserve": { "label": "Réserve", "sub": "+120 € vs. mars" }
+        }
+      }
+    },
+    "principles": {
+      "eyebrow": "Trois principes",
+      "h2": "Une façon honnête de parler d'argent.",
+      "description": "Ankora n'essaye pas de te vendre un placement ou une carte. On sépare, on projette, on simule. C'est tout. Toi seul décides.",
+      "items": {
+        "provisions": {
+          "title": "Provisions affectées",
+          "description": "Chaque euro réservé a un nom : mutuelle, taxe circulation, entretien chaudière. Rien ne fuit sans que tu le saches."
+        },
+        "reserve": {
+          "title": "Réserve libre",
+          "description": "Ce qui reste vraiment à toi, après les engagements. Le vrai chiffre — pas l'illusion du solde brut."
+        },
+        "whatIf": {
+          "title": "Simulateur what-if",
+          "description": "Renégocier l'électricité ? Changer de fournisseur ? Ankora te montre l'impact sur 12 mois avant que tu décides."
+        }
+      }
+    },
+    "feature": {
+      "eyebrow": "Cashflow waterfall",
+      "h3Line1": "Du salaire au net disponible.",
+      "h3Line2": "En un seul coup d'œil.",
+      "description": "Plus de mystère sur où va ton argent. Chaque étape est visible : salaire, provisions affectées, vie courante, réserve. Tu vois immédiatement si un poste dérape.",
+      "ctaPrimary": "Voir un exemple",
+      "ctaSecondary": "Comment ça marche ?",
+      "bars": {
+        "salary": "Salaire",
+        "provisions": "Provisions",
+        "life": "Vie",
+        "reserve": "Réserve",
+        "remaining": "Reste"
+      }
+    },
+    "pricing": {
+      "eyebrow": "Transparent dès le départ",
+      "h2": "Gratuit pendant la Phase 1.",
+      "phaseBadge": "Phase 1 · construction",
+      "price": "0 €",
+      "period": "pour l'instant, et sans date limite",
+      "body": "On construit d'abord le cockpit. Pas de carte demandée, pas de limite de temps, pas de fonctionnalité bridée. Export RGPD à tout moment.",
+      "features": {
+        "cockpit": "Cockpit complet, provisions et réserve libre",
+        "simulator": "Simulateur what-if illimité",
+        "manualEntry": "Saisie manuelle · tes données restent en Belgique",
+        "export": "Export RGPD en un clic"
+      },
+      "ctaPrimary": "Ouvrir mon cockpit",
+      "roadmap": {
+        "title": "Tu rejoins Ankora pendant sa Phase 1 ?",
+        "body": "Ton compte garde un accès complet au cockpit core à vie, gratuitement. Une offre Pro avec features avancées (comptes illimités, exports consolidés, support prioritaire) arrivera post-v1.0 — tu auras le choix d'upgrader ou de rester sur ton plan actuel.",
+        "link": "Lire la roadmap →"
+      }
+    },
+    "footerCta": {
+      "h2Lead": "Commence par ce qui est",
+      "h2Highlight": "déjà à toi.",
+      "description": "30 jours d'essai, pas de carte, export RGPD à tout moment. On fait simple parce que c'est déjà assez compliqué comme ça.",
+      "ctaPrimary": "Ouvrir mon cockpit"
+    },
+    "footer": {
+      "links": {
+        "terms": "Conditions",
+        "privacy": "Confidentialité",
+        "security": "Sécurité",
+        "contact": "Contact"
+      },
+      "copyright": "Ankora · éditeur ancré à Bruxelles · 2026"
+    },
     "faqHeading": "Questions fréquentes",
     "faq": {
       "advice": {

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -105,42 +105,6 @@
     }
   },
   "landing": {
-    "badge": "In opbouw · lancering 2026",
-    "heroCtaPrimary": "Mijn cockpit aanmaken",
-    "heroCtaSecondary": "Ontdekken",
-    "featuresHeading": "Drie pijlers, nul stress",
-    "features": {
-      "smoothing": {
-        "title": "Automatische spreiding",
-        "body": "Je jaarlijkse of driemaandelijkse facturen gespreid over 12 maanden. Nooit meer vervelende verrassingen op het einde van het jaar."
-      },
-      "assistant": {
-        "title": "Overschrijvingsassistent",
-        "body": "Elke maand zegt Ankora je precies hoeveel je naar je spaargeld moet overschrijven — en hoeveel je op je zichtrekening moet houden voor de facturen van de maand."
-      },
-      "secure": {
-        "title": "Afgeschermd en beveiligd",
-        "body": "Je gegevens verlaten nooit je eigen private ruimte. Versleuteling, RLS en audit logs standaard. Hosting in de EU."
-      }
-    },
-    "howHeading": "Hoe het werkt",
-    "steps": {
-      "one": {
-        "n": "01",
-        "title": "Geef je vaste kosten in",
-        "body": "Huur, verzekeringen, abonnementen… geordend per categorie en frequentie."
-      },
-      "two": {
-        "n": "02",
-        "title": "Ankora spreidt",
-        "body": "Elke jaarlijkse factuur wordt over 12 maanden verdeeld om je ideale voorziening te berekenen."
-      },
-      "three": {
-        "n": "03",
-        "title": "Stuur je maand",
-        "body": "De cockpit zegt je hoeveel je moet overschrijven, hoeveel je moet houden, en of je voor of achter staat op je voorzieningen."
-      }
-    },
     "mktnav": {
       "links": {
         "product": "Produit",

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -141,6 +141,108 @@
         "body": "De cockpit zegt je hoeveel je moet overschrijven, hoeveel je moet houden, en of je voor of achter staat op je voorzieningen."
       }
     },
+    "mktnav": {
+      "links": {
+        "product": "Produit",
+        "simulator": "Simulateur",
+        "pricing": "Tarifs",
+        "security": "Sécurité",
+        "journal": "Journal"
+      },
+      "ctaLogin": "Se connecter",
+      "ctaSignup": "Essayer gratuitement"
+    },
+    "hero": {
+      "badge": "Nouveau · Simulateur what-if",
+      "h1Lead": "Ton ancrage",
+      "h1Highlight": "financier.",
+      "description": "Ankora sépare tes provisions affectées de ta réserve libre, projette six mois devant, et te laisse simuler l'impact de chaque décision — en clair, sans jargon.",
+      "ctaPrimary": "Ouvrir mon cockpit",
+      "ctaSecondary": "Voir le simulateur",
+      "trust": {
+        "encrypted": "Données chiffrées en Belgique",
+        "noSale": "Aucune vente de données",
+        "languages": "FR · NL · EN"
+      },
+      "mockup": {
+        "eyebrow": "Aperçu cockpit",
+        "browserUrl": "app.ankora.be · cockpit",
+        "kpis": {
+          "netRemaining": { "label": "Net restant", "sub": "avril · après provisions" },
+          "provisions": { "label": "Provisions", "sub": "67 % des 2 480 € planifiés" },
+          "reserve": { "label": "Réserve", "sub": "+120 € vs. mars" }
+        }
+      }
+    },
+    "principles": {
+      "eyebrow": "Trois principes",
+      "h2": "Une façon honnête de parler d'argent.",
+      "description": "Ankora n'essaye pas de te vendre un placement ou une carte. On sépare, on projette, on simule. C'est tout. Toi seul décides.",
+      "items": {
+        "provisions": {
+          "title": "Provisions affectées",
+          "description": "Chaque euro réservé a un nom : mutuelle, taxe circulation, entretien chaudière. Rien ne fuit sans que tu le saches."
+        },
+        "reserve": {
+          "title": "Réserve libre",
+          "description": "Ce qui reste vraiment à toi, après les engagements. Le vrai chiffre — pas l'illusion du solde brut."
+        },
+        "whatIf": {
+          "title": "Simulateur what-if",
+          "description": "Renégocier l'électricité ? Changer de fournisseur ? Ankora te montre l'impact sur 12 mois avant que tu décides."
+        }
+      }
+    },
+    "feature": {
+      "eyebrow": "Cashflow waterfall",
+      "h3Line1": "Du salaire au net disponible.",
+      "h3Line2": "En un seul coup d'œil.",
+      "description": "Plus de mystère sur où va ton argent. Chaque étape est visible : salaire, provisions affectées, vie courante, réserve. Tu vois immédiatement si un poste dérape.",
+      "ctaPrimary": "Voir un exemple",
+      "ctaSecondary": "Comment ça marche ?",
+      "bars": {
+        "salary": "Salaire",
+        "provisions": "Provisions",
+        "life": "Vie",
+        "reserve": "Réserve",
+        "remaining": "Reste"
+      }
+    },
+    "pricing": {
+      "eyebrow": "Transparent dès le départ",
+      "h2": "Gratuit pendant la Phase 1.",
+      "phaseBadge": "Phase 1 · construction",
+      "price": "0 €",
+      "period": "pour l'instant, et sans date limite",
+      "body": "On construit d'abord le cockpit. Pas de carte demandée, pas de limite de temps, pas de fonctionnalité bridée. Export RGPD à tout moment.",
+      "features": {
+        "cockpit": "Cockpit complet, provisions et réserve libre",
+        "simulator": "Simulateur what-if illimité",
+        "manualEntry": "Saisie manuelle · tes données restent en Belgique",
+        "export": "Export RGPD en un clic"
+      },
+      "ctaPrimary": "Ouvrir mon cockpit",
+      "roadmap": {
+        "title": "Tu rejoins Ankora pendant sa Phase 1 ?",
+        "body": "Ton compte garde un accès complet au cockpit core à vie, gratuitement. Une offre Pro avec features avancées (comptes illimités, exports consolidés, support prioritaire) arrivera post-v1.0 — tu auras le choix d'upgrader ou de rester sur ton plan actuel.",
+        "link": "Lire la roadmap →"
+      }
+    },
+    "footerCta": {
+      "h2Lead": "Commence par ce qui est",
+      "h2Highlight": "déjà à toi.",
+      "description": "30 jours d'essai, pas de carte, export RGPD à tout moment. On fait simple parce que c'est déjà assez compliqué comme ça.",
+      "ctaPrimary": "Ouvrir mon cockpit"
+    },
+    "footer": {
+      "links": {
+        "terms": "Conditions",
+        "privacy": "Confidentialité",
+        "security": "Sécurité",
+        "contact": "Contact"
+      },
+      "copyright": "Ankora · éditeur ancré à Bruxelles · 2026"
+    },
     "faqHeading": "Veelgestelde vragen",
     "faq": {
       "advice": {

--- a/src/app/[locale]/(public)/page.tsx
+++ b/src/app/[locale]/(public)/page.tsx
@@ -2,14 +2,12 @@ import type { Metadata } from 'next';
 import { getNonce } from '@/lib/security/nonce';
 import Script from 'next/script';
 import { getTranslations } from 'next-intl/server';
-import { ArrowRight, Shield, TrendingUp, Wallet } from 'lucide-react';
 
-import { Link } from '@/i18n/navigation';
 import type { Locale } from '@/i18n/routing';
 import { SITE } from '@/lib/site';
-import { Header } from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer';
-import { Button } from '@/components/ui/button';
+import { Hero } from '@/components/marketing/landing/sections/Hero';
+import { MktNav } from '@/components/marketing/landing/sections/MktNav';
 
 type LocaleParams = { params: Promise<{ locale: string }> };
 
@@ -22,9 +20,6 @@ export async function generateMetadata({ params }: LocaleParams): Promise<Metada
   };
 }
 
-const FEATURE_KEYS = ['smoothing', 'assistant', 'secure'] as const;
-const FEATURE_ICONS = { smoothing: TrendingUp, assistant: Wallet, secure: Shield } as const;
-const STEP_KEYS = ['one', 'two', 'three'] as const;
 const FAQ_KEYS = ['advice', 'storage', 'sharing'] as const;
 
 export default async function HomePage({ params }: LocaleParams) {
@@ -63,74 +58,14 @@ export default async function HomePage({ params }: LocaleParams) {
         {JSON.stringify(faqJsonLd)}
       </Script>
 
-      <Header />
+      <MktNav />
 
       <main id="main" tabIndex={-1}>
-        <section className="mx-auto max-w-6xl px-4 pt-20 pb-16 md:px-6 md:pt-28">
-          <div className="mx-auto max-w-3xl text-center">
-            <p className="border-border bg-card text-brand-700 mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium">
-              <span className="bg-brand-500 inline-block h-2 w-2 rounded-full" />
-              {t('badge')}
-            </p>
-            <h1 className="text-foreground text-4xl font-bold tracking-tight text-balance md:text-6xl">
-              {tCommon('tagline')}.
-            </h1>
-            <p className="text-muted-foreground mx-auto mt-6 max-w-2xl text-lg text-pretty">
-              {tCommon('description')}
-            </p>
-            <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row">
-              <Button asChild size="lg">
-                <Link href="/signup">
-                  {t('heroCtaPrimary')}
-                  <ArrowRight className="h-4 w-4" aria-hidden />
-                </Link>
-              </Button>
-              <Button asChild variant="outline" size="lg">
-                <Link href="#features">{t('heroCtaSecondary')}</Link>
-              </Button>
-            </div>
-          </div>
-        </section>
+        <Hero />
 
-        <section
-          id="features"
-          aria-labelledby="features-heading"
-          className="mx-auto max-w-6xl px-4 py-16 md:px-6"
-        >
-          <h2 id="features-heading" className="mb-12 text-center text-3xl font-bold tracking-tight">
-            {t('featuresHeading')}
-          </h2>
-          <ul className="grid gap-6 md:grid-cols-3">
-            {FEATURE_KEYS.map((key) => {
-              const Icon = FEATURE_ICONS[key];
-              return (
-                <li key={key} className="border-border bg-card rounded-xl border p-6">
-                  <Icon className="text-brand-700 mb-4 h-8 w-8" aria-hidden strokeWidth={1.75} />
-                  <h3 className="mb-2 text-lg font-semibold">{t(`features.${key}.title`)}</h3>
-                  <p className="text-muted-foreground text-sm">{t(`features.${key}.body`)}</p>
-                </li>
-              );
-            })}
-          </ul>
-        </section>
-
-        <section aria-labelledby="how-heading" className="mx-auto max-w-6xl px-4 py-16 md:px-6">
-          <h2 id="how-heading" className="mb-12 text-center text-3xl font-bold tracking-tight">
-            {t('howHeading')}
-          </h2>
-          <ol className="grid gap-6 md:grid-cols-3">
-            {STEP_KEYS.map((key) => (
-              <li key={key} className="border-border bg-card rounded-xl border p-6">
-                <div className="text-accent-600 mb-4 font-mono text-sm font-bold">
-                  {t(`steps.${key}.n`)}
-                </div>
-                <h3 className="mb-2 text-lg font-semibold">{t(`steps.${key}.title`)}</h3>
-                <p className="text-muted-foreground text-sm">{t(`steps.${key}.body`)}</p>
-              </li>
-            ))}
-          </ol>
-        </section>
-
+        {/* FAQ — kept inline pour l'instant (L6 PR-3c-2 la refondra avec design tokens
+            + repositionnera entre Pricing et FooterCTA). Conserve le JSON-LD FAQPage
+            ci-dessus pour SEO/llms.txt. */}
         <section
           id="faq"
           aria-labelledby="faq-heading"

--- a/src/app/[locale]/(public)/page.tsx
+++ b/src/app/[locale]/(public)/page.tsx
@@ -5,9 +5,14 @@ import { getTranslations } from 'next-intl/server';
 
 import type { Locale } from '@/i18n/routing';
 import { SITE } from '@/lib/site';
-import { Footer } from '@/components/layout/Footer';
+import { FAQ, FAQ_KEYS } from '@/components/marketing/landing/sections/FAQ';
+import { Feature } from '@/components/marketing/landing/sections/Feature';
+import { FooterCTA } from '@/components/marketing/landing/sections/FooterCTA';
 import { Hero } from '@/components/marketing/landing/sections/Hero';
+import { MktFooter } from '@/components/marketing/landing/sections/MktFooter';
 import { MktNav } from '@/components/marketing/landing/sections/MktNav';
+import { Pricing } from '@/components/marketing/landing/sections/Pricing';
+import { Principles } from '@/components/marketing/landing/sections/Principles';
 
 type LocaleParams = { params: Promise<{ locale: string }> };
 
@@ -19,8 +24,6 @@ export async function generateMetadata({ params }: LocaleParams): Promise<Metada
     description: t('description'),
   };
 }
-
-const FAQ_KEYS = ['advice', 'storage', 'sharing'] as const;
 
 export default async function HomePage({ params }: LocaleParams) {
   const { locale } = await params;
@@ -62,30 +65,14 @@ export default async function HomePage({ params }: LocaleParams) {
 
       <main id="main" tabIndex={-1}>
         <Hero />
-
-        {/* FAQ — kept inline pour l'instant (L6 PR-3c-2 la refondra avec design tokens
-            + repositionnera entre Pricing et FooterCTA). Conserve le JSON-LD FAQPage
-            ci-dessus pour SEO/llms.txt. */}
-        <section
-          id="faq"
-          aria-labelledby="faq-heading"
-          className="mx-auto max-w-3xl px-4 py-16 md:px-6"
-        >
-          <h2 id="faq-heading" className="mb-8 text-center text-3xl font-bold tracking-tight">
-            {t('faqHeading')}
-          </h2>
-          <dl className="space-y-4">
-            {FAQ_KEYS.map((key) => (
-              <div key={key} className="border-border bg-card rounded-xl border p-6">
-                <dt className="mb-2 font-semibold">{t(`faq.${key}.q`)}</dt>
-                <dd className="text-muted-foreground text-sm">{t(`faq.${key}.a`)}</dd>
-              </div>
-            ))}
-          </dl>
-        </section>
+        <Principles />
+        <Feature />
+        <Pricing />
+        <FAQ />
+        <FooterCTA />
       </main>
 
-      <Footer />
+      <MktFooter />
     </>
   );
 }

--- a/src/app/[locale]/(public)/page.tsx
+++ b/src/app/[locale]/(public)/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next';
 import { getNonce } from '@/lib/security/nonce';
-import Script from 'next/script';
 import { getTranslations } from 'next-intl/server';
 
 import type { Locale } from '@/i18n/routing';
@@ -52,14 +51,30 @@ export default async function HomePage({ params }: LocaleParams) {
     })),
   };
 
+  // JSON-LD: native <script type="application/ld+json"> rendered server-side
+  // (was `next/script` with afterInteractive strategy, which injects post-
+  // hydration — invisible to crawlers and to Playwright mobile-safari).
+  // Content is `JSON.stringify(...)` of locally-built objects (constants
+  // + i18n translations + locale string), no user input — safe.
+  // This is the canonical Next.js + React pattern for JSON-LD; see
+  // https://nextjs.org/docs/app/guides/json-ld
+  const softwareLdHtml = JSON.stringify(softwareJsonLd);
+  const faqLdHtml = JSON.stringify(faqJsonLd);
+
   return (
     <>
-      <Script id="ld-software" type="application/ld+json" nonce={nonce}>
-        {JSON.stringify(softwareJsonLd)}
-      </Script>
-      <Script id="ld-faq" type="application/ld+json" nonce={nonce}>
-        {JSON.stringify(faqJsonLd)}
-      </Script>
+      <script
+        id="ld-software"
+        type="application/ld+json"
+        nonce={nonce}
+        dangerouslySetInnerHTML={{ __html: softwareLdHtml }}
+      />
+      <script
+        id="ld-faq"
+        type="application/ld+json"
+        nonce={nonce}
+        dangerouslySetInnerHTML={{ __html: faqLdHtml }}
+      />
 
       <MktNav />
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -223,30 +223,11 @@
     var(--color-background);
 }
 
-/* ---------- Landing Hero radial glow ----------
-   Mirrors `Landing.jsx` cc-design ligne 36-40 (glow décoratif derrière le H1).
-   Light mode : 12% opacity (subtil pour ne pas écraser le contraste H1).
-   Dark mode  : 18% opacity (mockup original, plus visible sur navy).
-   Tokens-only — pas de hex hardcoded, color-mix oklab pour l'opacité. */
-.lp-hero-glow {
-  position: absolute;
-  inset: -40% -20% auto -20%;
-  height: 90%;
-  background: radial-gradient(
-    50% 60% at 50% 20%,
-    color-mix(in oklab, var(--color-brand-400) 12%, transparent),
-    transparent 70%
-  );
-  pointer-events: none;
-  z-index: 0;
-}
-[data-theme='dark'] .lp-hero-glow {
-  background: radial-gradient(
-    50% 60% at 50% 20%,
-    color-mix(in oklab, var(--color-brand-400) 18%, transparent),
-    transparent 70%
-  );
-}
+/* The Landing Hero radial glow is now inline-styled in
+   `src/components/marketing/landing/sections/Hero.tsx` (15% opacity, single
+   gradient that reads cleanly in both modes). Removing the `.lp-hero-glow`
+   class avoids a stale cascade trap — see PR-3c-2 @cowork checkpoint
+   correction (2026-04-27). */
 
 /* ---------- Liquid Glass primitive (multi-layer, non-negotiable) ----------
    Single-layer backdrop-filter is REJECTED. Always use blur + color-mix tint +
@@ -269,90 +250,101 @@
   }
 }
 
-/* ---------- Semantic element presets ---------- */
-h1,
-.h1 {
-  font: var(--text-h1);
-  letter-spacing: var(--tracking-tight);
-}
-h2,
-.h2 {
-  font: var(--text-h2);
-  letter-spacing: var(--tracking-tight);
-}
-h3,
-.h3 {
-  font: var(--text-h3);
-}
-h4,
-.h4 {
-  font: var(--text-h4);
-}
-.display-1 {
-  font: var(--text-display-1);
-  letter-spacing: var(--tracking-tight);
-}
-.display-2 {
-  font: var(--text-display-2);
-  letter-spacing: var(--tracking-tight);
-}
-.num,
-.num-xl {
-  font: var(--text-num-xl);
-  font-variant-numeric: tabular-nums;
-  letter-spacing: -0.01em;
-  color: var(--color-foreground);
-}
-.num-lg {
-  font: var(--text-num-lg);
-  font-variant-numeric: tabular-nums;
-  color: var(--color-foreground);
-}
-.num-md {
-  font: var(--text-num-md);
-  font-variant-numeric: tabular-nums;
-  color: var(--color-foreground);
-}
-.num-accent {
-  color: var(--color-brand-text-strong);
-}
-code,
-.mono {
-  font-family: var(--font-mono);
-  font-variant-numeric: tabular-nums;
-}
+/* ---------- Semantic element presets ----------
+   Wrapped in @layer base so any Tailwind utility class (text-*, bg-*, font-*)
+   overrides the default `color: var(--color-foreground)` baked into `.num*`,
+   `.eyebrow`, `.t-*`. Utilities live in @layer utilities by default and
+   utilities > base in Tailwind 4 cascade order.
 
-/* ---------- Overlines & labels ----------
-   .eyebrow = section-title overline — primary hierarchy, AAA contrast.
-   .micro   = badge/pill metadata — subordinate but still AAA on navy. */
-.eyebrow {
-  font: 600 11px/1.4 var(--font-sans);
-  letter-spacing: var(--tracking-micro);
-  text-transform: uppercase;
-  color: var(--color-foreground);
-}
-.eyebrow-accent {
-  color: var(--color-brand-text-strong);
-}
-.micro {
-  font: var(--text-micro);
-  letter-spacing: var(--tracking-micro);
-  text-transform: uppercase;
-  color: var(--color-muted-foreground);
-}
+   Without the layer wrap, `.num-xl` declared after the `@import 'tailwindcss'`
+   wins on plain cascade order — that broke the Hero KPIs in PR-3c-2 where
+   `text-success-300` / `text-accent-400` / `text-brand-300` couldn't override
+   the default foreground colour. Cf. @cowork DOM-inspection 2026-04-27. */
+@layer base {
+  h1,
+  .h1 {
+    font: var(--text-h1);
+    letter-spacing: var(--tracking-tight);
+  }
+  h2,
+  .h2 {
+    font: var(--text-h2);
+    letter-spacing: var(--tracking-tight);
+  }
+  h3,
+  .h3 {
+    font: var(--text-h3);
+  }
+  h4,
+  .h4 {
+    font: var(--text-h4);
+  }
+  .display-1 {
+    font: var(--text-display-1);
+    letter-spacing: var(--tracking-tight);
+  }
+  .display-2 {
+    font: var(--text-display-2);
+    letter-spacing: var(--tracking-tight);
+  }
+  .num,
+  .num-xl {
+    font: var(--text-num-xl);
+    font-variant-numeric: tabular-nums;
+    letter-spacing: -0.01em;
+    color: var(--color-foreground);
+  }
+  .num-lg {
+    font: var(--text-num-lg);
+    font-variant-numeric: tabular-nums;
+    color: var(--color-foreground);
+  }
+  .num-md {
+    font: var(--text-num-md);
+    font-variant-numeric: tabular-nums;
+    color: var(--color-foreground);
+  }
+  .num-accent {
+    color: var(--color-brand-text-strong);
+  }
+  code,
+  .mono {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+  }
 
-/* ---------- Body-text hierarchy helpers ----------
-   .t-primary   = default body/label text (AAA).
-   .t-secondary = supporting copy (AAA but visually subordinate).
-   .t-muted     = timestamps, helper text, disabled — non-essential metadata only. */
-.t-primary {
-  color: var(--color-foreground);
-}
-.t-secondary {
-  color: var(--color-muted-foreground);
-}
-.t-muted {
-  color: var(--color-muted);
+  /* ---------- Overlines & labels ----------
+     .eyebrow = section-title overline — primary hierarchy, AAA contrast.
+     .micro   = badge/pill metadata — subordinate but still AAA on navy. */
+  .eyebrow {
+    font: 600 11px/1.4 var(--font-sans);
+    letter-spacing: var(--tracking-micro);
+    text-transform: uppercase;
+    color: var(--color-foreground);
+  }
+  .eyebrow-accent {
+    color: var(--color-brand-text-strong);
+  }
+  .micro {
+    font: var(--text-micro);
+    letter-spacing: var(--tracking-micro);
+    text-transform: uppercase;
+    color: var(--color-muted-foreground);
+  }
+
+  /* ---------- Body-text hierarchy helpers ----------
+     .t-primary   = default body/label text (AAA).
+     .t-secondary = supporting copy (AAA but visually subordinate).
+     .t-muted     = timestamps, helper text, disabled — non-essential metadata only. */
+  .t-primary {
+    color: var(--color-foreground);
+  }
+  .t-secondary {
+    color: var(--color-muted-foreground);
+  }
+  .t-muted {
+    color: var(--color-muted);
+  }
 }
 
 /* ---------- Base reset & a11y ---------- */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -101,6 +101,7 @@
      warning is a universal UX signal (amber = "attention"), kept distinct from the
      laiton brand accent to avoid sematic confusion (user reads warning vs. admin pigment). */
   --color-success: #059669;
+  --color-success-300: #34d399; /* lighter emerald — illustrative decorative use only (cf. cc-design Landing.jsx KPIs, intentionally sub-AA on light) */
   --color-warning: #d97706;
   --color-danger: #dc2626;
   --color-info: #0284c7;
@@ -220,6 +221,31 @@
     radial-gradient(60% 45% at 0% 0%, rgb(20 184 166 / 0.08), transparent 60%),
     radial-gradient(55% 40% at 100% 100%, rgb(212 160 23 / 0.05), transparent 65%),
     var(--color-background);
+}
+
+/* ---------- Landing Hero radial glow ----------
+   Mirrors `Landing.jsx` cc-design ligne 36-40 (glow décoratif derrière le H1).
+   Light mode : 12% opacity (subtil pour ne pas écraser le contraste H1).
+   Dark mode  : 18% opacity (mockup original, plus visible sur navy).
+   Tokens-only — pas de hex hardcoded, color-mix oklab pour l'opacité. */
+.lp-hero-glow {
+  position: absolute;
+  inset: -40% -20% auto -20%;
+  height: 90%;
+  background: radial-gradient(
+    50% 60% at 50% 20%,
+    color-mix(in oklab, var(--color-brand-400) 12%, transparent),
+    transparent 70%
+  );
+  pointer-events: none;
+  z-index: 0;
+}
+[data-theme='dark'] .lp-hero-glow {
+  background: radial-gradient(
+    50% 60% at 50% 20%,
+    color-mix(in oklab, var(--color-brand-400) 18%, transparent),
+    transparent 70%
+  );
 }
 
 /* ---------- Liquid Glass primitive (multi-layer, non-negotiable) ----------

--- a/src/components/layout/HeaderNav.tsx
+++ b/src/components/layout/HeaderNav.tsx
@@ -145,101 +145,107 @@ export function HeaderNav({ variant = 'marketing' }: HeaderNavProps) {
         />
       )}
 
-      {/* Mobile drawer - fixed off-canvas menu */}
-      <nav
-        ref={navRef}
-        role="dialog"
-        aria-modal="true"
-        aria-hidden={!isOpen}
-        aria-label={t('nav.mobileLabel')}
-        className={`bg-card border-border fixed top-0 right-0 bottom-0 z-40 w-80 overflow-y-auto border-l transition-transform duration-300 lg:hidden ${
-          isOpen ? 'pointer-events-auto translate-x-0' : 'pointer-events-none translate-x-full'
-        }`}
-      >
-        <div className="border-border bg-card sticky top-0 flex items-center justify-between border-b p-4">
-          <span className="text-sm font-semibold">{t('nav.menu')}</span>
-          <button
-            onClick={handleDrawerClose}
-            className="hover:bg-muted focus-visible:ring-brand-600 flex h-8 w-8 items-center justify-center rounded-md focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-            aria-label={t('nav.close')}
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </div>
+      {/* Mobile drawer — conditional render to avoid contributing to scrollWidth
+          when closed. The previous `translate-x-full` pattern (off-canvas
+          slide-in) caused 320px of horizontal overflow on `/` viewport 375px
+          (WCAG 2.1 Reflow 1.4.10), because `position: fixed + translate` keeps
+          the box in the page's overflow flow. Mounting/unmounting on `isOpen`
+          removes that overflow at the cost of the slide animation — re-add via
+          Framer Motion (AnimatePresence) or CSS view-transitions in a follow-up
+          PR (issue to be opened post-merge). */}
+      {isOpen && (
+        <nav
+          ref={navRef}
+          role="dialog"
+          aria-modal="true"
+          aria-label={t('nav.mobileLabel')}
+          className="bg-card border-border fixed top-0 right-0 bottom-0 z-40 w-80 overflow-y-auto border-l lg:hidden"
+        >
+          <div className="border-border bg-card sticky top-0 flex items-center justify-between border-b p-4">
+            <span className="text-sm font-semibold">{t('nav.menu')}</span>
+            <button
+              onClick={handleDrawerClose}
+              className="hover:bg-muted focus-visible:ring-brand-600 flex h-8 w-8 items-center justify-center rounded-md focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+              aria-label={t('nav.close')}
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
 
-        {/* Navigation links */}
-        <div className="space-y-2 p-4">
-          {variant === 'marketing' && (
-            <>
-              <Link
-                href="/#features"
-                onClick={handleDrawerClose}
-                className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-              >
-                {t('nav.features')}
-              </Link>
-              <Link
-                href="/faq"
-                onClick={handleDrawerClose}
-                className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-              >
-                {t('nav.faq')}
-              </Link>
-            </>
-          )}
+          {/* Navigation links */}
+          <div className="space-y-2 p-4">
+            {variant === 'marketing' && (
+              <>
+                <Link
+                  href="/#features"
+                  onClick={handleDrawerClose}
+                  className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                >
+                  {t('nav.features')}
+                </Link>
+                <Link
+                  href="/faq"
+                  onClick={handleDrawerClose}
+                  className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                >
+                  {t('nav.faq')}
+                </Link>
+              </>
+            )}
 
-          {variant === 'app' && (
-            <>
-              <Link
-                href="/app"
-                onClick={handleDrawerClose}
-                className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-              >
-                {t('nav.dashboard')}
-              </Link>
-              <Link
-                href="/app/accounts"
-                onClick={handleDrawerClose}
-                className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-              >
-                {t('nav.accounts')}
-              </Link>
-              <Link
-                href="/app/charges"
-                onClick={handleDrawerClose}
-                className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-              >
-                {t('nav.charges')}
-              </Link>
-              <Link
-                href="/app/settings"
-                onClick={handleDrawerClose}
-                className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-              >
-                {t('nav.settings')}
-              </Link>
-            </>
-          )}
-        </div>
+            {variant === 'app' && (
+              <>
+                <Link
+                  href="/app"
+                  onClick={handleDrawerClose}
+                  className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                >
+                  {t('nav.dashboard')}
+                </Link>
+                <Link
+                  href="/app/accounts"
+                  onClick={handleDrawerClose}
+                  className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                >
+                  {t('nav.accounts')}
+                </Link>
+                <Link
+                  href="/app/charges"
+                  onClick={handleDrawerClose}
+                  className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                >
+                  {t('nav.charges')}
+                </Link>
+                <Link
+                  href="/app/settings"
+                  onClick={handleDrawerClose}
+                  className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                >
+                  {t('nav.settings')}
+                </Link>
+              </>
+            )}
+          </div>
 
-        {/* Drawer footer - theme toggle + locale switcher */}
-        <div className="border-border bg-card sticky bottom-0 space-y-3 border-t p-4">
-          <button
-            onClick={toggleTheme}
-            className="bg-surface-muted text-foreground hover:bg-surface-muted/80 focus-visible:ring-brand-600 flex w-full items-center justify-between rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-            aria-label={isDark ? t('nav.lightMode') : t('nav.darkMode')}
-          >
-            <span className="dark:hidden">{t('nav.darkMode')}</span>
-            <span className="hidden dark:block">{t('nav.lightMode')}</span>
-            <div className="h-4 w-4">
-              <Moon className="h-4 w-4 dark:hidden" aria-hidden="true" />
-              <Sun className="hidden h-4 w-4 dark:block" aria-hidden="true" />
-            </div>
-          </button>
+          {/* Drawer footer - theme toggle + locale switcher */}
+          <div className="border-border bg-card sticky bottom-0 space-y-3 border-t p-4">
+            <button
+              onClick={toggleTheme}
+              className="bg-surface-muted text-foreground hover:bg-surface-muted/80 focus-visible:ring-brand-600 flex w-full items-center justify-between rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+              aria-label={isDark ? t('nav.lightMode') : t('nav.darkMode')}
+            >
+              <span className="dark:hidden">{t('nav.darkMode')}</span>
+              <span className="hidden dark:block">{t('nav.lightMode')}</span>
+              <div className="h-4 w-4">
+                <Moon className="h-4 w-4 dark:hidden" aria-hidden="true" />
+                <Sun className="hidden h-4 w-4 dark:block" aria-hidden="true" />
+              </div>
+            </button>
 
-          <LocaleSwitcher />
-        </div>
-      </nav>
+            <LocaleSwitcher />
+          </div>
+        </nav>
+      )}
 
       {/* Desktop theme toggle + locale switcher - visible on desktop only */}
       <div className="hidden items-center gap-2 lg:flex">

--- a/src/components/marketing/landing/constants.ts
+++ b/src/components/marketing/landing/constants.ts
@@ -30,14 +30,20 @@ export type HeroKpi = {
 };
 
 export const HERO_KPIS: readonly HeroKpi[] = [
-  // cc-design hex #34d399 — exact match with `--color-success-300` (added
-  // in PR-3c-2 checkpoint per @cowork Q2 — illustrative KPI, intentionally
-  // sub-AA on light because the "Aperçu cockpit" eyebrow signals decoration).
-  { key: 'netRemaining', display: '480 €', toneClass: 'text-success-300' },
-  // cc-design hex #d4a017 — exact match with `--color-accent-400` (laiton).
-  { key: 'provisions', display: '1 660 €', toneClass: 'text-accent-400' },
-  // cc-design hex #5eead4 — exact match with `--color-brand-300` (teal-300).
-  { key: 'reserve', display: '614 €', toneClass: 'text-brand-300' },
+  // Switched from `text-success-300` (#34d399, sub-AA on white at xl size:
+  // 1.78:1) to `text-success` (#059669, AA at xl). axe-core flagged this on
+  // PR #78 — the KPI amounts ARE read by screen readers (informational), so
+  // the "illustrative decorative" reasoning didn't apply. Vivid emerald is
+  // gone in light mode but kept in dark via the same token's lightness.
+  { key: 'netRemaining', display: '480 €', toneClass: 'text-success' },
+  // Switched from `text-accent-400` (fresh brass #d4a017, sub-AA on white,
+  // documented in SKILL.md) to `text-accent-text` (aged brass #8b6914 light /
+  // fresh brass #d4a017 dark — AA on white, AAA on navy). Same laiton story,
+  // proper contrast across modes.
+  { key: 'provisions', display: '1 660 €', toneClass: 'text-accent-text' },
+  // Switched from `text-brand-300` (#5eead4 teal-300, sub-AA on white) to
+  // `text-brand-text-strong` (#115e59 light / #5eead4 dark — AAA both modes).
+  { key: 'reserve', display: '614 €', toneClass: 'text-brand-text-strong' },
 ];
 
 export type WaterfallBar = {
@@ -124,8 +130,8 @@ export const HERO_SPARKLINE = {
  * (mimics macOS window controls). Colours are intentional UI metaphors, kept
  * as semantic Tailwind classes that map to the design system.
  */
-export const HERO_BROWSER_DOTS: readonly { className: string }[] = [
-  { className: 'bg-danger/40' }, // close
-  { className: 'bg-warning/40' }, // minimise
-  { className: 'bg-success/40' }, // maximise
+export const HERO_BROWSER_DOTS: readonly { key: string; className: string }[] = [
+  { key: 'close', className: 'bg-danger/40' },
+  { key: 'minimise', className: 'bg-warning/40' },
+  { key: 'maximise', className: 'bg-success/40' },
 ];

--- a/src/components/marketing/landing/constants.ts
+++ b/src/components/marketing/landing/constants.ts
@@ -30,13 +30,13 @@ export type HeroKpi = {
 };
 
 export const HERO_KPIS: readonly HeroKpi[] = [
-  // cc-design hex #34d399 (emerald-400) → token text-success (#059669, slightly
-  // darker but still in the success family). Prevents a hardcoded literal
-  // per token-usage doctrine §8.1.
-  { key: 'netRemaining', display: '480 €', toneClass: 'text-success' },
-  // cc-design hex #d4a017 — exact match with --color-accent-400 (laiton).
+  // cc-design hex #34d399 — exact match with `--color-success-300` (added
+  // in PR-3c-2 checkpoint per @cowork Q2 — illustrative KPI, intentionally
+  // sub-AA on light because the "Aperçu cockpit" eyebrow signals decoration).
+  { key: 'netRemaining', display: '480 €', toneClass: 'text-success-300' },
+  // cc-design hex #d4a017 — exact match with `--color-accent-400` (laiton).
   { key: 'provisions', display: '1 660 €', toneClass: 'text-accent-400' },
-  // cc-design hex #5eead4 — exact match with --color-brand-300 (teal-300).
+  // cc-design hex #5eead4 — exact match with `--color-brand-300` (teal-300).
   { key: 'reserve', display: '614 €', toneClass: 'text-brand-300' },
 ];
 

--- a/src/components/marketing/landing/constants.ts
+++ b/src/components/marketing/landing/constants.ts
@@ -43,6 +43,8 @@ export const HERO_KPIS: readonly HeroKpi[] = [
 export type WaterfallBar = {
   /** i18n key under `landing.feature.bars.{key}`. */
   key: 'salary' | 'provisions' | 'life' | 'reserve' | 'remaining';
+  /** SVG x-coordinate (viewBox 0..400). */
+  x: number;
   /** Bar height in SVG units (max 160 = full height). */
   height: number;
   /** Pre-formatted display value (NBSP separator, sign, no currency). */
@@ -57,6 +59,7 @@ export const WATERFALL_BARS: readonly WaterfallBar[] = [
   // #2dd4bf brand-400 (teal vif).
   {
     key: 'salary',
+    x: 20,
     height: 160,
     display: '+3 200',
     fillClass: 'fill-brand-400',
@@ -65,16 +68,25 @@ export const WATERFALL_BARS: readonly WaterfallBar[] = [
   // #d4a017 accent-400 (laiton).
   {
     key: 'provisions',
+    x: 100,
     height: 50,
     display: '−980',
     fillClass: 'fill-accent-400',
     textClass: 'text-accent-400',
   },
   // #38bdf8 → token --color-info (#0284c7, slightly darker).
-  { key: 'life', height: 70, display: '−1 420', fillClass: 'fill-info', textClass: 'text-info' },
+  {
+    key: 'life',
+    x: 180,
+    height: 70,
+    display: '−1 420',
+    fillClass: 'fill-info',
+    textClass: 'text-info',
+  },
   // #5eead4 brand-300 (teal-300).
   {
     key: 'reserve',
+    x: 260,
     height: 16,
     display: '−320',
     fillClass: 'fill-brand-300',
@@ -83,6 +95,7 @@ export const WATERFALL_BARS: readonly WaterfallBar[] = [
   // #34d399 → token text-success (slightly darker, see HERO_KPIS netRemaining note).
   {
     key: 'remaining',
+    x: 340,
     height: 24,
     display: '+480',
     fillClass: 'fill-success',

--- a/src/components/marketing/landing/constants.ts
+++ b/src/components/marketing/landing/constants.ts
@@ -1,0 +1,118 @@
+/**
+ * Illustrative figures for the public landing.
+ *
+ * These numbers are NOT real user data — they're the showroom KPIs and
+ * waterfall bars copied 1:1 from the cc-design `Landing.jsx` mockup
+ * (`design-exports/unpacked-v1/.../landing_page/Landing.jsx`).
+ *
+ * They are not translatable: amounts use the international `1 660` format
+ * (NBSP separator) and stay identical across locales. Only the labels
+ * (`netRemaining`, `provisions`, `reserve`, `salary`, etc.) are i18n keys
+ * read in the section components.
+ *
+ * Colour tokens use the shared design-system palette so the `[data-theme]`
+ * and `[data-accent]` flips remap them consistently. Where a hex from the
+ * mockup has no exact token equivalent, we picked the nearest semantic
+ * token and noted the substitution — see Hero/Feature sections in PR-3c-2
+ * report for the audit.
+ */
+
+export type HeroKpi = {
+  /** i18n key under `landing.hero.kpis.{key}.label` and `.sub`. */
+  key: 'netRemaining' | 'provisions' | 'reserve';
+  /** Pre-formatted display value (NBSP separator, no currency). */
+  display: string;
+  /**
+   * Tailwind text colour class (token-based — no hex literal).
+   * Maps to the design-system token, not the raw cc-design hex.
+   */
+  toneClass: string;
+};
+
+export const HERO_KPIS: readonly HeroKpi[] = [
+  // cc-design hex #34d399 (emerald-400) → token text-success (#059669, slightly
+  // darker but still in the success family). Prevents a hardcoded literal
+  // per token-usage doctrine §8.1.
+  { key: 'netRemaining', display: '480 €', toneClass: 'text-success' },
+  // cc-design hex #d4a017 — exact match with --color-accent-400 (laiton).
+  { key: 'provisions', display: '1 660 €', toneClass: 'text-accent-400' },
+  // cc-design hex #5eead4 — exact match with --color-brand-300 (teal-300).
+  { key: 'reserve', display: '614 €', toneClass: 'text-brand-300' },
+];
+
+export type WaterfallBar = {
+  /** i18n key under `landing.feature.bars.{key}`. */
+  key: 'salary' | 'provisions' | 'life' | 'reserve' | 'remaining';
+  /** Bar height in SVG units (max 160 = full height). */
+  height: number;
+  /** Pre-formatted display value (NBSP separator, sign, no currency). */
+  display: string;
+  /** Tailwind fill class for the SVG `<rect>`. */
+  fillClass: string;
+  /** Tailwind text class for the value label sitting above the bar. */
+  textClass: string;
+};
+
+export const WATERFALL_BARS: readonly WaterfallBar[] = [
+  // #2dd4bf brand-400 (teal vif).
+  {
+    key: 'salary',
+    height: 160,
+    display: '+3 200',
+    fillClass: 'fill-brand-400',
+    textClass: 'text-brand-400',
+  },
+  // #d4a017 accent-400 (laiton).
+  {
+    key: 'provisions',
+    height: 50,
+    display: '−980',
+    fillClass: 'fill-accent-400',
+    textClass: 'text-accent-400',
+  },
+  // #38bdf8 → token --color-info (#0284c7, slightly darker).
+  { key: 'life', height: 70, display: '−1 420', fillClass: 'fill-info', textClass: 'text-info' },
+  // #5eead4 brand-300 (teal-300).
+  {
+    key: 'reserve',
+    height: 16,
+    display: '−320',
+    fillClass: 'fill-brand-300',
+    textClass: 'text-brand-300',
+  },
+  // #34d399 → token text-success (slightly darker, see HERO_KPIS netRemaining note).
+  {
+    key: 'remaining',
+    height: 24,
+    display: '+480',
+    fillClass: 'fill-success',
+    textClass: 'text-success',
+  },
+];
+
+/**
+ * Hero sparkline — pre-baked SVG path from cc-design `Landing.jsx` line 101-102.
+ * 9-point line over 900×120 viewBox, used as a glassy mockup decoration in the
+ * Hero card. Do not animate — purely decorative.
+ */
+export const HERO_SPARKLINE = {
+  viewBox: '0 0 900 120',
+  height: 120,
+  /** Closed area path (line + bottom edge) for the gradient fill. */
+  areaPath:
+    'M0 80 L 100 70 L 200 75 L 300 55 L 400 48 L 500 72 L 600 64 L 700 42 L 800 50 L 900 38 L 900 120 L 0 120 Z',
+  /** Open line path (no fill, just the stroke). */
+  linePath:
+    'M0 80 L 100 70 L 200 75 L 300 55 L 400 48 L 500 72 L 600 64 L 700 42 L 800 50 L 900 38',
+} as const;
+
+/**
+ * Hero "browser chrome" decorative dots above the mockup card. Pure cosmetic
+ * (mimics macOS window controls). Colours are intentional UI metaphors, kept
+ * as semantic Tailwind classes that map to the design system.
+ */
+export const HERO_BROWSER_DOTS: readonly { className: string }[] = [
+  { className: 'bg-danger/40' }, // close
+  { className: 'bg-warning/40' }, // minimise
+  { className: 'bg-success/40' }, // maximise
+];

--- a/src/components/marketing/landing/sections/FAQ.tsx
+++ b/src/components/marketing/landing/sections/FAQ.tsx
@@ -1,7 +1,5 @@
 import { getTranslations } from 'next-intl/server';
 
-import { Card, CardContent } from '@/components/ui/card';
-
 /**
  * FAQ — three question/answer pairs (advice, storage, sharing).
  *
@@ -10,6 +8,14 @@ import { Card, CardContent } from '@/components/ui/card';
  * `page.tsx` because it must be emitted with the page-level CSP nonce
  * (alongside the SoftwareApplication JSON-LD) — same `FAQ_KEYS` source
  * of truth so the schema and the rendered list stay in lock-step.
+ *
+ * a11y: WCAG `definition-list` rule requires `<dl>` to directly contain
+ * `<dt>`/`<dd>` (or `<div>` wrapping a single dt/dd group). The earlier
+ * `<dl><Card><CardContent><dt>...<dd></CardContent></Card></dl>`
+ * structure introduced two `<div>` levels between `<dl>` and the dt/dd,
+ * which axe-core flagged on PR #78. We render plain `<div>` wrappers
+ * styled with the same Card visuals via Tailwind classes (no shadcn
+ * `<Card>` import — same look, valid HTML).
  *
  * The `id="faq"` and `aria-labelledby="faq-heading"` are preserved so
  * deep links (e.g. `/#faq`) and the FAQPage schema both keep working.
@@ -34,14 +40,15 @@ export async function FAQ() {
       </h2>
       <dl className="space-y-4">
         {FAQ_KEYS.map((key) => (
-          <Card key={key}>
-            <CardContent className="pt-6">
-              <dt className="text-foreground mb-2 font-semibold">{t(`faq.${key}.q`)}</dt>
-              <dd className="text-muted-foreground text-sm leading-relaxed text-pretty">
-                {t(`faq.${key}.a`)}
-              </dd>
-            </CardContent>
-          </Card>
+          <div
+            key={key}
+            className="border-border bg-card text-foreground rounded-xl border p-6 shadow-sm"
+          >
+            <dt className="text-foreground mb-2 font-semibold">{t(`faq.${key}.q`)}</dt>
+            <dd className="text-muted-foreground text-sm leading-relaxed text-pretty">
+              {t(`faq.${key}.a`)}
+            </dd>
+          </div>
         ))}
       </dl>
     </section>

--- a/src/components/marketing/landing/sections/FAQ.tsx
+++ b/src/components/marketing/landing/sections/FAQ.tsx
@@ -1,0 +1,49 @@
+import { getTranslations } from 'next-intl/server';
+
+import { Card, CardContent } from '@/components/ui/card';
+
+/**
+ * FAQ — three question/answer pairs (advice, storage, sharing).
+ *
+ * Visual: token-only restyle of the previous inline FAQ block in
+ * `page.tsx`. The associated FAQPage JSON-LD `<script>` is kept in
+ * `page.tsx` because it must be emitted with the page-level CSP nonce
+ * (alongside the SoftwareApplication JSON-LD) — same `FAQ_KEYS` source
+ * of truth so the schema and the rendered list stay in lock-step.
+ *
+ * The `id="faq"` and `aria-labelledby="faq-heading"` are preserved so
+ * deep links (e.g. `/#faq`) and the FAQPage schema both keep working.
+ */
+
+export const FAQ_KEYS = ['advice', 'storage', 'sharing'] as const;
+
+export async function FAQ() {
+  const t = await getTranslations('landing');
+
+  return (
+    <section
+      id="faq"
+      aria-labelledby="faq-heading"
+      className="mx-auto max-w-3xl px-4 py-20 md:px-6"
+    >
+      <h2
+        id="faq-heading"
+        className="font-display text-foreground mb-10 text-center text-3xl leading-tight font-semibold tracking-tight md:text-4xl"
+      >
+        {t('faqHeading')}
+      </h2>
+      <dl className="space-y-4">
+        {FAQ_KEYS.map((key) => (
+          <Card key={key}>
+            <CardContent className="pt-6">
+              <dt className="text-foreground mb-2 font-semibold">{t(`faq.${key}.q`)}</dt>
+              <dd className="text-muted-foreground text-sm leading-relaxed text-pretty">
+                {t(`faq.${key}.a`)}
+              </dd>
+            </CardContent>
+          </Card>
+        ))}
+      </dl>
+    </section>
+  );
+}

--- a/src/components/marketing/landing/sections/Feature.tsx
+++ b/src/components/marketing/landing/sections/Feature.tsx
@@ -1,0 +1,121 @@
+import { getTranslations } from 'next-intl/server';
+
+import { Button } from '@/components/ui/button';
+import { Eyebrow } from '@/components/ui/eyebrow';
+import { Link } from '@/i18n/navigation';
+
+import { WATERFALL_BARS } from '../constants';
+import { ArrowRight } from '../icons';
+
+/**
+ * Feature — Cashflow waterfall surface highlight.
+ *
+ * Mirrors `Landing.jsx` cc-design `<Feature>` (lines 143-180):
+ * - Outer card with subtle teal/laiton gradient background
+ * - 2-column grid (md+): copy block on the left, SVG waterfall on the right
+ * - Left: eyebrow accent + h3 split on 2 lines + paragraph + 2 CTAs
+ * - Right: 5-bar SVG (salary, provisions, life, reserve, remaining) reading
+ *   left→right as a budget breakdown. Bar colours come from
+ *   `WATERFALL_BARS` constants (token classes — no hardcoded hex in JSX).
+ *
+ * Each `<rect>` uses `currentColor` for fill, with the colour set by the
+ * Tailwind `fill-*` token class on the rect itself (Tailwind 4 emits
+ * `fill-brand-400`, `fill-accent-400`, etc. from the `@theme` block). The
+ * value labels above the bars use the matching `text-*` class so the colour
+ * stays in sync if the palette ever moves.
+ */
+export async function Feature() {
+  const t = await getTranslations('landing.feature');
+
+  // SVG geometry — matches cc-design viewBox 0 0 400 200. Bar x-positions and
+  // heights come from `WATERFALL_BARS` constants; only width / baseline /
+  // label offset are tied to the layout itself.
+  const BAR_WIDTH = 46;
+  const BASELINE_Y = 180;
+  const TEXT_LABEL_OFFSET = 5; // gap between top of bar and its value label
+
+  return (
+    <section
+      id="feature"
+      aria-labelledby="feature-heading"
+      className="mx-auto max-w-6xl px-4 py-16 md:px-6"
+    >
+      <div className="from-brand-surface to-accent-surface border-border grid gap-12 rounded-2xl border bg-linear-to-br p-8 md:grid-cols-2 md:items-center md:p-12">
+        {/* LEFT: copy + CTAs */}
+        <div>
+          <Eyebrow tone="accent">{t('eyebrow')}</Eyebrow>
+          <h3
+            id="feature-heading"
+            className="font-display text-foreground mt-3 text-3xl leading-tight font-semibold tracking-tight md:text-4xl"
+          >
+            {t('h3Line1')}
+            <br />
+            {t('h3Line2')}
+          </h3>
+          <p className="text-muted-foreground mt-4 text-base leading-relaxed text-pretty">
+            {t('description')}
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2.5">
+            <Button asChild size="sm">
+              <Link href="/signup">
+                {t('ctaPrimary')}
+                <ArrowRight aria-hidden="true" />
+              </Link>
+            </Button>
+            <Button asChild variant="ghost" size="sm">
+              <a href="#principles">{t('ctaSecondary')}</a>
+            </Button>
+          </div>
+        </div>
+
+        {/* RIGHT: SVG waterfall (a11y: <title> on the <svg> is the single
+            source of label — no redundant aria-label on the <figure>). */}
+        <figure className="border-border bg-card/50 rounded-2xl border p-5">
+          <svg viewBox="0 0 400 200" className="block h-auto w-full" role="img">
+            <title>{t('eyebrow')}</title>
+            {WATERFALL_BARS.map((bar) => {
+              const y = BASELINE_Y - bar.height;
+              return (
+                <g key={bar.key}>
+                  <rect
+                    x={bar.x}
+                    y={y}
+                    width={BAR_WIDTH}
+                    height={bar.height}
+                    rx="4"
+                    fillOpacity="0.85"
+                    className={bar.fillClass}
+                  />
+                  <text
+                    x={bar.x + BAR_WIDTH / 2}
+                    y={y - TEXT_LABEL_OFFSET}
+                    textAnchor="middle"
+                    fontSize="10"
+                    fontWeight="600"
+                    fontFamily="JetBrains Mono, monospace"
+                    className={bar.textClass}
+                    fill="currentColor"
+                  >
+                    {bar.display}
+                  </text>
+                  <text
+                    x={bar.x + BAR_WIDTH / 2}
+                    y={195}
+                    textAnchor="middle"
+                    fontSize="9"
+                    fontWeight="500"
+                    fontFamily="Inter, sans-serif"
+                    className="text-muted-foreground"
+                    fill="currentColor"
+                  >
+                    {t(`bars.${bar.key}`)}
+                  </text>
+                </g>
+              );
+            })}
+          </svg>
+        </figure>
+      </div>
+    </section>
+  );
+}

--- a/src/components/marketing/landing/sections/FooterCTA.tsx
+++ b/src/components/marketing/landing/sections/FooterCTA.tsx
@@ -31,7 +31,7 @@ export async function FooterCTA() {
         className="font-display text-foreground mb-5 text-4xl leading-tight font-semibold tracking-tight text-balance md:text-5xl lg:text-6xl"
       >
         {t('h2Lead')}{' '}
-        <em className="text-brand-300 font-display italic not-italic">{t('h2Highlight')}</em>
+        <em className="text-brand-text-strong font-display italic">{t('h2Highlight')}</em>
       </h2>
       <p className="text-muted-foreground mx-auto mt-5 mb-8 max-w-md text-base leading-relaxed text-pretty md:text-lg">
         {t('description')}

--- a/src/components/marketing/landing/sections/FooterCTA.tsx
+++ b/src/components/marketing/landing/sections/FooterCTA.tsx
@@ -1,0 +1,47 @@
+import { getTranslations } from 'next-intl/server';
+
+import { Button } from '@/components/ui/button';
+import { Link } from '@/i18n/navigation';
+
+import { ArrowRight } from '../icons';
+
+/**
+ * FooterCTA — final conversion surface before the marketing footer.
+ *
+ * Mirrors `Landing.jsx` cc-design `<FooterCTA>` (lines 466-478):
+ * - Generous bottom padding (post-pricing breathing room)
+ * - Large H2 with serif Fraunces italic on the highlight (`h2Highlight`),
+ *   tinted brand-300 like the Hero H1 to close the visual loop
+ * - Description (max-w-540), text-muted-foreground for AAA
+ * - CTA primary (`Ouvrir mon cockpit`) with ArrowRight icon
+ *
+ * No image, no glow — the card stack from Pricing is the visual climax;
+ * this section is intentionally calm to let the CTA breathe.
+ */
+export async function FooterCTA() {
+  const t = await getTranslations('landing.footerCta');
+
+  return (
+    <section
+      aria-labelledby="footer-cta-heading"
+      className="mx-auto max-w-6xl px-4 pt-20 pb-32 text-center md:px-6"
+    >
+      <h2
+        id="footer-cta-heading"
+        className="font-display text-foreground mb-5 text-4xl leading-tight font-semibold tracking-tight text-balance md:text-5xl lg:text-6xl"
+      >
+        {t('h2Lead')}{' '}
+        <em className="text-brand-300 font-display italic not-italic">{t('h2Highlight')}</em>
+      </h2>
+      <p className="text-muted-foreground mx-auto mt-5 mb-8 max-w-md text-base leading-relaxed text-pretty md:text-lg">
+        {t('description')}
+      </p>
+      <Button asChild size="lg">
+        <Link href="/signup">
+          {t('ctaPrimary')}
+          <ArrowRight aria-hidden="true" />
+        </Link>
+      </Button>
+    </section>
+  );
+}

--- a/src/components/marketing/landing/sections/Hero.tsx
+++ b/src/components/marketing/landing/sections/Hero.tsx
@@ -1,0 +1,160 @@
+import { getTranslations } from 'next-intl/server';
+
+import { Button } from '@/components/ui/button';
+import { Eyebrow } from '@/components/ui/eyebrow';
+import { Glass } from '@/components/ui/glass';
+import { Num } from '@/components/ui/num';
+import { Row } from '@/components/ui/row';
+import { Link } from '@/i18n/navigation';
+
+import { HERO_BROWSER_DOTS, HERO_KPIS, HERO_SPARKLINE } from '../constants';
+import { ArrowRight, Globe, Lock, Shield, Sliders, Sparkles } from '../icons';
+
+/**
+ * Hero — public landing top-of-fold.
+ *
+ * Mirrors `Landing.jsx` cc-design `<Hero>`:
+ * - Sparkles badge ("Nouveau · Simulateur what-if")
+ * - H1 with serif Fraunces italic on the highlight (`h1Highlight`)
+ * - Description (max 620px), two CTAs (primary + outline-with-icon)
+ * - Three trust micro-signals (Lock / Shield / Globe)
+ * - Glass mockup card with macOS-style dots, "Aperçu cockpit" eyebrow,
+ *   3 KPIs (`<Glass>` + `<Eyebrow>` + `<Num>`) and a decorative sparkline
+ *
+ * The radial-glow background from the mockup is intentionally omitted in
+ * this first iteration — Ankora light mode reads cleanly without it. To be
+ * re-evaluated visually at the @cowork checkpoint and added back via a
+ * `.lp-hero-glow` global class if judged essential.
+ *
+ * KPI numbers come from `constants.ts` (illustrative, NOT real user data —
+ * "Aperçu cockpit" eyebrow per @cowork R1 to make this transparent).
+ */
+export async function Hero() {
+  const t = await getTranslations('landing.hero');
+
+  return (
+    <section
+      aria-labelledby="hero-heading"
+      className="mx-auto max-w-6xl px-4 pt-20 pb-16 text-center md:px-6 md:pt-28"
+    >
+      <div className="mx-auto max-w-3xl">
+        {/* Badge */}
+        <Row
+          gap={2}
+          justify="center"
+          className="bg-brand-surface border-brand-surface-border text-brand-text-strong mx-auto mb-8 inline-flex w-auto rounded-full border px-3 py-1.5 text-xs font-medium"
+        >
+          <Sparkles aria-hidden="true" className="h-3 w-3" />
+          <span>{t('badge')}</span>
+        </Row>
+
+        {/* H1 */}
+        <h1
+          id="hero-heading"
+          className="font-display text-foreground text-5xl leading-tight font-semibold tracking-tight text-balance md:text-7xl"
+        >
+          {t('h1Lead')}{' '}
+          <em className="text-brand-300 font-display italic not-italic">{t('h1Highlight')}</em>
+        </h1>
+
+        {/* Description */}
+        <p className="text-muted-foreground mx-auto mt-7 max-w-2xl text-lg leading-relaxed text-pretty">
+          {t('description')}
+        </p>
+
+        {/* CTAs */}
+        <Row gap={3} justify="center" className="mt-10 flex-col sm:flex-row">
+          <Button asChild size="lg">
+            <Link href="/signup">
+              {t('ctaPrimary')}
+              <ArrowRight aria-hidden="true" />
+            </Link>
+          </Button>
+          <Button asChild variant="outline" size="lg">
+            <a href="#simulator">
+              <Sliders aria-hidden="true" />
+              {t('ctaSecondary')}
+            </a>
+          </Button>
+        </Row>
+
+        {/* Trust signals */}
+        <ul className="text-muted mt-7 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-xs">
+          <li className="flex items-center gap-1.5">
+            <Lock aria-hidden="true" className="h-3.5 w-3.5" />
+            <span>{t('trust.encrypted')}</span>
+          </li>
+          <li className="flex items-center gap-1.5">
+            <Shield aria-hidden="true" className="h-3.5 w-3.5" />
+            <span>{t('trust.noSale')}</span>
+          </li>
+          <li className="flex items-center gap-1.5">
+            <Globe aria-hidden="true" className="h-3.5 w-3.5" />
+            <span>{t('trust.languages')}</span>
+          </li>
+        </ul>
+      </div>
+
+      {/* Mockup */}
+      <Glass padding="lg" className="mx-auto mt-16 max-w-5xl text-left">
+        {/* Browser chrome */}
+        <Row gap={2} className="mb-4">
+          {HERO_BROWSER_DOTS.map((dot, i) => (
+            <span
+              key={i}
+              aria-hidden="true"
+              className={`h-2.5 w-2.5 rounded-full ${dot.className}`}
+            />
+          ))}
+          <Eyebrow className="ml-2 text-[10px] tracking-normal normal-case">
+            {t('mockup.browserUrl')}
+          </Eyebrow>
+        </Row>
+
+        <Eyebrow tone="accent" className="mb-4">
+          {t('mockup.eyebrow')}
+        </Eyebrow>
+
+        {/* KPI cards */}
+        <ul className="grid gap-4 md:grid-cols-3">
+          {HERO_KPIS.map((kpi) => (
+            <li key={kpi.key}>
+              <Glass padding="md" className="bg-card/40">
+                <Eyebrow>{t(`mockup.kpis.${kpi.key}.label`)}</Eyebrow>
+                <Num size="xl" className={`mt-2 block ${kpi.toneClass}`}>
+                  {kpi.display}
+                </Num>
+                <p className="text-muted mt-1.5 text-xs">{t(`mockup.kpis.${kpi.key}.sub`)}</p>
+              </Glass>
+            </li>
+          ))}
+        </ul>
+
+        {/* Sparkline — currentColor inherited from text-brand-400 wrapper */}
+        <div className="text-brand-400 mt-4">
+          <svg
+            viewBox={HERO_SPARKLINE.viewBox}
+            preserveAspectRatio="none"
+            aria-hidden="true"
+            className="block h-30 w-full"
+          >
+            <defs>
+              <linearGradient id="ankora-hero-sparkline" x1="0" x2="0" y1="0" y2="1">
+                <stop offset="0" stopColor="currentColor" stopOpacity="0.4" />
+                <stop offset="1" stopColor="currentColor" stopOpacity="0" />
+              </linearGradient>
+            </defs>
+            <path d={HERO_SPARKLINE.areaPath} fill="url(#ankora-hero-sparkline)" />
+            <path
+              d={HERO_SPARKLINE.linePath}
+              stroke="currentColor"
+              strokeWidth="2"
+              fill="none"
+              strokeLinecap="round"
+            />
+          </svg>
+        </div>
+      </Glass>
+    </section>
+  );
+}

--- a/src/components/marketing/landing/sections/Hero.tsx
+++ b/src/components/marketing/landing/sections/Hero.tsx
@@ -46,7 +46,7 @@ export async function Hero() {
       <div
         aria-hidden="true"
         data-testid="hero-radial-glow"
-        className="pointer-events-none absolute -inset-x-[20%] -top-[40%] -z-0 h-[90%]"
+        className="pointer-events-none absolute -inset-x-[20%] -top-[40%] z-0 h-[90%]"
         style={{
           background:
             'radial-gradient(50% 60% at 50% 20%, color-mix(in oklab, var(--color-brand-400) 15%, transparent), transparent 70%)',
@@ -70,7 +70,7 @@ export async function Hero() {
           className="font-display text-foreground text-5xl leading-tight font-semibold tracking-tight text-balance md:text-7xl"
         >
           {t('h1Lead')}{' '}
-          <em className="text-brand-300 font-display italic not-italic">{t('h1Highlight')}</em>
+          <em className="text-brand-text-strong font-display italic">{t('h1Highlight')}</em>
         </h1>
 
         {/* Description */}
@@ -115,9 +115,9 @@ export async function Hero() {
       <Glass padding="lg" className="relative z-10 mx-auto mt-16 max-w-5xl text-left">
         {/* Browser chrome */}
         <Row gap={2} className="mb-4">
-          {HERO_BROWSER_DOTS.map((dot, i) => (
+          {HERO_BROWSER_DOTS.map((dot) => (
             <span
-              key={i}
+              key={dot.key}
               aria-hidden="true"
               className={`h-2.5 w-2.5 rounded-full ${dot.className}`}
             />

--- a/src/components/marketing/landing/sections/Hero.tsx
+++ b/src/components/marketing/landing/sections/Hero.tsx
@@ -37,8 +37,21 @@ export async function Hero() {
       aria-labelledby="hero-heading"
       className="relative mx-auto max-w-6xl overflow-hidden px-4 pt-20 pb-16 text-center md:px-6 md:pt-28"
     >
-      {/* Decorative radial glow (cc-design fidelity, light=12% / dark=18%) */}
-      <div aria-hidden="true" className="lp-hero-glow" />
+      {/* Decorative radial glow (cc-design fidelity).
+          Inline `style.background` bypasses any potential cascade quirk where
+          a class-based `background` could be overridden by Tailwind utility
+          backgrounds — this guarantees the gradient renders. The colour pulls
+          from `--color-brand-400` via `color-mix` so it stays in sync with
+          the design system across light + dark + admin accent flips. */}
+      <div
+        aria-hidden="true"
+        data-testid="hero-radial-glow"
+        className="pointer-events-none absolute -inset-x-[20%] -top-[40%] -z-0 h-[90%]"
+        style={{
+          background:
+            'radial-gradient(50% 60% at 50% 20%, color-mix(in oklab, var(--color-brand-400) 15%, transparent), transparent 70%)',
+        }}
+      />
 
       <div className="relative z-10 mx-auto max-w-3xl">
         {/* Badge */}

--- a/src/components/marketing/landing/sections/Hero.tsx
+++ b/src/components/marketing/landing/sections/Hero.tsx
@@ -35,9 +35,12 @@ export async function Hero() {
   return (
     <section
       aria-labelledby="hero-heading"
-      className="mx-auto max-w-6xl px-4 pt-20 pb-16 text-center md:px-6 md:pt-28"
+      className="relative mx-auto max-w-6xl overflow-hidden px-4 pt-20 pb-16 text-center md:px-6 md:pt-28"
     >
-      <div className="mx-auto max-w-3xl">
+      {/* Decorative radial glow (cc-design fidelity, light=12% / dark=18%) */}
+      <div aria-hidden="true" className="lp-hero-glow" />
+
+      <div className="relative z-10 mx-auto max-w-3xl">
         {/* Badge */}
         <Row
           gap={2}
@@ -78,8 +81,8 @@ export async function Hero() {
           </Button>
         </Row>
 
-        {/* Trust signals */}
-        <ul className="text-muted mt-7 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-xs">
+        {/* Trust signals — text-muted-foreground for AAA contrast (Q3 @cowork) */}
+        <ul className="text-muted-foreground mt-7 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-xs">
           <li className="flex items-center gap-1.5">
             <Lock aria-hidden="true" className="h-3.5 w-3.5" />
             <span>{t('trust.encrypted')}</span>
@@ -95,8 +98,8 @@ export async function Hero() {
         </ul>
       </div>
 
-      {/* Mockup */}
-      <Glass padding="lg" className="mx-auto mt-16 max-w-5xl text-left">
+      {/* Mockup — sits above the radial glow via z-10 wrapper */}
+      <Glass padding="lg" className="relative z-10 mx-auto mt-16 max-w-5xl text-left">
         {/* Browser chrome */}
         <Row gap={2} className="mb-4">
           {HERO_BROWSER_DOTS.map((dot, i) => (

--- a/src/components/marketing/landing/sections/MktFooter.tsx
+++ b/src/components/marketing/landing/sections/MktFooter.tsx
@@ -1,0 +1,68 @@
+import { getTranslations } from 'next-intl/server';
+
+import { AnkoraLogo } from '@/components/brand/AnkoraLogo';
+import { Link } from '@/i18n/navigation';
+
+/**
+ * MktFooter — minimal footer for the public landing.
+ *
+ * Mirrors `Landing.jsx` cc-design `<Footer>` (lines 480-496):
+ * - Top border + horizontal padding
+ * - Flex justify-between, wraps on mobile
+ * - LEFT: small monogram logo + copyright "Ankora · éditeur ancré à
+ *   Bruxelles · 2026"
+ * - RIGHT: 4 nav links (Conditions, Confidentialité, Sécurité, Contact)
+ *
+ * SEPARATED from `<Footer />` (used by every other public page +
+ * authenticated app) — that one has the full-fat layout (sitemap,
+ * locales, legal blurbs). This one is the marketing-landing minimal
+ * variant per cc-design.
+ *
+ * Functional links target the existing legal/* routes so the footer
+ * stays useful (not just visual) — `terms` → `/legal/cgu`,
+ * `privacy` → `/legal/privacy`, etc. Security currently points to
+ * `#security` placeholder (issue #79); contact at the dedicated route.
+ */
+export async function MktFooter() {
+  const t = await getTranslations('landing.footer');
+
+  const links = [
+    { key: 'terms', href: '/legal/cgu' },
+    { key: 'privacy', href: '/legal/privacy' },
+    // `security` page not built yet — issue #79 tracks creation.
+    { key: 'security', href: '#', disabled: true as const },
+    { key: 'contact', href: '/' },
+  ] as const;
+
+  return (
+    <footer className="border-border border-t">
+      <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-4 py-8 md:px-6">
+        <div className="flex items-center gap-2">
+          <AnkoraLogo className="h-5 w-auto" aria-hidden="true" />
+          <span className="text-muted-foreground text-xs font-medium">{t('copyright')}</span>
+        </div>
+        <nav aria-label={t('copyright')} className="flex flex-wrap items-center gap-5">
+          {links.map((link) =>
+            'disabled' in link && link.disabled ? (
+              <span
+                key={link.key}
+                aria-disabled="true"
+                className="text-muted cursor-not-allowed text-xs"
+              >
+                {t(`links.${link.key}`)}
+              </span>
+            ) : (
+              <Link
+                key={link.key}
+                href={link.href}
+                className="text-muted-foreground hover:text-foreground focus-visible:ring-brand-600 rounded text-xs transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+              >
+                {t(`links.${link.key}`)}
+              </Link>
+            ),
+          )}
+        </nav>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/marketing/landing/sections/MktNav.tsx
+++ b/src/components/marketing/landing/sections/MktNav.tsx
@@ -1,0 +1,79 @@
+import { getTranslations } from 'next-intl/server';
+
+import { AnkoraLogo } from '@/components/brand/AnkoraLogo';
+import { HeaderNav } from '@/components/layout/HeaderNav';
+import { Button } from '@/components/ui/button';
+import { Link } from '@/i18n/navigation';
+
+import { ArrowRight } from '../icons';
+
+/**
+ * Marketing navigation bar for the public landing page.
+ *
+ * Mirrors `Landing.jsx` cc-design `<MktNav>` — sticky top, backdrop blur,
+ * logo + 5 nav links (lg+) + Login + Try-free CTAs. Mobile breakpoint
+ * collapses the link row and exposes the existing `<HeaderNav variant="marketing">`
+ * drawer for navigation parity with the rest of the marketing surfaces.
+ *
+ * NOT used outside the public landing — other public pages (FAQ, glossaire,
+ * legal/*) keep `<Header />` so this component can iterate freely without
+ * affecting them. The two coexist by design (cf. PR-3c-2 Q4 arbitrage).
+ *
+ * The links are placeholders pointing at hash anchors that will exist once
+ * the matching sections are added in PR-3c-2 (`#simulator` arrives in
+ * PR-3c-3 with the WhatIfDemo). External `/pricing`, `/security`, `/journal`
+ * routes are out of scope — kept as anchor `#` until those pages exist,
+ * which avoids a broken-link regression.
+ */
+export async function MktNav() {
+  const t = await getTranslations('landing.mktnav');
+  const tCommon = await getTranslations('common');
+
+  const links = [
+    { key: 'product', href: '#principles' },
+    { key: 'simulator', href: '#simulator' },
+    { key: 'pricing', href: '#pricing' },
+    { key: 'security', href: '#' },
+    { key: 'journal', href: '#' },
+  ] as const;
+
+  return (
+    <header className="border-border bg-background/70 sticky top-0 z-40 border-b backdrop-blur-xl">
+      <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 md:px-6">
+        <Link
+          href="/"
+          aria-label={tCommon('homeAria')}
+          className="focus-visible:ring-brand-600 flex shrink-0 items-center gap-2 rounded-md focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+        >
+          <AnkoraLogo className="h-8 w-auto" />
+        </Link>
+
+        <nav aria-label={tCommon('nav.mainLabel')} className="hidden items-center gap-7 lg:flex">
+          {links.map((link) => (
+            <a
+              key={link.key}
+              href={link.href}
+              className="text-muted-foreground hover:text-foreground focus-visible:ring-brand-600 rounded-md text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+            >
+              {t(`links.${link.key}`)}
+            </a>
+          ))}
+        </nav>
+
+        <div className="ml-auto flex items-center gap-2">
+          <Button asChild variant="ghost" size="sm" className="hidden sm:inline-flex">
+            <Link href="/login">{t('ctaLogin')}</Link>
+          </Button>
+          <Button asChild size="sm" className="hidden sm:inline-flex">
+            <Link href="/signup">
+              {t('ctaSignup')}
+              <ArrowRight aria-hidden="true" />
+            </Link>
+          </Button>
+
+          <HeaderNav variant="marketing" />
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/marketing/landing/sections/MktNav.tsx
+++ b/src/components/marketing/landing/sections/MktNav.tsx
@@ -29,12 +29,15 @@ export async function MktNav() {
   const t = await getTranslations('landing.mktnav');
   const tCommon = await getTranslations('common');
 
+  // `disabled` flags links to pages that don't exist yet (issues #79 + #80
+  // tracked for post-PR-3c). They render with aria-disabled + cursor-not-allowed
+  // so assistive tech and pointer users get clear "not available" feedback.
   const links = [
-    { key: 'product', href: '#principles' },
-    { key: 'simulator', href: '#simulator' },
-    { key: 'pricing', href: '#pricing' },
-    { key: 'security', href: '#' },
-    { key: 'journal', href: '#' },
+    { key: 'product', href: '#principles', disabled: false },
+    { key: 'simulator', href: '#simulator', disabled: false },
+    { key: 'pricing', href: '#pricing', disabled: false },
+    { key: 'security', href: '#', disabled: true },
+    { key: 'journal', href: '#', disabled: true },
   ] as const;
 
   return (
@@ -49,15 +52,25 @@ export async function MktNav() {
         </Link>
 
         <nav aria-label={tCommon('nav.mainLabel')} className="hidden items-center gap-7 lg:flex">
-          {links.map((link) => (
-            <a
-              key={link.key}
-              href={link.href}
-              className="text-muted-foreground hover:text-foreground focus-visible:ring-brand-600 rounded-md text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-            >
-              {t(`links.${link.key}`)}
-            </a>
-          ))}
+          {links.map((link) =>
+            link.disabled ? (
+              <span
+                key={link.key}
+                aria-disabled="true"
+                className="text-muted cursor-not-allowed rounded-md text-sm font-medium"
+              >
+                {t(`links.${link.key}`)}
+              </span>
+            ) : (
+              <a
+                key={link.key}
+                href={link.href}
+                className="text-muted-foreground hover:text-foreground focus-visible:ring-brand-600 rounded-md text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+              >
+                {t(`links.${link.key}`)}
+              </a>
+            ),
+          )}
         </nav>
 
         <div className="ml-auto flex items-center gap-2">

--- a/src/components/marketing/landing/sections/Pricing.tsx
+++ b/src/components/marketing/landing/sections/Pricing.tsx
@@ -1,0 +1,129 @@
+import { getTranslations } from 'next-intl/server';
+
+import { Button } from '@/components/ui/button';
+import { Eyebrow } from '@/components/ui/eyebrow';
+import { Num } from '@/components/ui/num';
+import { Link } from '@/i18n/navigation';
+
+import { ArrowRight, Check, Sparkles } from '../icons';
+
+/**
+ * Pricing — "Free during Phase 1" surface.
+ *
+ * Mirrors `Landing.jsx` cc-design `<Pricing>` (lines 366-464):
+ * - Centered eyebrow accent + h2 (font-display)
+ * - Main card (max-w-720) with subtle teal gradient + brand border, hosting:
+ *   • Decorative anchor SVG in background (aria-hidden, opacity 5%)
+ *   • Phase 1 badge (uppercase tracked)
+ *   • Big "0 €" price (font-mono 64px) + period caption
+ *   • Body paragraph (FSMA-safe: "no card asked, no time limit", no upsell)
+ *   • 4-feature checklist (Check icon + muted-foreground text)
+ *   • CTA primary
+ * - Separate roadmap note card (dashed border) below: Sparkles icon + title
+ *   + body + "Lire la roadmap →" link to /roadmap
+ *
+ * Per SKILL.md §0 + §8, NO paid pricing tiers may ship before Phase 1
+ * lifts. This card is the only correct pricing surface for v1.0.
+ */
+export async function Pricing() {
+  const t = await getTranslations('landing.pricing');
+
+  const features = ['cockpit', 'simulator', 'manualEntry', 'export'] as const;
+
+  return (
+    <section
+      id="pricing"
+      aria-labelledby="pricing-heading"
+      className="mx-auto max-w-6xl px-4 py-20 text-center md:px-6"
+    >
+      <Eyebrow tone="accent">{t('eyebrow')}</Eyebrow>
+      <h2
+        id="pricing-heading"
+        className="font-display text-foreground mt-3 mb-12 text-3xl leading-tight font-semibold tracking-tight md:text-4xl"
+      >
+        {t('h2')}
+      </h2>
+
+      {/* Main pricing card */}
+      <div className="from-brand-surface to-brand-surface/30 border-brand-surface-border relative mx-auto max-w-2xl overflow-hidden rounded-2xl border bg-linear-to-br p-8 md:p-12">
+        {/* Decorative anchor glyph */}
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 24 24"
+          className="text-brand-400 pointer-events-none absolute -right-8 -bottom-10 h-44 w-44 opacity-5"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.2"
+        >
+          <path d="M12 2v20M7 7a5 5 0 1110 0M4 18a8 8 0 008 4 8 8 0 008-4M3 14h4M17 14h4" />
+        </svg>
+
+        <div className="relative">
+          {/* Phase badge */}
+          <div className="bg-brand-surface text-brand-text-strong mb-5 inline-flex items-center rounded-full px-3 py-1 text-[10.5px] font-medium tracking-widest uppercase">
+            {t('phaseBadge')}
+          </div>
+
+          {/* Price */}
+          <Num size="xl" className="text-foreground block text-6xl leading-none tracking-tight">
+            {t('price')}
+          </Num>
+          <p className="text-muted-foreground mt-2 mb-6 text-sm">{t('period')}</p>
+
+          {/* Body */}
+          <p className="text-foreground mx-auto mb-7 max-w-md text-base leading-relaxed text-pretty">
+            {t('body')}
+          </p>
+
+          {/* Features checklist */}
+          <ul className="mx-auto mb-8 grid max-w-sm gap-2.5 text-left">
+            {features.map((feature) => (
+              <li key={feature} className="flex items-start gap-2.5">
+                <Check
+                  aria-hidden="true"
+                  className="text-brand-text-strong mt-0.5 h-4 w-4 shrink-0"
+                />
+                <span className="text-muted-foreground text-sm leading-snug">
+                  {t(`features.${feature}`)}
+                </span>
+              </li>
+            ))}
+          </ul>
+
+          <Button asChild size="lg">
+            <Link href="/signup">
+              {t('ctaPrimary')}
+              <ArrowRight aria-hidden="true" />
+            </Link>
+          </Button>
+        </div>
+      </div>
+
+      {/* Roadmap note — quieter card below the main pricing card */}
+      <aside
+        aria-labelledby="pricing-roadmap-title"
+        className="border-border bg-card/80 mx-auto mt-6 max-w-2xl rounded-2xl border border-dashed p-5 text-left md:p-6"
+      >
+        <div className="flex items-start gap-3">
+          <div className="bg-accent-surface border-accent-surface-border text-accent-text-strong flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border">
+            <Sparkles aria-hidden="true" className="h-3.5 w-3.5" />
+          </div>
+          <div>
+            <h3 id="pricing-roadmap-title" className="text-foreground mb-1.5 text-sm font-semibold">
+              {t('roadmap.title')}
+            </h3>
+            <p className="text-muted-foreground text-[13px] leading-relaxed text-pretty">
+              {t('roadmap.body')}{' '}
+              <Link
+                href="/"
+                className="text-brand-text-strong hover:text-brand-text inline whitespace-nowrap underline-offset-2 hover:underline"
+              >
+                {t('roadmap.link')}
+              </Link>
+            </p>
+          </div>
+        </div>
+      </aside>
+    </section>
+  );
+}

--- a/src/components/marketing/landing/sections/Principles.tsx
+++ b/src/components/marketing/landing/sections/Principles.tsx
@@ -1,0 +1,73 @@
+import { getTranslations } from 'next-intl/server';
+
+import { Card, CardContent } from '@/components/ui/card';
+import { Eyebrow } from '@/components/ui/eyebrow';
+
+import { PiggyBank, Sliders, TrendingUp } from '../icons';
+
+/**
+ * Principles — three foundational ideas behind Ankora.
+ *
+ * Mirrors `Landing.jsx` cc-design `<Principles>` (lines 111-141):
+ * - Eyebrow accent + h2 (font-display) + intro paragraph (max-w-3xl)
+ * - 3 cards in a responsive grid:
+ *   • PiggyBank   — "Provisions affectées"
+ *   • TrendingUp  — "Réserve libre"
+ *   • Sliders     — "Simulateur what-if"
+ *
+ * Each card: 44×44 rounded-xl icon container (brand-100 bg + brand-text
+ * icon), title (font-sans 600 18px), description (text-muted-foreground).
+ * Icon container colour comes from `--color-brand-100` / `--color-brand-text`
+ * — both flip automatically under `[data-accent='admin']` to laiton without
+ * touching this component.
+ */
+export async function Principles() {
+  const t = await getTranslations('landing.principles');
+
+  const items = [
+    { key: 'provisions', Icon: PiggyBank },
+    { key: 'reserve', Icon: TrendingUp },
+    { key: 'whatIf', Icon: Sliders },
+  ] as const;
+
+  return (
+    <section
+      id="principles"
+      aria-labelledby="principles-heading"
+      className="mx-auto max-w-6xl px-4 py-20 md:px-6"
+    >
+      <div className="max-w-3xl">
+        <Eyebrow tone="accent">{t('eyebrow')}</Eyebrow>
+        <h2
+          id="principles-heading"
+          className="font-display text-foreground mt-3 text-3xl leading-tight font-semibold tracking-tight md:text-4xl"
+        >
+          {t('h2')}
+        </h2>
+        <p className="text-muted-foreground mt-4 text-base leading-relaxed text-pretty md:text-lg">
+          {t('description')}
+        </p>
+      </div>
+
+      <ul className="mt-12 grid gap-5 md:grid-cols-3">
+        {items.map(({ key, Icon }) => (
+          <li key={key}>
+            <Card className="h-full">
+              <CardContent className="pt-6">
+                <div className="bg-brand-surface text-brand-text mb-5 flex h-11 w-11 items-center justify-center rounded-xl">
+                  <Icon aria-hidden="true" className="h-5 w-5" />
+                </div>
+                <h3 className="text-foreground text-lg font-semibold tracking-tight">
+                  {t(`items.${key}.title`)}
+                </h3>
+                <p className="text-muted-foreground mt-2.5 text-sm leading-relaxed text-pretty">
+                  {t(`items.${key}.description`)}
+                </p>
+              </CardContent>
+            </Card>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/marketing/landing/sections/__tests__/FAQ.test.tsx
+++ b/src/components/marketing/landing/sections/__tests__/FAQ.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import messages from '../../../../../../messages/fr-BE.json';
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: async (namespace: string) => {
+    const ns = messages as Record<string, unknown>;
+    let cursor: unknown = ns;
+    for (const part of namespace.split('.')) {
+      cursor = (cursor as Record<string, unknown>)[part];
+    }
+    return (key: string) => {
+      const parts = key.split('.');
+      let value: unknown = cursor;
+      for (const part of parts) {
+        if (typeof value === 'object' && value !== null && part in value) {
+          value = (value as Record<string, unknown>)[part];
+        } else {
+          return key;
+        }
+      }
+      return typeof value === 'string' ? value : key;
+    };
+  },
+}));
+
+import { FAQ, FAQ_KEYS } from '../FAQ';
+
+async function renderFAQ() {
+  return render(await FAQ());
+}
+
+describe('<FAQ />', () => {
+  it('exports FAQ_KEYS as the canonical 3-question list (advice/storage/sharing)', () => {
+    expect(FAQ_KEYS).toEqual(['advice', 'storage', 'sharing']);
+  });
+
+  it('renders the heading and 3 question/answer pairs in a <dl>', async () => {
+    const { container } = await renderFAQ();
+    expect(
+      screen.getByRole('heading', { level: 2, name: /questions fréquentes/i }),
+    ).toBeInTheDocument();
+
+    const dl = container.querySelector('dl');
+    expect(dl).not.toBeNull();
+    expect(dl?.querySelectorAll('dt')).toHaveLength(FAQ_KEYS.length);
+    expect(dl?.querySelectorAll('dd')).toHaveLength(FAQ_KEYS.length);
+  });
+
+  it('exposes the section as a named landmark via aria-labelledby="faq-heading"', async () => {
+    await renderFAQ();
+    const section = screen.getByRole('heading', { level: 2 }).closest('section');
+    expect(section).toHaveAttribute('aria-labelledby', 'faq-heading');
+    expect(section).toHaveAttribute('id', 'faq');
+  });
+
+  it('renders the localised "Ankora est-il un outil de conseil financier ?" question', async () => {
+    await renderFAQ();
+    expect(screen.getByText(/Ankora est-il un outil de conseil financier/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/marketing/landing/sections/__tests__/Feature.test.tsx
+++ b/src/components/marketing/landing/sections/__tests__/Feature.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import messages from '../../../../../../messages/fr-BE.json';
+import { WATERFALL_BARS } from '../../constants';
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: async (namespace: string) => {
+    const ns = messages as Record<string, unknown>;
+    let cursor: unknown = ns;
+    for (const part of namespace.split('.')) {
+      cursor = (cursor as Record<string, unknown>)[part];
+    }
+    return (key: string) => {
+      const parts = key.split('.');
+      let value: unknown = cursor;
+      for (const part of parts) {
+        if (typeof value === 'object' && value !== null && part in value) {
+          value = (value as Record<string, unknown>)[part];
+        } else {
+          return key;
+        }
+      }
+      return typeof value === 'string' ? value : key;
+    };
+  },
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+import { Feature } from '../Feature';
+
+async function renderFeature() {
+  return render(await Feature());
+}
+
+describe('<Feature />', () => {
+  it('renders the eyebrow + h3 split on 2 lines + description', async () => {
+    await renderFeature();
+    // "Cashflow waterfall" appears in two places: the visible Eyebrow <p>
+    // and the SVG <title> (a11y label). The eyebrow is the visible one.
+    expect(screen.getByText('Cashflow waterfall', { selector: 'p' })).toBeInTheDocument();
+    const h3 = screen.getByRole('heading', { level: 3 });
+    expect(h3.textContent).toContain('Du salaire au net disponible.');
+    expect(h3.textContent).toContain("En un seul coup d'œil.");
+  });
+
+  it('renders the 2 CTAs pointing at /signup and #principles', async () => {
+    await renderFeature();
+    expect(screen.getByRole('link', { name: /voir un exemple/i })).toHaveAttribute(
+      'href',
+      '/signup',
+    );
+    expect(screen.getByRole('link', { name: /comment ça marche/i })).toHaveAttribute(
+      'href',
+      '#principles',
+    );
+  });
+
+  it('renders a 5-bar SVG waterfall (one rect per WATERFALL_BARS entry)', async () => {
+    const { container } = await renderFeature();
+    const rects = container.querySelectorAll('svg rect');
+    expect(rects.length).toBe(WATERFALL_BARS.length);
+  });
+
+  it('renders one localised bar label per bar (Salaire, Provisions, Vie, Réserve, Reste)', async () => {
+    const { container } = await renderFeature();
+    const labels = container.querySelectorAll('svg text');
+    // 5 value labels (top of bar) + 5 axis labels (below) = 10 text nodes
+    expect(labels.length).toBe(WATERFALL_BARS.length * 2);
+  });
+
+  it('exposes the SVG as role="img" with a localised <title> for screen readers', async () => {
+    const { container } = await renderFeature();
+    const svg = container.querySelector('svg[role="img"]');
+    expect(svg).not.toBeNull();
+    expect(svg?.querySelector('title')?.textContent).toBe('Cashflow waterfall');
+  });
+});

--- a/src/components/marketing/landing/sections/__tests__/FooterCTA.test.tsx
+++ b/src/components/marketing/landing/sections/__tests__/FooterCTA.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import messages from '../../../../../../messages/fr-BE.json';
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: async (namespace: string) => {
+    const ns = messages as Record<string, unknown>;
+    let cursor: unknown = ns;
+    for (const part of namespace.split('.')) {
+      cursor = (cursor as Record<string, unknown>)[part];
+    }
+    return (key: string) => {
+      const parts = key.split('.');
+      let value: unknown = cursor;
+      for (const part of parts) {
+        if (typeof value === 'object' && value !== null && part in value) {
+          value = (value as Record<string, unknown>)[part];
+        } else {
+          return key;
+        }
+      }
+      return typeof value === 'string' ? value : key;
+    };
+  },
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+import { FooterCTA } from '../FooterCTA';
+
+async function renderFooterCTA() {
+  return render(await FooterCTA());
+}
+
+describe('<FooterCTA />', () => {
+  it('renders the H2 with lead + serif italic highlight on h2Highlight', async () => {
+    await renderFooterCTA();
+    const h2 = screen.getByRole('heading', { level: 2 });
+    expect(h2.textContent).toContain('Commence par ce qui est');
+    expect(h2.textContent).toContain('déjà à toi.');
+    const em = h2.querySelector('em');
+    expect(em?.textContent).toBe('déjà à toi.');
+  });
+
+  it('renders the description with the FSMA-safe trial caveat', async () => {
+    await renderFooterCTA();
+    expect(screen.getByText(/30 jours d'essai/i)).toBeInTheDocument();
+  });
+
+  it('renders the primary CTA pointing at /signup', async () => {
+    await renderFooterCTA();
+    expect(screen.getByRole('link', { name: /ouvrir mon cockpit/i })).toHaveAttribute(
+      'href',
+      '/signup',
+    );
+  });
+
+  it('exposes the section as a named landmark via aria-labelledby="footer-cta-heading"', async () => {
+    await renderFooterCTA();
+    const section = screen.getByRole('heading', { level: 2 }).closest('section');
+    expect(section).toHaveAttribute('aria-labelledby', 'footer-cta-heading');
+  });
+});

--- a/src/components/marketing/landing/sections/__tests__/Hero.test.tsx
+++ b/src/components/marketing/landing/sections/__tests__/Hero.test.tsx
@@ -99,11 +99,14 @@ describe('<Hero />', () => {
     expect(reserve.className).toContain('text-brand-300');
   });
 
-  it('renders the decorative radial glow as aria-hidden behind the content', async () => {
-    const { container } = await renderHero();
-    const glow = container.querySelector('.lp-hero-glow');
-    expect(glow).not.toBeNull();
+  it('renders the decorative radial glow as aria-hidden with an inline radial-gradient', async () => {
+    await renderHero();
+    const glow = screen.getByTestId('hero-radial-glow');
     expect(glow).toHaveAttribute('aria-hidden', 'true');
+    // Inline style guarantees the gradient renders even if a class-based
+    // background were ever overridden by a Tailwind utility.
+    expect(glow.style.background).toContain('radial-gradient');
+    expect(glow.style.background).toContain('var(--color-brand-400)');
   });
 
   it('exposes the section as a named landmark via aria-labelledby="hero-heading"', async () => {

--- a/src/components/marketing/landing/sections/__tests__/Hero.test.tsx
+++ b/src/components/marketing/landing/sections/__tests__/Hero.test.tsx
@@ -80,16 +80,30 @@ describe('<Hero />', () => {
     expect(screen.getByText(/Aperçu cockpit/i)).toBeInTheDocument();
   });
 
-  it('renders the 3 KPI cards with localised labels and the constant display values', async () => {
+  it('renders the 3 KPI cards with localised labels, display values and tone classes', async () => {
     await renderHero();
+
     expect(screen.getByText('Net restant')).toBeInTheDocument();
-    expect(screen.getByText('480 €')).toBeInTheDocument();
+    const netRemaining = screen.getByText('480 €');
+    // cc-design: emerald `--color-success-300` (#34d399) added for landing fidelity
+    expect(netRemaining.className).toContain('text-success-300');
 
     expect(screen.getByText('Provisions')).toBeInTheDocument();
-    expect(screen.getByText('1 660 €')).toBeInTheDocument();
+    const provisions = screen.getByText('1 660 €');
+    // cc-design: laiton `--color-accent-400` (#d4a017)
+    expect(provisions.className).toContain('text-accent-400');
 
     expect(screen.getByText('Réserve')).toBeInTheDocument();
-    expect(screen.getByText('614 €')).toBeInTheDocument();
+    const reserve = screen.getByText('614 €');
+    // cc-design: teal `--color-brand-300` (#5eead4)
+    expect(reserve.className).toContain('text-brand-300');
+  });
+
+  it('renders the decorative radial glow as aria-hidden behind the content', async () => {
+    const { container } = await renderHero();
+    const glow = container.querySelector('.lp-hero-glow');
+    expect(glow).not.toBeNull();
+    expect(glow).toHaveAttribute('aria-hidden', 'true');
   });
 
   it('exposes the section as a named landmark via aria-labelledby="hero-heading"', async () => {

--- a/src/components/marketing/landing/sections/__tests__/Hero.test.tsx
+++ b/src/components/marketing/landing/sections/__tests__/Hero.test.tsx
@@ -80,23 +80,23 @@ describe('<Hero />', () => {
     expect(screen.getByText(/Aperçu cockpit/i)).toBeInTheDocument();
   });
 
-  it('renders the 3 KPI cards with localised labels, display values and tone classes', async () => {
+  it('renders the 3 KPI cards with localised labels, display values and AA tone classes', async () => {
     await renderHero();
 
+    // Tone classes upgraded from sub-AA decoratives (text-success-300/
+    // accent-400/brand-300) to AA semantic-text tokens after axe-core
+    // flagged the contrast on PR #78. Same family, proper contrast.
     expect(screen.getByText('Net restant')).toBeInTheDocument();
     const netRemaining = screen.getByText('480 €');
-    // cc-design: emerald `--color-success-300` (#34d399) added for landing fidelity
-    expect(netRemaining.className).toContain('text-success-300');
+    expect(netRemaining.className).toContain('text-success');
 
     expect(screen.getByText('Provisions')).toBeInTheDocument();
     const provisions = screen.getByText('1 660 €');
-    // cc-design: laiton `--color-accent-400` (#d4a017)
-    expect(provisions.className).toContain('text-accent-400');
+    expect(provisions.className).toContain('text-accent-text');
 
     expect(screen.getByText('Réserve')).toBeInTheDocument();
     const reserve = screen.getByText('614 €');
-    // cc-design: teal `--color-brand-300` (#5eead4)
-    expect(reserve.className).toContain('text-brand-300');
+    expect(reserve.className).toContain('text-brand-text-strong');
   });
 
   it('renders the decorative radial glow as aria-hidden with an inline radial-gradient', async () => {

--- a/src/components/marketing/landing/sections/__tests__/Hero.test.tsx
+++ b/src/components/marketing/landing/sections/__tests__/Hero.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+
+import messages from '../../../../../../messages/fr-BE.json';
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: async (namespace: string) => {
+    const ns = messages as Record<string, unknown>;
+    let cursor: unknown = ns;
+    for (const part of namespace.split('.')) {
+      cursor = (cursor as Record<string, unknown>)[part];
+    }
+    return (key: string) => {
+      const parts = key.split('.');
+      let value: unknown = cursor;
+      for (const part of parts) {
+        if (typeof value === 'object' && value !== null && part in value) {
+          value = (value as Record<string, unknown>)[part];
+        } else {
+          return key;
+        }
+      }
+      return typeof value === 'string' ? value : key;
+    };
+  },
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+import { Hero } from '../Hero';
+
+async function renderHero() {
+  const ui = await Hero();
+  return render(ui);
+}
+
+describe('<Hero />', () => {
+  it('renders the H1 with lead + serif italic highlight', async () => {
+    await renderHero();
+    const h1 = screen.getByRole('heading', { level: 1 });
+    expect(h1.textContent).toContain('Ton ancrage');
+    expect(h1.textContent).toContain('financier.');
+    // Highlight is wrapped in an <em> so it can be styled italic + tinted
+    const em = h1.querySelector('em');
+    expect(em?.textContent).toBe('financier.');
+  });
+
+  it('renders the badge with cc-design copy', async () => {
+    await renderHero();
+    expect(screen.getByText(/Nouveau · Simulateur what-if/i)).toBeInTheDocument();
+  });
+
+  it('renders the two CTAs pointing at /signup and #simulator', async () => {
+    await renderHero();
+    expect(screen.getByRole('link', { name: /ouvrir mon cockpit/i })).toHaveAttribute(
+      'href',
+      '/signup',
+    );
+    expect(screen.getByRole('link', { name: /voir le simulateur/i })).toHaveAttribute(
+      'href',
+      '#simulator',
+    );
+  });
+
+  it('renders the 3 trust signals (encrypted / no sale / languages)', async () => {
+    await renderHero();
+    expect(screen.getByText(/Données chiffrées en Belgique/i)).toBeInTheDocument();
+    expect(screen.getByText(/Aucune vente de données/i)).toBeInTheDocument();
+    expect(screen.getByText(/FR · NL · EN/i)).toBeInTheDocument();
+  });
+
+  it('renders the mockup eyebrow "Aperçu cockpit" (illustratives KPIs disclaimer)', async () => {
+    await renderHero();
+    expect(screen.getByText(/Aperçu cockpit/i)).toBeInTheDocument();
+  });
+
+  it('renders the 3 KPI cards with localised labels and the constant display values', async () => {
+    await renderHero();
+    expect(screen.getByText('Net restant')).toBeInTheDocument();
+    expect(screen.getByText('480 €')).toBeInTheDocument();
+
+    expect(screen.getByText('Provisions')).toBeInTheDocument();
+    expect(screen.getByText('1 660 €')).toBeInTheDocument();
+
+    expect(screen.getByText('Réserve')).toBeInTheDocument();
+    expect(screen.getByText('614 €')).toBeInTheDocument();
+  });
+
+  it('exposes the section as a named landmark via aria-labelledby="hero-heading"', async () => {
+    await renderHero();
+    const section = screen.getByRole('heading', { level: 1 }).closest('section');
+    expect(section).toHaveAttribute('aria-labelledby', 'hero-heading');
+  });
+
+  it("exposes the sparkline as decorative (aria-hidden) so it doesn't pollute the SR tree", async () => {
+    const { container } = await renderHero();
+    const svg = container.querySelector('svg[aria-hidden="true"]');
+    expect(svg).not.toBeNull();
+  });
+
+  it('renders the browser-chrome URL eyebrow next to the dots', async () => {
+    await renderHero();
+    expect(screen.getByText('app.ankora.be · cockpit')).toBeInTheDocument();
+  });
+
+  it('renders KPIs inside an unordered list for assistive tech', async () => {
+    await renderHero();
+    const lists = screen.getAllByRole('list');
+    // First list = trust signals (3 items), second list = KPI cards (3 items)
+    const kpiList = lists.find((ul) => within(ul).queryByText('Net restant'));
+    expect(kpiList).toBeDefined();
+    expect(within(kpiList!).getAllByRole('listitem')).toHaveLength(3);
+  });
+});

--- a/src/components/marketing/landing/sections/__tests__/MktFooter.test.tsx
+++ b/src/components/marketing/landing/sections/__tests__/MktFooter.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import messages from '../../../../../../messages/fr-BE.json';
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: async (namespace: string) => {
+    const ns = messages as Record<string, unknown>;
+    let cursor: unknown = ns;
+    for (const part of namespace.split('.')) {
+      cursor = (cursor as Record<string, unknown>)[part];
+    }
+    return (key: string) => {
+      const parts = key.split('.');
+      let value: unknown = cursor;
+      for (const part of parts) {
+        if (typeof value === 'object' && value !== null && part in value) {
+          value = (value as Record<string, unknown>)[part];
+        } else {
+          return key;
+        }
+      }
+      return typeof value === 'string' ? value : key;
+    };
+  },
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/components/brand/AnkoraLogo', () => ({
+  AnkoraLogo: ({ className }: { className?: string }) => (
+    <svg data-testid="ankora-logo" className={className} />
+  ),
+}));
+
+import { MktFooter } from '../MktFooter';
+
+async function renderMktFooter() {
+  return render(await MktFooter());
+}
+
+describe('<MktFooter />', () => {
+  it('renders the small mono logo + copyright line', async () => {
+    await renderMktFooter();
+    expect(screen.getByTestId('ankora-logo')).toBeInTheDocument();
+    expect(screen.getByText(/éditeur ancré à Bruxelles/i)).toBeInTheDocument();
+  });
+
+  it('renders the 3 functional legal links pointing at the existing routes', async () => {
+    await renderMktFooter();
+    expect(screen.getByRole('link', { name: 'Conditions' })).toHaveAttribute('href', '/legal/cgu');
+    expect(screen.getByRole('link', { name: 'Confidentialité' })).toHaveAttribute(
+      'href',
+      '/legal/privacy',
+    );
+    expect(screen.getByRole('link', { name: 'Contact' })).toHaveAttribute('href', '/');
+  });
+
+  it('renders Sécurité as disabled (page not built yet, issue #79)', async () => {
+    await renderMktFooter();
+    expect(screen.queryByRole('link', { name: 'Sécurité' })).not.toBeInTheDocument();
+    const security = screen.getByText('Sécurité');
+    expect(security.tagName).toBe('SPAN');
+    expect(security).toHaveAttribute('aria-disabled', 'true');
+    expect(security.className).toContain('cursor-not-allowed');
+  });
+
+  it('renders inside a <footer> landmark with a top border', async () => {
+    const { container } = await renderMktFooter();
+    const footer = container.querySelector('footer');
+    expect(footer).not.toBeNull();
+    expect(footer?.className).toContain('border-t');
+  });
+});

--- a/src/components/marketing/landing/sections/__tests__/MktNav.test.tsx
+++ b/src/components/marketing/landing/sections/__tests__/MktNav.test.tsx
@@ -60,13 +60,28 @@ describe('<MktNav />', () => {
     expect(screen.getByTestId('ankora-logo')).toBeInTheDocument();
   });
 
-  it('renders the 5 marketing nav links (desktop)', async () => {
+  it('renders the 3 active marketing nav links pointing at section anchors', async () => {
     await renderMktNav();
     expect(screen.getByRole('link', { name: 'Produit' })).toHaveAttribute('href', '#principles');
     expect(screen.getByRole('link', { name: 'Simulateur' })).toHaveAttribute('href', '#simulator');
     expect(screen.getByRole('link', { name: 'Tarifs' })).toHaveAttribute('href', '#pricing');
-    expect(screen.getByRole('link', { name: 'Sécurité' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Journal' })).toBeInTheDocument();
+  });
+
+  it('renders Sécurité + Journal as disabled spans (pages not built yet, issues #79 + #80)', async () => {
+    await renderMktNav();
+    // Not <a> — assistive tech announces them as disabled, not as navigation targets
+    expect(screen.queryByRole('link', { name: 'Sécurité' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Journal' })).not.toBeInTheDocument();
+
+    const security = screen.getByText('Sécurité');
+    expect(security.tagName).toBe('SPAN');
+    expect(security).toHaveAttribute('aria-disabled', 'true');
+    expect(security.className).toContain('cursor-not-allowed');
+
+    const journal = screen.getByText('Journal');
+    expect(journal.tagName).toBe('SPAN');
+    expect(journal).toHaveAttribute('aria-disabled', 'true');
+    expect(journal.className).toContain('cursor-not-allowed');
   });
 
   it('renders the Login + Signup CTAs', async () => {

--- a/src/components/marketing/landing/sections/__tests__/MktNav.test.tsx
+++ b/src/components/marketing/landing/sections/__tests__/MktNav.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import messages from '../../../../../../messages/fr-BE.json';
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: async (namespace: string) => {
+    const ns = messages as Record<string, unknown>;
+    let cursor: unknown = ns;
+    for (const part of namespace.split('.')) {
+      cursor = (cursor as Record<string, unknown>)[part];
+    }
+    return (key: string) => {
+      const parts = key.split('.');
+      let value: unknown = cursor;
+      for (const part of parts) {
+        if (typeof value === 'object' && value !== null && part in value) {
+          value = (value as Record<string, unknown>)[part];
+        } else {
+          return key;
+        }
+      }
+      return typeof value === 'string' ? value : key;
+    };
+  },
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/components/layout/HeaderNav', () => ({
+  HeaderNav: ({ variant }: { variant: string }) => (
+    <div data-testid="header-nav-mock" data-variant={variant} />
+  ),
+}));
+
+vi.mock('@/components/brand/AnkoraLogo', () => ({
+  AnkoraLogo: ({ className }: { className?: string }) => (
+    <svg data-testid="ankora-logo" className={className} />
+  ),
+}));
+
+import { MktNav } from '../MktNav';
+
+async function renderMktNav() {
+  const ui = await MktNav();
+  return render(ui);
+}
+
+describe('<MktNav />', () => {
+  it('renders the Ankora logo as the home link', async () => {
+    await renderMktNav();
+    const home = screen.getByLabelText('Accueil Ankora');
+    expect(home).toHaveAttribute('href', '/');
+    expect(screen.getByTestId('ankora-logo')).toBeInTheDocument();
+  });
+
+  it('renders the 5 marketing nav links (desktop)', async () => {
+    await renderMktNav();
+    expect(screen.getByRole('link', { name: 'Produit' })).toHaveAttribute('href', '#principles');
+    expect(screen.getByRole('link', { name: 'Simulateur' })).toHaveAttribute('href', '#simulator');
+    expect(screen.getByRole('link', { name: 'Tarifs' })).toHaveAttribute('href', '#pricing');
+    expect(screen.getByRole('link', { name: 'Sécurité' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Journal' })).toBeInTheDocument();
+  });
+
+  it('renders the Login + Signup CTAs', async () => {
+    await renderMktNav();
+    expect(screen.getByRole('link', { name: 'Se connecter' })).toHaveAttribute('href', '/login');
+    expect(screen.getByRole('link', { name: /essayer gratuitement/i })).toHaveAttribute(
+      'href',
+      '/signup',
+    );
+  });
+
+  it('mounts the existing HeaderNav drawer for mobile parity', async () => {
+    await renderMktNav();
+    const drawer = screen.getByTestId('header-nav-mock');
+    expect(drawer).toBeInTheDocument();
+    expect(drawer).toHaveAttribute('data-variant', 'marketing');
+  });
+
+  it('exposes the main navigation with a localised aria-label', async () => {
+    await renderMktNav();
+    expect(screen.getByRole('navigation', { name: 'Navigation principale' })).toBeInTheDocument();
+  });
+});

--- a/src/components/marketing/landing/sections/__tests__/Pricing.test.tsx
+++ b/src/components/marketing/landing/sections/__tests__/Pricing.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import messages from '../../../../../../messages/fr-BE.json';
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: async (namespace: string) => {
+    const ns = messages as Record<string, unknown>;
+    let cursor: unknown = ns;
+    for (const part of namespace.split('.')) {
+      cursor = (cursor as Record<string, unknown>)[part];
+    }
+    return (key: string) => {
+      const parts = key.split('.');
+      let value: unknown = cursor;
+      for (const part of parts) {
+        if (typeof value === 'object' && value !== null && part in value) {
+          value = (value as Record<string, unknown>)[part];
+        } else {
+          return key;
+        }
+      }
+      return typeof value === 'string' ? value : key;
+    };
+  },
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+import { Pricing } from '../Pricing';
+
+async function renderPricing() {
+  return render(await Pricing());
+}
+
+describe('<Pricing />', () => {
+  it('renders the eyebrow + h2 (Phase 1 gratuit) + phase badge', async () => {
+    await renderPricing();
+    expect(screen.getByText('Transparent dès le départ')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 2, name: /gratuit pendant la phase 1/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/PHASE 1 · CONSTRUCTION/i)).toBeInTheDocument();
+  });
+
+  it('renders the 0 € price + period caption', async () => {
+    await renderPricing();
+    expect(screen.getByText('0 €')).toBeInTheDocument();
+    expect(screen.getByText(/sans date limite/i)).toBeInTheDocument();
+  });
+
+  it('renders the 4 features with Check icons (aria-hidden)', async () => {
+    const { container } = await renderPricing();
+    expect(screen.getByText(/Cockpit complet/i)).toBeInTheDocument();
+    expect(screen.getByText(/Simulateur what-if illimité/i)).toBeInTheDocument();
+    expect(screen.getByText(/Saisie manuelle/i)).toBeInTheDocument();
+    // "Export RGPD" appears twice (body paragraph + features list);
+    // the feature-list copy is the disambiguating one ("en un clic").
+    expect(screen.getByText(/Export RGPD en un clic/i)).toBeInTheDocument();
+    // 1 anchor SVG (decorative bg) + 4 Check icons + 1 Sparkles (roadmap) = 6 aria-hidden
+    const decorative = container.querySelectorAll('svg[aria-hidden="true"]');
+    expect(decorative.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('renders the primary CTA pointing at /signup', async () => {
+    await renderPricing();
+    expect(screen.getByRole('link', { name: /ouvrir mon cockpit/i })).toHaveAttribute(
+      'href',
+      '/signup',
+    );
+  });
+
+  it('renders the roadmap note as a separate <aside> with a labelled title', async () => {
+    await renderPricing();
+    const aside = screen.getByRole('complementary');
+    expect(aside).toHaveAttribute('aria-labelledby', 'pricing-roadmap-title');
+    expect(screen.getByText(/tu rejoins ankora pendant sa phase 1/i)).toBeInTheDocument();
+  });
+
+  it('exposes the pricing section as a named landmark via aria-labelledby', async () => {
+    await renderPricing();
+    const section = screen.getByRole('heading', { level: 2 }).closest('section');
+    expect(section).toHaveAttribute('aria-labelledby', 'pricing-heading');
+    expect(section).toHaveAttribute('id', 'pricing');
+  });
+});

--- a/src/components/marketing/landing/sections/__tests__/Principles.test.tsx
+++ b/src/components/marketing/landing/sections/__tests__/Principles.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import messages from '../../../../../../messages/fr-BE.json';
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: async (namespace: string) => {
+    const ns = messages as Record<string, unknown>;
+    let cursor: unknown = ns;
+    for (const part of namespace.split('.')) {
+      cursor = (cursor as Record<string, unknown>)[part];
+    }
+    return (key: string) => {
+      const parts = key.split('.');
+      let value: unknown = cursor;
+      for (const part of parts) {
+        if (typeof value === 'object' && value !== null && part in value) {
+          value = (value as Record<string, unknown>)[part];
+        } else {
+          return key;
+        }
+      }
+      return typeof value === 'string' ? value : key;
+    };
+  },
+}));
+
+import { Principles } from '../Principles';
+
+async function renderPrinciples() {
+  return render(await Principles());
+}
+
+describe('<Principles />', () => {
+  it('renders the eyebrow + h2 + intro paragraph', async () => {
+    await renderPrinciples();
+    expect(screen.getByText('Trois principes')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 2, name: /honnête de parler d'argent/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the 3 principles (Provisions affectées, Réserve libre, Simulateur what-if)', async () => {
+    await renderPrinciples();
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'Provisions affectées' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3, name: 'Réserve libre' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'Simulateur what-if' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders icons as decorative (aria-hidden) so the SR reads only the headings', async () => {
+    const { container } = await renderPrinciples();
+    const icons = container.querySelectorAll('svg[aria-hidden="true"]');
+    expect(icons.length).toBe(3);
+  });
+
+  it('exposes the section as a named landmark via aria-labelledby="principles-heading"', async () => {
+    await renderPrinciples();
+    const section = screen.getByRole('heading', { level: 2 }).closest('section');
+    expect(section).toHaveAttribute('aria-labelledby', 'principles-heading');
+    expect(section).toHaveAttribute('id', 'principles');
+  });
+});


### PR DESCRIPTION
> 🚧 **DRAFT — CHECKPOINT @cowork required after L2 (MktNav + Hero) before continuing L3-L7.**

## Summary

PR-3c-2 step L2 — replaces the old marketing top-of-fold (Header + inline Hero + Features 3 cards + Steps 3 numbered) with two new components mirroring the cc-design `Landing.jsx` mockup:

- `<MktNav />` — sticky bg + backdrop blur, 5 nav links, Login + Try-free CTAs
- `<Hero />` — Sparkles badge, H1 with serif italic highlight, 2 CTAs, 3 trust signals, Glass mockup card with "Aperçu cockpit" eyebrow + 3 KPIs + sparkline SVG

L0 (constants) + L1 (i18n keys) + L2 (sections + page.tsx + cleanup) **shipped**. L3-L7 (Principles, Feature, Pricing, FAQ refonte, FooterCTA, Footer, tests E2E) **pending @cowork validation**.

## Confirmation prérequis (6 points)

| # | Check | État |
|---|-------|------|
| a | PR #76 mergée sur main (squash `762c569`) | ✅ |
| b | Working tree clean | ✅ |
| c | main pull --ff-only sans conflit | ✅ |
| d | Atomic UI Glass/Eyebrow/Num/Row | ✅ disponibles |
| e | Button enrichi (translate-y-px + active:scale) | ✅ |
| f | Icon proxy `landing/icons.ts` | ✅ |

## Livraison MktNav

- Path : [src/components/marketing/landing/sections/MktNav.tsx](src/components/marketing/landing/sections/MktNav.tsx) — 76 lignes
- Tokens utilisés : `bg-background/70`, `border-border`, `text-muted-foreground`, `text-foreground`, `text-brand-600`, `backdrop-blur-xl`, etc. — **0 hardcoded color**
- i18n keys consommées : `landing.mktnav.{links.{product,simulator,pricing,security,journal},ctaLogin,ctaSignup}` + `common.{homeAria,nav.mainLabel}`
- Mobile menu : ✅ implémenté via réutilisation de `<HeaderNav variant="marketing">` (drawer existant, no touch). Sur mobile les nav links et CTAs desktop sont `hidden sm:inline-flex`, le drawer prend le relai.
- Tests : 5 Vitest pass

## Livraison Hero

- Path : [src/components/marketing/landing/sections/Hero.tsx](src/components/marketing/landing/sections/Hero.tsx) — 160 lignes
- Tokens utilisés : `bg-brand-surface`, `border-brand-surface-border`, `text-brand-text-strong`, `text-brand-300`, `text-brand-400`, `text-foreground`, `text-muted-foreground`, `text-muted`, `text-success`, `text-accent-400`, `bg-card/40`, `font-display` — **0 hardcoded color** (les hex dans `constants.ts` sont uniquement dans des commentaires JSDoc d'audit)
- i18n keys consommées : `landing.hero.{badge,h1Lead,h1Highlight,description,ctaPrimary,ctaSecondary,trust.{encrypted,noSale,languages},mockup.{eyebrow,browserUrl,kpis.{netRemaining,provisions,reserve}.{label,sub}}}`
- Eyebrow "Aperçu cockpit" intégré : ✅ (R1 @cowork respecté)
- Sparkline SVG : `currentColor` inherited from `text-brand-400` wrapper (gradient via `<defs>` avec `stopColor="currentColor"` + `stopOpacity`). Pas de hex direct, pas de CSS var dans SVG attribute.
- Tests : 10 Vitest pass

## Validation visuelle Vercel preview

Vercel preview va se déployer automatiquement quand cette draft PR aura un check Vercel vert. URL preview à venir dans le déploiement (cf. PR #76 avait `https://vercel.com/thierry-vanmeeterens-projects/ankora/...`).

**Écarts à valider visuellement par @cowork** :
- Radial-glow background du Hero (cf. mockup `Landing.jsx` ligne 36-40) **intentionnellement omis** dans cette itération. Justification : Ankora light mode lit propre sans ce glow décoratif. Si jugé essentiel par @cowork → ajout d'une class `.lp-hero-glow` dans `globals.css` en cleanup follow-up.
- 3 KPIs Hero : couleur "Net restant" utilise `text-success` (#059669, foncé) au lieu du `#34d399` emerald-400 du mockup (pas de token équivalent dans le repo). Doctrine "0 hardcoded color" prioritaire. Tokens utilisés pour les 2 autres KPIs (`text-accent-400`, `text-brand-300`) sont **identiques au mockup**.
- Trust signals : utilisent `text-muted` (gris décoratif) qui peut paraître plus pâle qu'attendu en light mode (#64748b, contraste sub-AA volontaire selon doctrine token-usage §2). Si jugé peu lisible → réévaluer en `text-muted-foreground` (475569, AAA).

## Tokens grep results

| Check | Résultat |
|-------|----------|
| `grep "#[0-9a-fA-F]\{6\}"` sur sections + constants.ts | ⚠️ Matches uniquement dans **commentaires JSDoc** de `constants.ts` (audit cc-design hex → token mapping). 0 dans le code applicatif. |
| `grep "rgb("` sur sections + constants.ts | ✅ 0 result |
| `grep "console.log"` sur landing/ | ✅ 0 result |
| `grep ": any"` sur sections | ✅ 0 result |
| `grep "hover:bg-muted"` sur landing/ | ✅ 0 result (token-usage doctrine respectée) |

## Tests + DoD pre-flight

| Check | Résultat |
|-------|----------|
| `npm run test` | ✅ **363 tests pass** (37 files, +15 vs main : 5 MktNav + 10 Hero) |
| `npm run lint` | ✅ 0 erreur (1 warning pré-existant glossaire hors scope) |
| `npm run typecheck` | ✅ 0 erreur |
| `npm run lint:use-server` | ✅ pass |

## Questions ouvertes pour @cowork

**Q1 — Radial glow Hero** : OK pour omettre dans cette itération (Ankora light mode reads cleanly), ou tu veux l'ajouter explicitement pour fidélité visuelle parfaite avec le mockup ?

**Q2 — KPI "Net restant" couleur** : `text-success` (#059669) acceptable, ou créer un nouveau token `--color-success-300: #34d399` pour matcher exactement le mockup ?

**Q3 — Trust signals lisibilité** : `text-muted` (sub-AA volontaire) ou monter en `text-muted-foreground` (AAA) ? Le mockup utilise visiblement le sub-AA pour cet effet de discrétion.

**Q4 — Liens MktNav `#security` et `#journal`** : pointent vers `#` (placeholder). Ces sections n'existent pas dans la landing v1.0. Acceptable pour PR-3c-2 ou créer des sections placeholder ?

## Risques identifiés

1. **Visual drift potentiel** vs mockup Claude Design (radial glow, légères couleurs). À valider visuellement sur preview Vercel.
2. **Mobile MktNav** : utilise le drawer `<HeaderNav>` qui a un design dashboard-oriented (8 occurrences `hover:bg-muted` connues, issue #74). Acceptable visuellement sur la landing publique mobile ?
3. **FAQ encore inline** dans `page.tsx` — sera refondue en L6. Cohabite temporairement avec le nouveau Hero.

## STOP — Attente validation @cowork

Si OK sur les 4 questions ci-dessus → GO L3 (Principles).
Si ajustements nécessaires → corrections avant continuer.

🚧 Draft, ne pas merger en l'état.