### PR TITLE
fix(seo): use SITE.url for canonical URL in glossary

### DIFF
--- a/src/lib/glossary.ts
+++ b/src/lib/glossary.ts
@@ -1,6 +1,7 @@
 import frBE from '../../content/glossary/fr-BE.json';
 import nlBE from '../../content/glossary/nl-BE.json';
 import en from '../../content/glossary/en.json';
+import { SITE } from './site';
 
 export type GlossaryTerm = {
   slug: string;
@@ -50,7 +51,6 @@ export function getLocalePrefix(locale: string): string {
 }
 
 export function buildCanonicalUrl(path: string, locale: string): string {
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://ankora-chi.vercel.app';
   const prefix = getLocalePrefix(locale);
-  return `${baseUrl}${prefix}${path}`;
+  return `${SITE.url}${prefix}${path}`;
 }


### PR DESCRIPTION
Replaces hardcoded NEXT_PUBLIC_SITE_URL fallback with SITE.url
(validated by Zod schema in env.ts). Closes P0-2 from SEO audit
2026-05-03 (cc-handoffs/2026-05-03-1430-seo-geo-aeo-og-audit.md).

## Summary by Sourcery

Améliorations :
- Remplacer l’URL de base codée en dur ou provenant de l’environnement, utilisée pour la construction de l’URL canonique du glossaire, par la valeur `SITE.url` de la configuration, validée par Zod.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Replace hardcoded and environment-based base URL in glossary canonical URL construction with the Zod-validated SITE.url configuration value.

</details>