### PR TITLE
PR-3c-4: Hero waterfall — simplify to 3 canonical steps

### DIFF
--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -136,6 +136,16 @@
           "provisions": { "label": "Provisions", "sub": "67 % des 2 480 € planifiés" },
           "reserve": { "label": "Réserve", "sub": "+120 € vs. mars" }
         }
+      },
+      "waterfall": {
+        "income": "Revenus",
+        "incomeAmount": "+2 466 €",
+        "expenses": "Dépenses courantes",
+        "expensesAmount": "−1 959 €",
+        "provisionsCaption": "dont {amount} € lissés vers provisions affectées",
+        "available": "Argent disponible",
+        "availableAmount": "+507 €",
+        "ariaLabel": "Cascade illustrative : 2 466 € de revenus, 1 959 € de dépenses courantes (dont 59 € lissés en provisions), 507 € disponibles."
       }
     },
     "principles": {
@@ -161,16 +171,9 @@
       "eyebrow": "Cashflow waterfall",
       "h3Line1": "Du salaire au net disponible.",
       "h3Line2": "En un seul coup d'œil.",
-      "description": "Plus de mystère sur où va ton argent. Chaque étape est visible : salaire, provisions affectées, vie courante, réserve. Tu vois immédiatement si un poste dérape.",
+      "description": "Plus de mystère sur où va ton argent. Chaque étape est visible : revenus, dépenses courantes, argent disponible. Tu vois immédiatement si un poste dérape.",
       "ctaPrimary": "Voir un exemple",
-      "ctaSecondary": "Comment ça marche ?",
-      "bars": {
-        "salary": "Salaire",
-        "provisions": "Provisions",
-        "life": "Vie",
-        "reserve": "Réserve",
-        "remaining": "Reste"
-      }
+      "ctaSecondary": "Comment ça marche ?"
     },
     "whatif": {
       "title": "Et si tu changeais une seule chose ?",

--- a/messages/en.json
+++ b/messages/en.json
@@ -136,6 +136,16 @@
           "provisions": { "label": "Provisions", "sub": "67% of €2,480 planned" },
           "reserve": { "label": "Reserve", "sub": "+€120 vs. March" }
         }
+      },
+      "waterfall": {
+        "income": "Income",
+        "incomeAmount": "+2,466 €",
+        "expenses": "Daily expenses",
+        "expensesAmount": "−1,959 €",
+        "provisionsCaption": "of which {amount} € smoothed into earmarked provisions",
+        "available": "Available money",
+        "availableAmount": "+507 €",
+        "ariaLabel": "Illustrative cascade: 2,466 € income, 1,959 € daily expenses (of which 59 € smoothed into provisions), 507 € available."
       }
     },
     "principles": {
@@ -161,16 +171,9 @@
       "eyebrow": "Cashflow waterfall",
       "h3Line1": "From salary to net available.",
       "h3Line2": "At a single glance.",
-      "description": "No more mystery about where your money goes. Every step is visible: salary, earmarked provisions, daily life, reserve. You see immediately if anything drifts.",
+      "description": "No more mystery about where your money goes. Every step is visible: income, daily expenses, available money. You see immediately if anything drifts.",
       "ctaPrimary": "See an example",
-      "ctaSecondary": "How does it work?",
-      "bars": {
-        "salary": "Salary",
-        "provisions": "Provisions",
-        "life": "Life",
-        "reserve": "Reserve",
-        "remaining": "Remaining"
-      }
+      "ctaSecondary": "How does it work?"
     },
     "whatif": {
       "title": "What if you changed one thing?",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -136,6 +136,16 @@
           "provisions": { "label": "Provisions", "sub": "67 % des 2 480 € planifiés" },
           "reserve": { "label": "Réserve", "sub": "+120 € vs. mars" }
         }
+      },
+      "waterfall": {
+        "income": "Revenus",
+        "incomeAmount": "+2 466 €",
+        "expenses": "Dépenses courantes",
+        "expensesAmount": "−1 959 €",
+        "provisionsCaption": "dont {amount} € lissés vers provisions affectées",
+        "available": "Argent disponible",
+        "availableAmount": "+507 €",
+        "ariaLabel": "Cascade illustrative : 2 466 € de revenus, 1 959 € de dépenses courantes (dont 59 € lissés en provisions), 507 € disponibles."
       }
     },
     "principles": {
@@ -161,16 +171,9 @@
       "eyebrow": "Cashflow waterfall",
       "h3Line1": "Du salaire au net disponible.",
       "h3Line2": "En un seul coup d'œil.",
-      "description": "Plus de mystère sur où va ton argent. Chaque étape est visible : salaire, provisions affectées, vie courante, réserve. Tu vois immédiatement si un poste dérape.",
+      "description": "Plus de mystère sur où va ton argent. Chaque étape est visible : revenus, dépenses courantes, argent disponible. Tu vois immédiatement si un poste dérape.",
       "ctaPrimary": "Voir un exemple",
-      "ctaSecondary": "Comment ça marche ?",
-      "bars": {
-        "salary": "Salaire",
-        "provisions": "Provisions",
-        "life": "Vie",
-        "reserve": "Réserve",
-        "remaining": "Reste"
-      }
+      "ctaSecondary": "Comment ça marche ?"
     },
     "whatif": {
       "title": "Et si tu changeais une seule chose ?",

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -136,6 +136,16 @@
           "provisions": { "label": "Provisions", "sub": "67 % des 2 480 € planifiés" },
           "reserve": { "label": "Réserve", "sub": "+120 € vs. mars" }
         }
+      },
+      "waterfall": {
+        "income": "Revenus",
+        "incomeAmount": "+2 466 €",
+        "expenses": "Dépenses courantes",
+        "expensesAmount": "−1 959 €",
+        "provisionsCaption": "dont {amount} € lissés vers provisions affectées",
+        "available": "Argent disponible",
+        "availableAmount": "+507 €",
+        "ariaLabel": "Cascade illustrative : 2 466 € de revenus, 1 959 € de dépenses courantes (dont 59 € lissés en provisions), 507 € disponibles."
       }
     },
     "principles": {
@@ -161,16 +171,9 @@
       "eyebrow": "Cashflow waterfall",
       "h3Line1": "Du salaire au net disponible.",
       "h3Line2": "En un seul coup d'œil.",
-      "description": "Plus de mystère sur où va ton argent. Chaque étape est visible : salaire, provisions affectées, vie courante, réserve. Tu vois immédiatement si un poste dérape.",
+      "description": "Plus de mystère sur où va ton argent. Chaque étape est visible : revenus, dépenses courantes, argent disponible. Tu vois immédiatement si un poste dérape.",
       "ctaPrimary": "Voir un exemple",
-      "ctaSecondary": "Comment ça marche ?",
-      "bars": {
-        "salary": "Revenus",
-        "provisions": "Provisions",
-        "life": "Dépenses courantes",
-        "reserve": "Réserve",
-        "remaining": "Argent disponible"
-      }
+      "ctaSecondary": "Comment ça marche ?"
     },
     "whatif": {
       "title": "Et si tu changeais une seule chose ?",

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -136,6 +136,16 @@
           "provisions": { "label": "Provisions", "sub": "67 % des 2 480 € planifiés" },
           "reserve": { "label": "Réserve", "sub": "+120 € vs. mars" }
         }
+      },
+      "waterfall": {
+        "income": "Revenus",
+        "incomeAmount": "+2 466 €",
+        "expenses": "Dépenses courantes",
+        "expensesAmount": "−1 959 €",
+        "provisionsCaption": "dont {amount} € lissés vers provisions affectées",
+        "available": "Argent disponible",
+        "availableAmount": "+507 €",
+        "ariaLabel": "Cascade illustrative : 2 466 € de revenus, 1 959 € de dépenses courantes (dont 59 € lissés en provisions), 507 € disponibles."
       }
     },
     "principles": {
@@ -161,16 +171,9 @@
       "eyebrow": "Cashflow waterfall",
       "h3Line1": "Du salaire au net disponible.",
       "h3Line2": "En un seul coup d'œil.",
-      "description": "Plus de mystère sur où va ton argent. Chaque étape est visible : salaire, provisions affectées, vie courante, réserve. Tu vois immédiatement si un poste dérape.",
+      "description": "Plus de mystère sur où va ton argent. Chaque étape est visible : revenus, dépenses courantes, argent disponible. Tu vois immédiatement si un poste dérape.",
       "ctaPrimary": "Voir un exemple",
-      "ctaSecondary": "Comment ça marche ?",
-      "bars": {
-        "salary": "Salaire",
-        "provisions": "Provisions",
-        "life": "Vie",
-        "reserve": "Réserve",
-        "remaining": "Reste"
-      }
+      "ctaSecondary": "Comment ça marche ?"
     },
     "whatif": {
       "title": "Et si tu changeais une seule chose ?",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -6,6 +6,7 @@ Ankora is built and operated in Belgium by a solo indie developer. The app delib
 
 ## Core concepts
 
+- [Cashflow waterfall](https://ankora.be/): three canonical steps — income → daily expenses → available money. Earmarked provisions are surfaced as a discreet sub-caption under expenses (smoothing mechanism), not as a standalone step.
 - [Smoothed budget](https://ankora.be/glossaire/budget-de-lissage): converting irregular annual charges into monthly contributions
 - [Bucket account](https://ankora.be/glossaire/compte-bucket): sub-savings-account earmarked for a specific goal
 - [Saving capacity](https://ankora.be/glossaire/capacite-d-epargne): maximum structural savings without cutting into baseline standard of living

--- a/src/components/marketing/landing/constants.ts
+++ b/src/components/marketing/landing/constants.ts
@@ -2,19 +2,24 @@
  * Illustrative figures for the public landing.
  *
  * These numbers are NOT real user data — they're the showroom KPIs and
- * waterfall bars copied 1:1 from the cc-design `Landing.jsx` mockup
- * (`design-exports/unpacked-v1/.../landing_page/Landing.jsx`).
+ * waterfall steps used in the Hero/Feature sections. Hero KPIs come from
+ * the cc-design `Landing.jsx` mockup. The hero waterfall steps were
+ * realigned in PR-3c-4 to the 3-canonical-step model (Revenus → Dépenses
+ * courantes → Argent disponible) per `docs/design/claude-design-brief.md`
+ * L95 + L250 and the audit at
+ * `Athenaeum/10_Projects/ankora/analysis/2026-04-28-waterfall-coherence-audit.md`.
  *
- * They are not translatable: amounts use the international `1 660` format
- * (NBSP separator) and stay identical across locales. Only the labels
- * (`netRemaining`, `provisions`, `reserve`, `salary`, etc.) are i18n keys
- * read in the section components.
+ * Numbers are anchored on a real anonymised user case (~2 466 € income,
+ * ~1 959 € expenses, ~59 € provision smoothing, ~507 € available) so the
+ * landing visualises a coherent monthly cashflow rather than the original
+ * cc-design 5-step mockup that over-represented provisions as a 980 €
+ * siphon.
  *
- * Colour tokens use the shared design-system palette so the `[data-theme]`
- * and `[data-accent]` flips remap them consistently. Where a hex from the
- * mockup has no exact token equivalent, we picked the nearest semantic
- * token and noted the substitution — see Hero/Feature sections in PR-3c-2
- * report for the audit.
+ * Localisation: amounts are pre-formatted per locale in the i18n bundles
+ * (`messages/{locale}.json` under `landing.hero.waterfall.*` and
+ * `landing.hero.kpis.*`), with NBSP separators kept for fr-BE only — see
+ * Sourcery #1 / PR #82 pattern. The numeric constants below remain the
+ * source of truth for tests and any future computation.
  */
 
 export type HeroKpi = {
@@ -46,68 +51,31 @@ export const HERO_KPIS: readonly HeroKpi[] = [
   { key: 'reserve', display: '614 €', toneClass: 'text-brand-text-strong' },
 ];
 
-export type WaterfallBar = {
-  /** i18n key under `landing.feature.bars.{key}`. */
-  key: 'salary' | 'provisions' | 'life' | 'reserve' | 'remaining';
-  /** SVG x-coordinate (viewBox 0..400). */
-  x: number;
-  /** Bar height in SVG units (max 160 = full height). */
-  height: number;
-  /** Pre-formatted display value (NBSP separator, sign, no currency). */
-  display: string;
-  /** Tailwind fill class for the SVG `<rect>`. */
-  fillClass: string;
-  /** Tailwind text class for the value label sitting above the bar. */
-  textClass: string;
-};
-
-export const WATERFALL_BARS: readonly WaterfallBar[] = [
-  // #2dd4bf brand-400 (teal vif).
-  {
-    key: 'salary',
-    x: 20,
-    height: 160,
-    display: '+3 200',
-    fillClass: 'fill-brand-400',
-    textClass: 'text-brand-400',
-  },
-  // #d4a017 accent-400 (laiton).
-  {
-    key: 'provisions',
-    x: 100,
-    height: 50,
-    display: '−980',
-    fillClass: 'fill-accent-400',
-    textClass: 'text-accent-400',
-  },
-  // #38bdf8 → token --color-info (#0284c7, slightly darker).
-  {
-    key: 'life',
-    x: 180,
-    height: 70,
-    display: '−1 420',
-    fillClass: 'fill-info',
-    textClass: 'text-info',
-  },
-  // #5eead4 brand-300 (teal-300).
-  {
-    key: 'reserve',
-    x: 260,
-    height: 16,
-    display: '−320',
-    fillClass: 'fill-brand-300',
-    textClass: 'text-brand-300',
-  },
-  // #34d399 → token text-success (slightly darker, see HERO_KPIS netRemaining note).
-  {
-    key: 'remaining',
-    x: 340,
-    height: 24,
-    display: '+480',
-    fillClass: 'fill-success',
-    textClass: 'text-success',
-  },
-];
+/**
+ * Hero waterfall — 3-step canonical cashflow (PR-3c-4).
+ *
+ * Replaces the previous 5-step mockup (`WATERFALL_BARS` removed) which
+ * incorrectly mixed transfers (Provisions, Réserve) with real outflows
+ * (Dépenses courantes) and over-represented provisions as a primary
+ * siphon. The 3-step model matches `claude-design-brief.md` L95 + L250
+ * (*"salary → envelopes → expenses"*) and the audit verdict at
+ * `Athenaeum/10_Projects/ankora/analysis/2026-04-28-waterfall-coherence-audit.md`.
+ *
+ * `provisions` is rendered as a discreet sub-caption under the expenses
+ * step ("dont 59 € lissés vers provisions affectées"), not as a standalone
+ * step. The `available` figure is the visible bottom-line user takeaway
+ * and equals `income − expenses` by construction.
+ */
+export const HERO_WATERFALL_DEMO = {
+  /** Monthly income (illustrative, anchored on real anonymised user data). */
+  income: 2466,
+  /** Daily expenses incl. fixed bills + subscriptions + provision smoothing. */
+  expenses: 1959,
+  /** Discreet sub-segment of expenses smoothed into earmarked provisions. */
+  provisions: 59,
+  /** Bottom-line money available after expenses (= income − expenses). */
+  available: 507,
+} as const;
 
 /**
  * Hero sparkline — pre-baked SVG path from cc-design `Landing.jsx` line 101-102.

--- a/src/components/marketing/landing/sections/Feature.tsx
+++ b/src/components/marketing/landing/sections/Feature.tsx
@@ -153,7 +153,12 @@ export async function Feature() {
                 <span className="text-foreground text-sm font-medium">
                   {tWaterfall('available')}
                 </span>
-                <Num size="md" tone="accent" className="font-semibold">
+                {/* All three step amounts use the same `<Num size>` + token-coloured
+                    className pattern (`text-success`, `text-danger`, `text-brand-text-strong`)
+                    so the visual semantic stays in sync across the cascade. The
+                    `<Num tone>` prop only covers `default` / `accent` — success / danger
+                    do not have prop equivalents, hence the className alignment. */}
+                <Num size="md" className="text-brand-text-strong font-semibold">
                   {tWaterfall('availableAmount')}
                 </Num>
               </div>

--- a/src/components/marketing/landing/sections/Feature.tsx
+++ b/src/components/marketing/landing/sections/Feature.tsx
@@ -1,38 +1,84 @@
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 
 import { Button } from '@/components/ui/button';
 import { Eyebrow } from '@/components/ui/eyebrow';
+import { Num } from '@/components/ui/num';
 import { Link } from '@/i18n/navigation';
 
-import { WATERFALL_BARS } from '../constants';
+import { HERO_WATERFALL_DEMO } from '../constants';
 import { ArrowRight } from '../icons';
 
 /**
- * Feature — Cashflow waterfall surface highlight.
+ * Inline SVG used as connector between successive waterfall steps.
+ * Decorative — always rendered with `aria-hidden="true"` and no text content.
+ * Lifted out of `<Feature>` so React tree-shaking can pick it up and to
+ * keep the parent function pure (`react/no-unstable-nested-components`).
+ */
+function WaterfallArrowConnector() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="14"
+      height="20"
+      viewBox="0 0 14 20"
+      fill="none"
+      className="text-muted-foreground mx-auto"
+    >
+      <path
+        d="M7 0 L7 16 M2 11 L7 16 L12 11"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Feature — Cashflow waterfall surface highlight (3 canonical steps).
  *
- * Mirrors `Landing.jsx` cc-design `<Feature>` (lines 143-180):
- * - Outer card with subtle teal/laiton gradient background
- * - 2-column grid (md+): copy block on the left, SVG waterfall on the right
- * - Left: eyebrow accent + h3 split on 2 lines + paragraph + 2 CTAs
- * - Right: 5-bar SVG (salary, provisions, life, reserve, remaining) reading
- *   left→right as a budget breakdown. Bar colours come from
- *   `WATERFALL_BARS` constants (token classes — no hardcoded hex in JSX).
+ * 3 canonical steps per `docs/design/claude-design-brief.md` L95 + L250
+ * (*"salary → envelopes → expenses"*) and the coherence audit at
+ * `Athenaeum/10_Projects/ankora/analysis/2026-04-28-waterfall-coherence-audit.md`.
+ * See `cowork-handoffs/2026-04-28-2345-pr-3c-4-hero-waterfall-3steps.md`
+ * for the full spec — this PR (PR-3c-4) realigned the waterfall away from
+ * the cc-design 5-step mockup which over-represented provisions as a
+ * primary siphon.
  *
- * Each `<rect>` uses `currentColor` for fill, with the colour set by the
- * Tailwind `fill-*` token class on the rect itself (Tailwind 4 emits
- * `fill-brand-400`, `fill-accent-400`, etc. from the `@theme` block). The
- * value labels above the bars use the matching `text-*` class so the colour
- * stays in sync if the palette ever moves.
+ * Layout:
+ * - LEFT: copy block (eyebrow accent, h3 split on 2 lines, paragraph, CTAs)
+ * - RIGHT: 3-step ordered list (Revenus → Dépenses courantes → Argent
+ *   disponible) with token-coloured amounts. Connector arrows live INSIDE
+ *   the second and third `<li>` (above the step content) so the `<ol>`
+ *   contains exactly 3 list items — screen readers announce a 3-item
+ *   ordered sequence (not 5). The expenses step also carries a discreet
+ *   sub-caption ("dont 59 € lissés vers provisions affectées") that
+ *   surfaces the provisioning mechanism without elevating it to a
+ *   standalone step.
+ *
+ * Numbers come from `HERO_WATERFALL_DEMO` (anchored on a real anonymised
+ * user case — 2 466 € income, 1 959 € expenses, 507 € available). The
+ * displayed strings are pre-formatted per-locale in the i18n bundles.
+ *
+ * Accessibility:
+ * - The waterfall is wrapped in a `<figure>` with an `aria-label` that
+ *   reads the full cascade in plain language for assistive tech.
+ * - The step list uses `<ol>` so screen readers announce a 3-item
+ *   ordered sequence. Connector arrows are pure SVG decorations marked
+ *   `aria-hidden="true"` and live inside their step's `<li>`.
+ * - Token-driven colours (`text-success`, `text-danger`, `text-brand-text-strong`)
+ *   guarantee AA/AAA contrast across light + dark + admin accent flips.
  */
 export async function Feature() {
   const t = await getTranslations('landing.feature');
+  const tWaterfall = await getTranslations('landing.hero.waterfall');
+  const locale = await getLocale();
 
-  // SVG geometry — matches cc-design viewBox 0 0 400 200. Bar x-positions and
-  // heights come from `WATERFALL_BARS` constants; only width / baseline /
-  // label offset are tied to the layout itself.
-  const BAR_WIDTH = 46;
-  const BASELINE_Y = 180;
-  const TEXT_LABEL_OFFSET = 5; // gap between top of bar and its value label
+  // Locale-aware formatter for the provisions sub-amount, which is the
+  // one figure rendered dynamically (the three step amounts come straight
+  // from i18n strings so designers can tweak punctuation per locale).
+  const provisions = HERO_WATERFALL_DEMO.provisions.toLocaleString(locale);
 
   return (
     <section
@@ -68,52 +114,51 @@ export async function Feature() {
           </div>
         </div>
 
-        {/* RIGHT: SVG waterfall (a11y: <title> on the <svg> is the single
-            source of label — no redundant aria-label on the <figure>). */}
-        <figure className="border-border bg-card/50 rounded-2xl border p-5">
-          <svg viewBox="0 0 400 200" className="block h-auto w-full" role="img">
-            <title>{t('eyebrow')}</title>
-            {WATERFALL_BARS.map((bar) => {
-              const y = BASELINE_Y - bar.height;
-              return (
-                <g key={bar.key}>
-                  <rect
-                    x={bar.x}
-                    y={y}
-                    width={BAR_WIDTH}
-                    height={bar.height}
-                    rx="4"
-                    fillOpacity="0.85"
-                    className={bar.fillClass}
-                  />
-                  <text
-                    x={bar.x + BAR_WIDTH / 2}
-                    y={y - TEXT_LABEL_OFFSET}
-                    textAnchor="middle"
-                    fontSize="10"
-                    fontWeight="600"
-                    fontFamily="JetBrains Mono, monospace"
-                    className={bar.textClass}
-                    fill="currentColor"
-                  >
-                    {bar.display}
-                  </text>
-                  <text
-                    x={bar.x + BAR_WIDTH / 2}
-                    y={195}
-                    textAnchor="middle"
-                    fontSize="9"
-                    fontWeight="500"
-                    fontFamily="Inter, sans-serif"
-                    className="text-muted-foreground"
-                    fill="currentColor"
-                  >
-                    {t(`bars.${bar.key}`)}
-                  </text>
-                </g>
-              );
-            })}
-          </svg>
+        {/* RIGHT: 3-step waterfall */}
+        <figure
+          aria-label={tWaterfall('ariaLabel')}
+          className="border-border bg-card/50 rounded-2xl border p-5"
+        >
+          <ol className="grid gap-0">
+            {/* Step 1 — Income */}
+            <li className="border-border bg-card/60 flex items-center justify-between rounded-xl border p-4">
+              <span className="text-foreground text-sm font-medium">{tWaterfall('income')}</span>
+              <Num size="md" className="text-success font-semibold">
+                {tWaterfall('incomeAmount')}
+              </Num>
+            </li>
+
+            {/* Step 2 — Expenses + provisions caption (arrow connector at top) */}
+            <li className="grid gap-2">
+              <WaterfallArrowConnector />
+              <div className="border-border bg-card/60 grid gap-1.5 rounded-xl border p-4">
+                <div className="flex items-center justify-between">
+                  <span className="text-foreground text-sm font-medium">
+                    {tWaterfall('expenses')}
+                  </span>
+                  <Num size="md" className="text-danger font-semibold">
+                    {tWaterfall('expensesAmount')}
+                  </Num>
+                </div>
+                <p className="text-muted-foreground pl-3 font-mono text-xs tabular-nums">
+                  {tWaterfall('provisionsCaption', { amount: provisions })}
+                </p>
+              </div>
+            </li>
+
+            {/* Step 3 — Available (arrow connector at top) */}
+            <li className="grid gap-2">
+              <WaterfallArrowConnector />
+              <div className="border-brand-surface-border bg-brand-surface flex items-center justify-between rounded-xl border p-4">
+                <span className="text-foreground text-sm font-medium">
+                  {tWaterfall('available')}
+                </span>
+                <Num size="md" tone="accent" className="font-semibold">
+                  {tWaterfall('availableAmount')}
+                </Num>
+              </div>
+            </li>
+          </ol>
         </figure>
       </div>
     </section>

--- a/src/components/marketing/landing/sections/__tests__/Feature.test.tsx
+++ b/src/components/marketing/landing/sections/__tests__/Feature.test.tsx
@@ -1,17 +1,18 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 
 import messages from '../../../../../../messages/fr-BE.json';
-import { WATERFALL_BARS } from '../../constants';
+import { HERO_WATERFALL_DEMO } from '../../constants';
 
 vi.mock('next-intl/server', () => ({
+  getLocale: async () => 'fr-BE',
   getTranslations: async (namespace: string) => {
     const ns = messages as Record<string, unknown>;
     let cursor: unknown = ns;
     for (const part of namespace.split('.')) {
       cursor = (cursor as Record<string, unknown>)[part];
     }
-    return (key: string) => {
+    return (key: string, params?: Record<string, string | number>) => {
       const parts = key.split('.');
       let value: unknown = cursor;
       for (const part of parts) {
@@ -20,6 +21,11 @@ vi.mock('next-intl/server', () => ({
         } else {
           return key;
         }
+      }
+      if (typeof value === 'string' && params) {
+        return value.replace(/\{(\w+)\}/g, (_, k: string) =>
+          k in params ? String(params[k]) : `{${k}}`,
+        );
       }
       return typeof value === 'string' ? value : key;
     };
@@ -40,11 +46,9 @@ async function renderFeature() {
   return render(await Feature());
 }
 
-describe('<Feature />', () => {
+describe('<Feature /> — 3-step canonical waterfall', () => {
   it('renders the eyebrow + h3 split on 2 lines + description', async () => {
     await renderFeature();
-    // "Cashflow waterfall" appears in two places: the visible Eyebrow <p>
-    // and the SVG <title> (a11y label). The eyebrow is the visible one.
     expect(screen.getByText('Cashflow waterfall', { selector: 'p' })).toBeInTheDocument();
     const h3 = screen.getByRole('heading', { level: 3 });
     expect(h3.textContent).toContain('Du salaire au net disponible.');
@@ -63,23 +67,54 @@ describe('<Feature />', () => {
     );
   });
 
-  it('renders a 5-bar SVG waterfall (one rect per WATERFALL_BARS entry)', async () => {
+  it('exposes the waterfall in a <figure> with a localised aria-label', async () => {
     const { container } = await renderFeature();
-    const rects = container.querySelectorAll('svg rect');
-    expect(rects.length).toBe(WATERFALL_BARS.length);
+    const figure = container.querySelector('figure[aria-label]');
+    expect(figure).not.toBeNull();
+    expect(figure?.getAttribute('aria-label')).toContain('Cascade illustrative');
+    expect(figure?.getAttribute('aria-label')).toContain('2 466 €');
+    expect(figure?.getAttribute('aria-label')).toContain('507 €');
   });
 
-  it('renders one localised bar label per bar (Revenus, Provisions, Dépenses courantes, Réserve, Argent disponible)', async () => {
+  it('renders the 3 canonical steps in an <ol> (Revenus, Dépenses courantes, Argent disponible)', async () => {
     const { container } = await renderFeature();
-    const labels = container.querySelectorAll('svg text');
-    // 5 value labels (top of bar) + 5 axis labels (below) = 10 text nodes
-    expect(labels.length).toBe(WATERFALL_BARS.length * 2);
+    const list = container.querySelector('ol');
+    expect(list).not.toBeNull();
+
+    // Exactly 3 <li> children — connector arrows live INSIDE the second
+    // and third <li>, not as standalone list items, so screen readers
+    // announce a 3-item ordered sequence.
+    const items = list!.querySelectorAll(':scope > li');
+    expect(items.length).toBe(3);
+
+    expect(within(list!).getByText('Revenus')).toBeInTheDocument();
+    expect(within(list!).getByText('Dépenses courantes')).toBeInTheDocument();
+    expect(within(list!).getByText('Argent disponible')).toBeInTheDocument();
   });
 
-  it('exposes the SVG as role="img" with a localised <title> for screen readers', async () => {
+  it('renders the three step amounts with the correct sign + currency', async () => {
+    await renderFeature();
+    expect(screen.getByText('+2 466 €')).toBeInTheDocument();
+    expect(screen.getByText('−1 959 €')).toBeInTheDocument();
+    expect(screen.getByText('+507 €')).toBeInTheDocument();
+  });
+
+  it('renders the provisions sub-caption under the expenses step (FSMA-safe descriptive copy)', async () => {
+    await renderFeature();
+    const caption = screen.getByText(/lissés vers provisions affectées/i);
+    expect(caption).toBeInTheDocument();
+    expect(caption.textContent).toContain(String(HERO_WATERFALL_DEMO.provisions));
+  });
+
+  it('marks connector arrows as decorative SVG (not as list items)', async () => {
     const { container } = await renderFeature();
-    const svg = container.querySelector('svg[role="img"]');
-    expect(svg).not.toBeNull();
-    expect(svg?.querySelector('title')?.textContent).toBe('Cashflow waterfall');
+    const list = container.querySelector('ol');
+    expect(list).not.toBeNull();
+    // Connectors are SVG decorations inside step 2 and step 3 — never
+    // standalone <li>, so the <ol> stays a clean 3-item ordered list.
+    const decorativeSvgs = list!.querySelectorAll('svg[aria-hidden="true"]');
+    expect(decorativeSvgs.length).toBe(2);
+    // No <li> should be aria-hidden — they all carry semantic meaning.
+    expect(list!.querySelectorAll('li[aria-hidden="true"]').length).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Realigns the cashflow waterfall on the **3 canonical steps** validated in `claude-design-brief.md` L95 + L250 (*"salary → envelopes → expenses"*) and the coherence audit at `Athenaeum/10_Projects/ankora/analysis/2026-04-28-waterfall-coherence-audit.md`.

The previous 5-step mockup mixed transfers (provisions, réserve = bucket movements) with real outflows (dépenses courantes), and over-represented provisions as a 980 €/month siphon when real-world smoothing sits around 59 €/month. New model anchored on a real anonymised user case — see handoff at `cowork-handoffs/2026-04-28-2345-pr-3c-4-hero-waterfall-3steps.md`.

## What changed

- **`Feature.tsx`** rewritten as `<figure>` + `<ol>` with 3 `<li>` steps. Connector arrows (`<WaterfallArrowConnector>`) live INSIDE step 2 + step 3 (above their content) so screen readers announce a 3-item ordered sequence (not 5). Module-level helper keeps the parent function pure (`react/no-unstable-nested-components`).
- **`landing/constants.ts`** drops `WATERFALL_BARS` (5-bar SVG geometry) and exports `HERO_WATERFALL_DEMO` (income / expenses / provisions / available) as the source of truth for tests + dynamic computation.
- **`useLocale()` + `n.toLocaleString(locale)`** used for the provisions sub-amount (Sourcery #1 / PR #82 pattern). Step amounts pre-formatted per-locale.
- **i18n (5 locales)** — added `landing.hero.waterfall.{income,incomeAmount,expenses,expensesAmount,provisionsCaption,available,availableAmount,ariaLabel}`, removed obsolete `landing.feature.bars.*`, refreshed `landing.feature.description` to reference the 3 new steps.
- **`Feature.test.tsx`** rewritten — 7 assertions on the 3-step structure (figure aria-label, `<ol>` with exactly 3 `<li>`, step amounts + signs, provisions caption, decorative arrows as aria-hidden SVG inside list items).
- **`public/llms.txt`** — added Cashflow waterfall line (3 canonical steps) for GEO retrieval coherence.

## DoD checklist (`docs/cowork-handoff-conventions.md` §2)

- [ ] CI verts (Lint, Typecheck, Tests, E2E, Security, Build)
- [ ] Sourcery silent sur le DERNIER commit (vérification explicite obligatoire)
- [ ] mergeStateStatus : CLEAN
- [ ] 0 violation axe-core sur `/`
- [ ] Lighthouse perf ≥ 95, a11y / BP / SEO = 100
- [ ] Rapport final livré dans `cc-handoffs/2026-04-XX-HHMM-pr-3c-4-merged.md`

## Test plan

- [x] `npm run lint` → 0 errors (3 pre-existing warnings unchanged)
- [x] `npm run lint:use-server` → all green
- [x] `npm run typecheck` → 0 errors
- [x] `npm run test -- --run` → 409 tests passing (407 from main + 2 net new)
- [x] `npx playwright test e2e/landing-sections.spec.ts --project=chromium-desktop` → 9/9 pass (when run sequentially ; local parallel fails are dev-server contention, CI is workers=1)
- [x] QA agents : ui-auditor (PASS_WITH_NOTES, blocker fixed pre-commit) · seo-geo-auditor (PASS_WITH_NOTES, llms.txt updated) · test-runner (ALL_GREEN)

## Garde-fous (handoff §9)

- ❌ ZÉRO touch on `src/lib/domain/` (bucket-model intact, ADR-002 unchanged)
- ❌ ZÉRO touch on `WhatIfDemo*` (PR #82 mergée, scope séparé)
- ❌ ZÉRO ajout dépendance (SVG inline pur)
- ❌ ZÉRO nouvelle ADR (alignment UI sur intention originale)

## Refs

- Handoff : `Athenaeum/10_Projects/ankora/cowork-handoffs/2026-04-28-2345-pr-3c-4-hero-waterfall-3steps.md`
- Audit : `Athenaeum/10_Projects/ankora/analysis/2026-04-28-waterfall-coherence-audit.md`
- Brief original : `docs/design/claude-design-brief.md` L95 + L250

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Réaligner la fonctionnalité de flux de trésorerie de la page d’accueil sur un modèle de héro « waterfall » en 3 étapes, accessible, basé sur les chiffres canoniques revenus → dépenses → trésorerie disponible.

Nouvelles fonctionnalités :
- Introduire une figure de flux de trésorerie principal (« hero cashflow waterfall ») en 3 étapes avec les montants de revenus, de dépenses et de trésorerie disponible, provenant de constantes de démonstration partagées.

Améliorations :
- Remplacer l’ancien graphique en cascade à 5 barres basé sur un SVG par une balise `<figure>` sémantique et une liste ordonnée qui reflètent mieux les flux de trésorerie réels et améliorent l’accessibilité.
- Centraliser les nombres de démonstration du hero waterfall dans une nouvelle constante `HERO_WATERFALL_DEMO` pour la réutilisation et des tests cohérents.

Documentation :
- Mettre à jour les bundles de messages de locale pour décrire le nouveau waterfall en 3 étapes, y compris les libellés, les montants, l’attribut aria-label et un texte de description de la fonctionnalité actualisé.
- Ajouter une note dans `public/llms.txt` documentant le flux de trésorerie en cascade en 3 étapes afin d’assurer la cohérence de la récupération externe.

Tests :
- Réécrire les tests du composant Feature pour vérifier la nouvelle structure en 3 étapes, les libellés aria, les montants formatés, la légende des provisions et les connecteurs SVG décoratifs.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Realign the landing page cashflow feature to a 3-step, accessible hero waterfall model based on canonical income → expenses → available cash figures.

New Features:
- Introduce a 3-step hero cashflow waterfall figure with income, expenses, and available cash amounts sourced from shared demo constants.

Enhancements:
- Replace the previous SVG-based 5-bar waterfall with a semantic figure and ordered list that better reflects real-world cashflow and improves accessibility.
- Centralise hero waterfall demo numbers in a new HERO_WATERFALL_DEMO constant for reuse and coherent testing.

Documentation:
- Update locale message bundles to describe the new 3-step waterfall, including labels, amounts, aria label, and refreshed feature description copy.
- Add a note to public/llms.txt documenting the 3-step cashflow waterfall for external retrieval consistency.

Tests:
- Rewrite Feature component tests to assert the new 3-step structure, aria labelling, formatted amounts, provisions caption, and decorative SVG connectors.

</details>