### PR TITLE
feat(cockpit): PR-D1 Voie D foundations — data model + 7 pure domain modules

### DIFF
--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -1,1024 +1,1068 @@
 {
   "common": {
-  "appName": "Ankora",
-  "tagline": "Dein finanzieller Anker",
-  "description": "Ankora hilft dir, deine Fixkosten zu verteilen, jede Rechnung vorauszuplanen und dein Budget im Griff zu behalten. Klares und sicheres Cockpit, ohne Anlageberatung.",
-  "homeAria": "Startseite Ankora",
-  "a11y": {
-    "skipToMain": "Zum Hauptinhalt springen"
-  },
-  "nav": {
-    "mainLabel": "Hauptnavigation",
-    "appLabel": "App-Navigation",
-    "mobileLabel": "Mobile Navigation",
-    "footerLabel": "Fußzeile",
-    "menu": "Menü",
-    "close": "Schließen",
-    "lightMode": "Heller Modus",
-    "darkMode": "Dunkler Modus",
-    "features": "Funktionen",
-    "faq": "FAQ",
-    "login": "Anmelden",
-    "signup": "Konto erstellen",
-    "myCockpit": "Mein Cockpit",
-    "dashboard": "Dashboard",
-    "accounts": "Konten",
-    "charges": "Fixkosten",
-    "settings": "Einstellungen"
-  },
-  "actions": {
-    "retry": "Erneut versuchen",
-    "back": "Zurück"
-  },
-  "months": {
-    "1": "Januar",
-    "2": "Februar",
-    "3": "März",
-    "4": "April",
-    "5": "Mai",
-    "6": "Juni",
-    "7": "Juli",
-    "8": "August",
-    "9": "September",
-    "10": "Oktober",
-    "11": "November",
-    "12": "Dezember"
-  },
-  "monthsShort": {
-    "1": "Jan",
-    "2": "Feb",
-    "3": "Mrz",
-    "4": "Apr",
-    "5": "Mai",
-    "6": "Jun",
-    "7": "Jul",
-    "8": "Aug",
-    "9": "Sep",
-    "10": "Okt",
-    "11": "Nov",
-    "12": "Dez"
-  },
-  "frequency": {
-    "monthly": "Monatlich",
-    "quarterly": "Vierteljährlich",
-    "semiannual": "Halbjährlich",
-    "annual": "Jährlich"
-  }
-  },
-  "ui": {
-  "scrollToTop": "Nach oben scrollen",
-  "localeSwitcher": {
-    "label": "Sprache",
-    "aria": "Sprache ändern",
-    "options": {
-    "fr-BE": "Français (BE)",
-    "nl-BE": "Nederlands (BE)",
-    "en": "English",
-    "es-ES": "Español",
-    "de-DE": "Deutsch"
-    }
-  },
-  "action": {
-    "submit": "Bestätigen",
-    "submitting": "Bestätigung…",
-    "save": "Speichern",
-    "saving": "Speichern…",
-    "cancel": "Abbrechen",
-    "cancelling": "Abbrechen…",
-    "delete": "Löschen",
-    "deleting": "Löschen…",
-    "create": "Erstellen",
-    "creating": "Erstellen…",
-    "update": "Aktualisieren",
-    "updating": "Aktualisieren…",
-    "send": "Senden",
-    "sending": "Senden…",
-    "verify": "Prüfen",
-    "verifying": "Prüfen…",
-    "generate": "Generieren",
-    "generating": "Generieren…",
-    "download": "Herunterladen",
-    "downloading": "Herunterladen…",
-    "preparing": "Vorbereiten…",
-    "confirm": "Bestätigen",
-    "close": "Schließen"
-  }
-  },
-  "landing": {
-  "mktnav": {
-    "links": {
-    "product": "Produit",
-    "simulator": "Simulateur",
-    "pricing": "Tarifs",
-    "security": "Sécurité",
-    "journal": "Journal"
+    "appName": "Ankora",
+    "tagline": "Dein finanzieller Anker",
+    "description": "Ankora hilft dir, deine Fixkosten zu verteilen, jede Rechnung vorauszuplanen und dein Budget im Griff zu behalten. Klares und sicheres Cockpit, ohne Anlageberatung.",
+    "homeAria": "Startseite Ankora",
+    "a11y": {
+      "skipToMain": "Zum Hauptinhalt springen"
     },
-    "ctaLogin": "Se connecter",
-    "ctaSignup": "Essayer gratuitement"
-  },
-  "hero": {
-    "badge": "Nouveau · Simulateur what-if",
-    "h1Lead": "Ton ancrage",
-    "h1Highlight": "financier.",
-    "description": "Ankora sépare tes provisions affectées de ta réserve libre, projette six mois devant, et te laisse simuler l'impact de chaque décision — en clair, sans jargon.",
-    "ctaPrimary": "Ouvrir mon cockpit",
-    "ctaSecondary": "Voir le simulateur",
-    "trust": {
-    "encrypted": "Données chiffrées en Belgique",
-    "noSale": "Aucune vente de données",
-    "languages": "FR · NL · EN"
+    "nav": {
+      "mainLabel": "Hauptnavigation",
+      "appLabel": "App-Navigation",
+      "mobileLabel": "Mobile Navigation",
+      "footerLabel": "Fußzeile",
+      "menu": "Menü",
+      "close": "Schließen",
+      "lightMode": "Heller Modus",
+      "darkMode": "Dunkler Modus",
+      "features": "Funktionen",
+      "faq": "FAQ",
+      "login": "Anmelden",
+      "signup": "Konto erstellen",
+      "myCockpit": "Mein Cockpit",
+      "dashboard": "Dashboard",
+      "accounts": "Konten",
+      "charges": "Fixkosten",
+      "settings": "Einstellungen"
     },
-    "mockup": {
-    "eyebrow": "Aperçu cockpit",
-    "browserUrl": "Ankora · cockpit",
-    "kpis": {
-      "netRemaining": {
-      "label": "Net restant",
-      "sub": "avril · après provisions"
-      },
-      "provisions": {
-      "label": "Provisions",
-      "sub": "67 % des 2 480 € planifiés"
-      },
-      "reserve": {
-      "label": "Réserve",
-      "sub": "+120 € vs. mars"
-      }
-    }
+    "actions": {
+      "retry": "Erneut versuchen",
+      "back": "Zurück"
     },
-    "waterfall": {
-    "income": "Revenus",
-    "incomeAmount": "+2 466 €",
-    "expenses": "Dépenses courantes",
-    "expensesAmount": "−1 959 €",
-    "provisionsCaption": "dont {amount} € lissés vers provisions affectées",
-    "available": "Argent disponible",
-    "availableAmount": "+507 €",
-    "ariaLabel": "Cascade illustrative : 2 466 € de revenus, 1 959 € de dépenses courantes (dont 59 € lissés en provisions), 507 € disponibles."
-    }
-  },
-  "principles": {
-    "eyebrow": "Trois principes",
-    "h2": "Une façon honnête de parler d'argent.",
-    "description": "Ankora n'essaye pas de te vendre un placement ou une carte. On sépare, on projette, on simule. C'est tout. Toi seul décides.",
-    "items": {
-    "provisions": {
-      "title": "Provisions affectées",
-      "description": "Chaque euro réservé a un nom : mutuelle, taxe circulation, entretien chaudière. Rien ne fuit sans que tu le saches."
-    },
-    "reserve": {
-      "title": "Réserve libre",
-      "description": "Ce qui reste vraiment à toi, après les engagements. Le vrai chiffre — pas l'illusion du solde brut."
-    },
-    "whatIf": {
-      "title": "Simulateur what-if",
-      "description": "Renégocier l'électricité ? Changer de fournisseur ? Ankora te montre l'impact sur 12 mois avant que tu décides."
-    }
-    }
-  },
-  "feature": {
-    "eyebrow": "Cashflow waterfall",
-    "h3Line1": "Du salaire au net disponible.",
-    "h3Line2": "En un seul coup d'œil.",
-    "description": "Plus de mystère sur où va ton argent. Chaque étape est visible : revenus, dépenses courantes, argent disponible. Tu vois immédiatement si un poste dérape.",
-    "ctaPrimary": "Voir un exemple",
-    "ctaSecondary": "Comment ça marche ?"
-  },
-  "whatif": {
-    "title": "Et si tu changeais une seule chose ?",
-    "subtitle": "Bouge le curseur. Vois l'impact sur ta réserve libre, sur six mois. C'est ce que fait Ankora à chaque décision financière.",
-    "badge": "Démo · pas de compte requis",
-    "scenarios": {
-    "gsm": {
-      "label": "Renégocier mon GSM",
-      "hint": "Forfait actuel : 42 €/mois · marché : 18–28 €/mois"
-    },
-    "elec": {
-      "label": "Changer de fournisseur d'électricité",
-      "hint": "Conso actuelle : 168 €/mois · 3 offres moins chères dans ta zone"
-    },
-    "stream": {
-      "label": "Couper deux streamings",
-      "hint": "5 abonnements actifs · usage réel : 2 sur 30 jours"
-    }
-    },
-    "controls": {
-    "scenario": "Scénario",
-    "savings": "Économie mensuelle",
-    "slider_aria": "Économie mensuelle pour {label}"
-    },
-    "annual": {
-    "eyebrow": "Sur 12 mois",
-    "fleche": "Ankora pourrait flécher {amount} €/mois vers ton épargne longue."
-    },
-    "chart": {
-    "title": "Réserve libre · projection",
-    "subtitle": "6 mois à partir d'aujourd'hui",
-    "legend": {
-      "baseline": "Sans changement",
-      "scenario": "Avec ton choix"
-    },
-    "aria": "Graphique projection sur 6 mois de la réserve libre, avec et sans le changement choisi",
     "months": {
-      "may": "mai",
-      "jun": "juin",
-      "jul": "juil",
-      "aug": "août",
-      "sep": "sept",
-      "oct": "oct"
+      "1": "Januar",
+      "2": "Februar",
+      "3": "März",
+      "4": "April",
+      "5": "Mai",
+      "6": "Juni",
+      "7": "Juli",
+      "8": "August",
+      "9": "September",
+      "10": "Oktober",
+      "11": "November",
+      "12": "Dezember"
     },
-    "thresholds": {
-      "danger": "⚠️ Découvert estimé",
-      "fragile": "Zone fragile",
-      "comfortable": "Zone confortable"
-    }
-    },
-    "caveat": "Démo basée sur des hypothèses moyennes. Ankora ne fournit pas de conseil en placement. Aucun import bancaire — tu saisis tes charges manuellement."
-  },
-  "pricing": {
-    "eyebrow": "Transparent dès le départ",
-    "h2": "Gratuit pendant la Phase 1.",
-    "phaseBadge": "Phase 1 · construction",
-    "price": "0 €",
-    "period": "pour l'instant, et sans date limite",
-    "body": "On construit d'abord le cockpit. Pas de carte demandée, pas de limite de temps, pas de fonctionnalité bridée. Export RGPD à tout moment.",
-    "features": {
-    "cockpit": "Cockpit complet, provisions et réserve libre",
-    "simulator": "Simulateur what-if illimité",
-    "manualEntry": "Saisie manuelle · tes données restent en Belgique",
-    "export": "Export RGPD en un clic"
-    },
-    "ctaPrimary": "Ouvrir mon cockpit",
-    "roadmap": {
-    "title": "Tu rejoins Ankora pendant sa Phase 1 ?",
-    "body": "Ton compte garde un accès complet au cockpit core à vie, gratuitement. Une offre Pro avec features avancées (comptes illimités, exports consolidés, support prioritaire) arrivera post-v1.0 — tu auras le choix d'upgrader ou de rester sur ton plan actuel.",
-    "link": "Lire la roadmap →"
-    }
-  },
-  "footerCta": {
-    "h2Lead": "Commence par ce qui est",
-    "h2Highlight": "déjà à toi.",
-    "description": "30 jours d'essai, pas de carte, export RGPD à tout moment. On fait simple parce que c'est déjà assez compliqué comme ça.",
-    "ctaPrimary": "Ouvrir mon cockpit"
-  },
-  "footer": {
-    "links": {
-    "terms": "Conditions",
-    "privacy": "Confidentialité",
-    "security": "Sécurité",
-    "contact": "Contact"
-    },
-    "copyright": "Ankora · éditeur ancré à Bruxelles · 2026"
-  },
-  "faqHeading": "Häufige Fragen",
-  "faq": {
-    "advice": {
-    "q": "Ist Ankora ein Finanzberatungstool?",
-    "a": "Nein. Ankora ist ein Tool für Budgetorganisation und finanzielle Bildung. Es bietet keine Anlageempfehlungen oder personalisierte Finanzberatung."
-    },
-    "storage": {
-    "q": "Wo werden meine Daten gespeichert?",
-    "a": "Deine Daten werden in der Europäischen Union gehostet (Supabase, EU-Region) mit Verschlüsselung im Ruhezustand und strikter Nutzer-Isolation über Row Level Security."
-    },
-    "sharing": {
-    "q": "Kann ich meine Daten teilen?",
-    "a": "Standardmäßig ist dein Bereich zu 100 % privat. Optionale geteilte Töpfe (Reise, gemeinsames Projekt) kommen in einer nächsten Version — du entscheidest ausdrücklich, was du teilst und mit wem."
-    }
-  }
-  },
-  "faq": {
-  "metaTitle": "FAQ",
-  "metaDescription": "Häufige Fragen zu Ankora: Sicherheit, Daten, Funktionsweise, Datenschutz.",
-  "title": "Häufige Fragen",
-  "subtitle": "Alles, was du über Ankora wissen musst, bevor du loslegst.",
-  "items": {
-    "bankConnection": {
-    "q": "Verbindet sich Ankora mit meiner Bank?",
-    "a": "Nein. Ankora nutzt die PSD2-Richtlinie nicht. Du trägst deine Fixkosten und Ausgaben manuell ein. Diese Wahl stellt sicher, dass du Eigentümer deiner Daten bleibst und keine sensiblen Bankinformationen gespeichert werden."
-    },
-    "dataLocation": {
-    "q": "Wo werden meine Daten gehostet?",
-    "a": "Alle deine Daten werden in der Europäischen Union gehostet (Supabase EU-Region, Vercel EU-Region, Upstash EU). Es findet keine Übertragung außerhalb der EU statt."
-    },
-    "smoothing": {
-    "q": "Wie funktioniert die Verteilung?",
-    "a": "Ankora nimmt deine vierteljährlichen, halbjährlichen und jährlichen Fixkosten und verteilt sie auf 12 Monate. So weißt du, wie viel du jeden Monat zurücklegen musst, um alle zukünftigen Rechnungen stressfrei zu decken."
-    },
-    "deletion": {
-    "q": "Kann ich mein Konto löschen?",
-    "a": "Ja, jederzeit unter Einstellungen → Datenschutz. Die Löschung wird 30 Tage nach deinem Antrag wirksam (du kannst sie in diesem Zeitraum widerrufen). Alle deine Finanzdaten werden gelöscht, die Sicherheitslogs werden pseudonymisiert."
-    },
-    "export": {
-    "q": "Kann ich meine Daten exportieren?",
-    "a": "Ja. Die Schaltfläche „Meine Daten herunterladen“ in den Einstellungen liefert dir eine vollständige JSON-Datei mit allem, was Ankora über dich hat. Konform mit dem Recht auf Datenübertragbarkeit der DSGVO (Art. 20)."
-    },
-    "advice": {
-    "q": "Gibt Ankora Finanzberatung?",
-    "a": "Nein. Ankora ist ein Tool für Budgetbildung und Organisation. Wir geben keine Anlageberatung (regulatorische Einschränkung FSMA Belgien). Für jede Anlageentscheidung wende dich an eine zugelassene Fachperson."
-    },
-    "ai": {
-    "q": "Gibt es künstliche Intelligenz?",
-    "a": "In Phase 1 nein. Die Berechnungen sind deterministisch und auditierbar. In Phase 2 ermöglicht dir eine optionale BYOK-Schicht (Bring Your Own Key), deinen eigenen Anthropic- oder OpenRouter-Schlüssel für Vorschläge zu verbinden — ohne Mehrkosten auf Ankora-Seite."
-    },
-    "sharing": {
-    "q": "Kann ich meinen Bereich mit meinen Kindern oder Freunden teilen?",
-    "a": "In Phase 1 hat jeder Nutzer einen privaten, standardmäßig isolierten Bereich. In Phase 2 fügen wir die Möglichkeit hinzu, „geteilte Töpfe“ zu erstellen (per Einladung, mit Viewer/Editor-Rollen), ohne jemals deine persönlichen Daten zu vermischen."
-    }
-  }
-  },
-  "legal": {
-  "versionLine": "Version {version} — letzte Aktualisierung: {date}",
-  "lastUpdatedLine": "Letzte Aktualisierung: {date}",
-  "cgu": {
-    "metaTitle": "Allgemeine Nutzungsbedingungen",
-    "metaDescription": "AGB von Ankora — Regeln für die Nutzung des Dienstes.",
-    "title": "Allgemeine Nutzungsbedingungen",
-    "s1": {
-    "heading": "1. Zweck",
-    "body": "Ankora ist ein Tool für Budgetorganisation und finanzielle Bildung für Privatpersonen. Es ermöglicht, Fixkosten und Ausgaben manuell einzutragen, sie über das Jahr zu verteilen und den Liquiditätsbedarf vorauszuplanen."
-    },
-    "s2": {
-    "heading": "2. Was Ankora NICHT ist",
-    "item1": "Ankora ist <b>kein Dienst für Anlage-</b> oder Investitionsberatung.",
-    "item2": "Ankora ist <b>kein Bankdienst</b> und hält keine Gelder.",
-    "item3": "Ankora ist <b>kein PSD2-Aggregator</b> — keine Verbindung zu deinen Bankkonten.",
-    "item4": "Ankora ist <b>keine professionelle Buchhaltungssoftware</b>.",
-    "outro": "Die angezeigten Informationen sind Schätzungen auf Basis deiner Eingaben. Sie stellen keine personalisierte Finanzberatung dar. Für wichtige Entscheidungen wende dich an eine zugelassene Fachperson."
-    },
-    "s3": {
-    "heading": "3. Konto",
-    "item1": "Du musst volljährig sein oder die Zustimmung eines gesetzlichen Vertreters haben.",
-    "item2": "Ein Konto pro natürlicher Person.",
-    "item3": "Passwort mindestens 12 Zeichen, gemischt.",
-    "item4": "Du bist für die Vertraulichkeit deiner Zugangsdaten verantwortlich."
-    },
-    "s4": {
-    "heading": "4. Akzeptable Nutzung",
-    "intro": "Du verpflichtest dich, nicht:",
-    "item1": "den Dienst für illegale Zwecke zu nutzen,",
-    "item2": "Sicherheitsmaßnahmen zu umgehen,",
-    "item3": "den Zugriff ohne ausdrückliche Erlaubnis zu automatisieren,",
-    "item4": "dein Konto mit Dritten zu teilen."
-    },
-    "s5": {
-    "heading": "5. Geistiges Eigentum",
-    "body": "Du bleibst Eigentümer deiner Daten. Ankora behält das Eigentum an seinem Code, seiner Marke, seinem Design und seiner Dokumentation."
-    },
-    "s6": {
-    "heading": "6. Haftung",
-    "body": "Ankora wird „wie besehen“ bereitgestellt. Der Herausgeber kann nicht für Finanzentscheidungen verantwortlich gemacht werden, die auf Grundlage der angezeigten Informationen getroffen werden. Keine Garantie für 100 % Verfügbarkeit."
-    },
-    "s7": {
-    "heading": "7. Kündigung",
-    "body": "Du kannst dein Konto jederzeit unter Einstellungen → Datenschutz löschen. Die Löschung wird 30 Tage nach dem Antrag wirksam (widerrufbare Frist)."
-    },
-    "s8": {
-    "heading": "8. Anwendbares Recht",
-    "body": "Diese AGB unterliegen belgischem Recht. Zuständiges Gericht: Brüssel."
-    },
-    "draft": "Unsere Allgemeinen Nutzungsbedingungen werden derzeit erstellt.",
-    "contact": "Bei Fragen kontaktiere uns: thierryvm@gmail.com",
-    "backHome": "Zurück zur Startseite"
-  },
-  "privacy": {
-    "metaTitle": "Datenschutzerklärung",
-    "metaDescription": "Datenschutzerklärung von Ankora — EU-Hosting, DSGVO, Rechte der Nutzer.",
-    "title": "Datenschutzerklärung",
-    "s1": {
-    "heading": "1. Verantwortlicher",
-    "body": "Ankora, herausgegeben von Thierry Van Mele (Belgien). Kontakt: <mail>thierryvm@gmail.com</mail>."
-    },
-    "s2": {
-    "heading": "2. Erhobene Daten",
-    "intro": "Ankora erhebt nur die für die Bereitstellung des Dienstes unbedingt erforderlichen Daten:",
-    "item1": "<b>Identität</b>: E-Mail-Adresse, Anzeigename (optional).",
-    "item2": "<b>Von dir eingegebene Finanzdaten</b>: Fixkosten, Ausgaben, Kategorien, deklariertes Einkommen, Sparguthaben.",
-    "item3": "<b>Technische Daten</b>: IP-Adresse, User-Agent (nur für Sicherheitslogs).",
-    "item4": "<b>Einwilligungen</b>: Zeitstempel, Version, Umfang (AGB, Datenschutz, Cookies).",
-    "outro": "Ankora verbindet sich mit keiner Bank (keine PSD2-Aggregation). Du gibst deine Fixkosten und Ausgaben selbst ein."
-    },
-    "s3": {
-    "heading": "3. Rechtsgrundlagen (DSGVO Art. 6)",
-    "item1": "<b>Vertrag</b>: Bereitstellung des Dienstes (Konto, Finanzdaten).",
-    "item2": "<b>Einwilligung</b>: Analytics-/Marketing-Cookies, Newsletter.",
-    "item3": "<b>Gesetzliche Pflicht</b>: Sicherheitslogs (Aufbewahrung 12 Monate).",
-    "item4": "<b>Berechtigtes Interesse</b>: Betrugsprävention, Aufrechterhaltung der Sicherheit."
-    },
-    "s4": {
-    "heading": "4. Hosting und Auftragsverarbeiter",
-    "item1": "<b>Supabase</b> (Datenbank, Auth) — EU-Region (Frankfurt oder Paris).",
-    "item2": "<b>Vercel</b> (Frontend-Hosting) — EU-Region (Dublin).",
-    "item3": "<b>Upstash</b> (Rate Limiting) — EU-Region.",
-    "outro": "Es werden keine Daten außerhalb der EU/EWR übertragen."
-    },
-    "s5": {
-    "heading": "5. Aufbewahrungsdauer",
-    "item1": "Aktives Konto: solange du den Dienst nutzt.",
-    "item2": "Gelöschtes Konto: Löschung wirksam 30 Tage nach deinem Antrag (widerrufbare Frist).",
-    "item3": "Sicherheitslogs: maximal 12 Monate, nach Kontolöschung pseudonymisiert."
-    },
-    "s6": {
-    "heading": "6. Deine Rechte (DSGVO Art. 15-22)",
-    "item1": "<b>Auskunft</b>: Sieh deine Daten jederzeit in deinem Bereich ein.",
-    "item2": "<b>Berichtigung</b>: Ändere Profil und Daten auf den entsprechenden Seiten.",
-    "item3": "<b>Löschung</b>: Schaltfläche „Mein Konto löschen“ unter Einstellungen → Datenschutz.",
-    "item4": "<b>Datenübertragbarkeit</b>: Schaltfläche „Meine Daten herunterladen“ — vollständiger JSON-Export.",
-    "item5": "<b>Widerspruch / Einschränkung</b>: Lehne nicht-essenzielle Cookies jederzeit ab oder widerrufe sie.",
-    "item6": "<b>Beschwerde</b>: bei der <apd>Datenschutzbehörde</apd> (Belgien)."
-    },
-    "s7": {
-    "heading": "7. Sicherheit",
-    "item1": "Verschlüsselung im Transit (TLS 1.3) und im Ruhezustand.",
-    "item2": "Row Level Security Supabase auf allen Tabellen.",
-    "item3": "Rate Limiting, strikte CSP, Append-only-Audit-Log.",
-    "item4": "Authentifizierung per starkem Passwort + MFA verfügbar."
-    },
-    "s8": {
-    "heading": "8. Cookies",
-    "body": "Siehe die <link>Cookie-Richtlinie</link>."
-    },
-    "s9": {
-    "heading": "9. Änderungen",
-    "body": "Jede wesentliche Änderung dieser Richtlinie wird per E-Mail mitgeteilt und erfordert deine erneute Einwilligung, um den Dienst weiterhin zu nutzen."
-    },
-    "draft": "Unsere Datenschutzerklärung wird derzeit erstellt.",
-    "contact": "Bei Fragen kontaktiere uns: thierryvm@gmail.com",
-    "backHome": "Zurück zur Startseite"
-  },
-  "cookies": {
-    "metaTitle": "Cookie-Richtlinie",
-    "metaDescription": "Cookie-Richtlinie von Ankora — volle Granularität, alles ablehnbar außer essenziell.",
-    "title": "Cookie-Richtlinie",
-    "categoriesHeading": "Kategorien",
-    "essentialHeading": "Essenziell (immer aktiv)",
-    "essentialBody": "Unverzichtbar für den Betrieb: Authentifizierungs-Session, Theme-Präferenz, Anti-CSRF.",
-    "essentialItem1": "<code>sb-*</code> — Supabase-Session (Auth)",
-    "essentialItem2": "<code>ankora-theme</code> — Präferenz hell/dunkel",
-    "analyticsHeading": "Analytics (standardmäßig deaktiviert)",
-    "analyticsBody1": "Nur wenn du deine Einwilligung gibst. Aggregierte Nutzungsmessung, ohne persönliche Kennung.",
-    "analyticsBody2": "Ankora nutzt kein Google Analytics. Die Vercel-Metriken sind aggregiert und anonymisiert.",
-    "marketingHeading": "Marketing (standardmäßig deaktiviert)",
-    "marketingBody": "Ankora nutzt derzeit keine Marketing-Cookies.",
-    "manageHeading": "Deine Präferenzen verwalten",
-    "manageBody1": "Du kannst deine Einwilligungen jederzeit unter <b>Einstellungen → Datenschutz</b> ändern oder indem du im Footer auf „Cookies verwalten“ klickst.",
-    "manageBody2": "Das Ablehnen nicht-essenzieller Cookies beeinträchtigt das Erlebnis nicht: Ankora bleibt voll funktionsfähig.",
-    "lifetimeHeading": "Lebensdauer",
-    "lifetimeItem1": "Session: Ende der Navigation",
-    "lifetimeItem2": "Präferenzen: 12 Monate",
-    "lifetimeItem3": "Analytics: 6 Monate (falls akzeptiert)",
-    "draft": "Diese Cookie-Richtlinienseite wird derzeit erstellt.",
-    "contact": "Bei Fragen kontaktiere uns: thierryvm@gmail.com",
-    "backHome": "Zurück zur Startseite"
-  }
-  },
-  "offline": {
-  "metaTitle": "Offline",
-  "metaDescription": "Du bist derzeit offline. Verbinde dich erneut, um auf Ankora zuzugreifen.",
-  "title": "Du bist offline",
-  "message": "Verbinde dich erneut, um auf dein Cockpit zuzugreifen. Deine Daten bleiben unversehrt.",
-  "retry": "Erneut versuchen"
-  },
-  "consent": {
-  "title": "Cookies und Datenschutz",
-  "body": "Wir verwenden nur essenzielle Cookies, um dich anzumelden. Analyse-Cookies sind standardmäßig deaktiviert — du kannst sie aktivieren, wenn du uns helfen möchtest, Ankora zu verbessern. Du kannst deine Meinung jederzeit über <link>die Cookie-Richtlinie</link> ändern.",
-  "essentialOnly": "Nur essenziell",
-  "acceptAnalytics": "Analysen akzeptieren"
-  },
-  "footer": {
-  "copyright": "© {year} — Alle Rechte vorbehalten",
-  "cgu": "AGB",
-  "privacy": "Datenschutz",
-  "cookies": "Cookies verwalten",
-  "faq": "FAQ",
-  "copyrightNotice": "© {year} Ankora™. Alle Rechte vorbehalten."
-  },
-  "auth": {
-  "login": {
-    "title": "Anmelden",
-    "subtitle": "Finde dein Ankora-Cockpit wieder.",
-    "metaTitle": "Anmeldung",
-    "emailLabel": "E-Mail",
-    "passwordLabel": "Passwort",
-    "forgotLink": "Passwort vergessen?",
-    "submit": "Anmelden",
-    "submitting": "Anmelden…",
-    "noAccount": "Noch kein Konto?",
-    "signupLink": "Konto erstellen",
-    "dividerOr": "oder",
-    "dividerOrEmail": "oder mit deiner E-Mail",
-    "passwordUpdatedBanner": "Passwort aktualisiert. Du kannst dich anmelden."
-  },
-  "signup": {
-    "title": "Konto erstellen",
-    "subtitle": "Starte dein Finanz-Cockpit in weniger als 2 Minuten.",
-    "pageTitle": "Mein Cockpit erstellen",
-    "pageDescription": "Wenige Sekunden. Keine Kreditkarte.",
-    "emailLabel": "E-Mail",
-    "passwordLabel": "Passwort",
-    "passwordHint": "Mindestens 12 Zeichen, 1 Großbuchstabe, 1 Kleinbuchstabe, 1 Ziffer.",
-    "passwordConfirmLabel": "Passwort bestätigen",
-    "acceptTosPrefix": "Ich akzeptiere die",
-    "acceptTosLink": "AGB",
-    "acceptPrivacyPrefix": "Ich akzeptiere die",
-    "acceptPrivacyLink": "Datenschutzerklärung",
-    "submit": "Mein Konto erstellen",
-    "submitting": "Erstellen…",
-    "haveAccount": "Schon ein Konto?",
-    "loginLink": "Anmelden",
-    "dividerOr": "oder",
-    "dividerOrEmail": "oder mit deiner E-Mail",
-    "googleCta": "Mein Konto mit Google erstellen",
-    "googleTerms": "Wenn du mit Google fortfährst, akzeptierst du unsere <cgu>AGB</cgu> und unsere <privacy>Datenschutzerklärung</privacy>."
-  },
-  "forgot": {
-    "title": "Passwort vergessen",
-    "subtitle": "Gib deine E-Mail ein, wir senden dir einen sicheren Link.",
-    "emailLabel": "E-Mail",
-    "submit": "Link senden",
-    "submitting": "Senden…",
-    "sentMessage": "Falls diese E-Mail existiert, wurde soeben ein Zurücksetzungs-Link gesendet.",
-    "backToLogin": "Zurück zur Anmeldung"
-  },
-  "reset": {
-    "title": "Neues Passwort",
-    "subtitle": "Wähle ein starkes Passwort für dein Konto.",
-    "passwordLabel": "Neues Passwort",
-    "passwordConfirmLabel": "Bestätigen",
-    "submit": "Aktualisieren",
-    "submitting": "Aktualisieren…"
-  },
-  "google": {
-    "label": "Mit Google fortfahren",
-    "redirecting": "Weiterleitung…"
-  },
-  "checkEmail": {
-    "title": "Prüfe dein Postfach",
-    "metaTitle": "Prüfe deine E-Mail",
-    "body": "Wir haben dir soeben einen Bestätigungslink gesendet. Klicke darauf, um dein Konto zu aktivieren.",
-    "backToLogin": "Zurück zur Anmeldung"
-  }
-  },
-  "onboarding": {
-  "defaultWorkspaceName": "Mein Bereich",
-  "previous": "Zurück",
-  "next": "Weiter",
-  "finish": "Fertigstellen",
-  "finishing": "Speichern…",
-  "validation": {
-    "workspaceNameRequired": "Gib deinem Bereich einen Namen.",
-    "incomeInvalid": "Gib ein gültiges Einkommen an (≥ 0)."
-  },
-  "step1": {
-    "title": "Benenne deinen Bereich",
-    "description": "Du kannst ihn später in den Einstellungen ändern.",
-    "nameLabel": "Name des Bereichs"
-  },
-  "step2": {
-    "title": "Dein Nettoeinkommen (monatlich)",
-    "description": "Dient als Basis, um dir die monatlichen Überweisungen vorzuschlagen.",
-    "incomeLabel": "Nettoeinkommen monatlich (€)"
-  },
-  "step3": {
-    "title": "Deine ersten Fixkosten (optional)",
-    "description": "Füge eine Miete, eine Versicherung, ein Abo hinzu…",
-    "labelLabel": "Bezeichnung",
-    "labelPlaceholder": "Miete, Autoversicherung…",
-    "amountLabel": "Betrag (€)",
-    "frequencyLabel": "Frequenz",
-    "dueMonthLabel": "Referenzmonat",
-    "skipLater": "Ich trage meine Fixkosten später ein"
-  }
-  },
-  "app": {
-  "dashboard": {
-    "metaTitle": "Dashboard",
-    "headerTitle": "{month} — dein Cockpit",
-    "emptyTitle": "Beginne mit dem Hinzufügen deiner Fixkosten",
-    "emptyDescription": "Miete, Versicherungen, Abos — Ankora verteilt sie für dich auf 12 Monate.",
-    "emptyCta": "Fixkosten hinzufügen",
-    "kpiProvisionsMonthly": "Rücklagen / Monat",
-    "kpiProvisionsAnnualHint": "Jährlich: {amount}",
-    "kpiHealth": "Rücklagen-Status",
-    "kpiHealthTargetHint": "Ziel: {amount}",
-    "kpiSuggestedTransfer": "Vorgeschlagene Überweisung",
-    "kpiSuggestedTransferToSavings": "Zurückzulegen",
-    "kpiSuggestedTransferFromSavings": "Von den Ersparnissen abzuheben",
-    "kpiBillsMonth": "Rechnungen {month}",
-    "kpiBillsHint": "Cash-Ausgang diesen Monat",
-    "healthHealthy": "Gesund",
-    "healthWarning": "Zu beobachten",
-    "healthCritical": "Kritisch",
-    "planTitle": "Plan des Monats — {month}",
-    "planDescription": "Die Überweisungen, die du zu Monatsbeginn auf deinen drei Konten ausführen musst.",
-    "planAdjustAccounts": "Meine Konten anpassen",
-    "missingSetupTitle": "Richte zuerst deine Konten ein",
-    "missingSetupDescription": "Um deine Intelligente Überweisung zu berechnen, benötigt Ankora dein monatliches Einkommen und den festen Betrag, den du auf Alltag überweist.",
-    "missingSetupCta": "Meine Konten einrichten",
-    "transferPrincipalToVieCourante": "Hauptkonto → Alltag",
-    "transferVieCouranteHint": "Umschlag für Einkäufe, Benzin, Restaurants.",
-    "transferPrincipalToEpargne": "Hauptkonto → Sparen",
-    "transferEpargneToPrincipal": "Sparen → Hauptkonto",
-    "transferEpargneHint": "Rücklage {provision} − Rechnungen {bills}",
-    "transferPrincipalRemaining": "Restbetrag Hauptkonto",
-    "transferPrincipalRemainingHint": "Nach Gehalt, Überweisungen und Rechnungen Hauptkonto ({bills}).",
-    "ctaCharges": "Meine Fixkosten",
-    "ctaExpenses": "Meine Ausgaben",
-    "ctaSimulator": "Simulieren",
-    "expensesTitle": "Ausgaben — {month}",
-    "expensesCount": "{count, plural, =0 {Keine Ausgaben diesen Monat} one {1 Ausgabe diesen Monat} other {# Ausgaben diesen Monat}}",
-    "expensesEmpty": "Keine Ausgaben für diesen Monat erfasst.",
-    "expensesViewAll": "Alle Ausgaben anzeigen →"
-  },
-  "charges": {
-    "title": "Meine Fixkosten",
-    "subtitle": "Jede Fixkost wird automatisch auf 12 Monate verteilt.",
-    "addFormTitle": "Fixkosten hinzufügen",
-    "emptyState": "Noch keine Fixkosten.",
-    "labelLabel": "Bezeichnung",
-    "amountLabel": "Betrag (€)",
-    "frequencyLabel": "Frequenz",
-    "dueMonthLabel": "Referenzmonat",
-    "addButton": "Hinzufügen",
-    "adding": "Hinzufügen…",
-    "count": "{count, plural, =0 {keine Fixkosten} one {1 Fixkosten-Eintrag} other {# Fixkosten-Einträge}}",
-    "referenceFormat": "{frequency} · Ref. {month}",
-    "deleteAria": "{label} löschen",
-    "toastCreated": "Fixkosten hinzugefügt",
-    "toastDeleted": "Fixkosten gelöscht"
-  },
-  "accounts": {
-    "metaTitle": "Meine Konten",
-    "metaDescription": "Verfolge die Salden deiner Konten Hauptkonto, Alltag und Sparen. Stelle dein monatliches Einkommen und deine Überweisung auf Alltag ein.",
-    "title": "Meine Konten",
-    "subtitle": "Gib deine echten Salden ein, damit Ankora deine intelligente Überweisung jeden Monat präzise berechnen kann.",
-    "balancesHeading": "Aktuelle Salden",
-    "amountLabel": "Betrag (€)",
-    "saveButton": "Speichern",
-    "saving": "Speichern…",
-    "income": {
-    "title": "Nettoeinkommen (monatlich)",
-    "description": "Das Gehalt, das jeden Monat auf deinem Hauptkonto eingeht. Dient zur Berechnung dessen, was dir nach Fixkosten und Überweisung auf Alltag bleibt.",
-    "placeholder": "Z. B. 2500",
-    "toastSaved": "Monatliches Einkommen aktualisiert"
-    },
-    "transfer": {
-    "title": "Monatliche Überweisung auf Alltag",
-    "description": "Fester Betrag, der jeden Monat vom Hauptkonto auf dein Alltag-Konto überwiesen wird. Das ist das Geld für Einkäufe, Benzin und Restaurants.",
-    "placeholder": "Z. B. 500",
-    "toastSaved": "Monatliche Überweisung aktualisiert"
-    },
-    "balance": {
-    "invalidAmount": "Gib einen gültigen Betrag ein.",
-    "saveLabel": "Aktualisieren",
-    "srLabel": "Aktueller Saldo von {label}",
-    "toastSaved": "{name} aktualisiert"
-    },
-    "kind": {
-    "principal": {
-      "description": "Erhält das Gehalt, zahlt die monatlichen Fixkosten."
-    },
-    "vieCourante": {
-      "description": "Budget des Alltags (Einkäufe, Benzin, Restaurants)."
-    },
-    "epargne": {
-      "description": "Verteilt die vierteljährlichen und jährlichen Rechnungen."
-    }
-    }
-  },
-  "expenses": {
-    "title": "Meine Ausgaben",
-    "subtitle": "Die Ausgaben abseits wiederkehrender Fixkosten — Einkäufe, Restaurant, Freizeit…",
-    "addFormTitle": "Ausgabe hinzufügen",
-    "labelLabel": "Bezeichnung",
-    "amountLabel": "Betrag (€)",
-    "dateLabel": "Datum",
-    "addButton": "Hinzufügen",
-    "adding": "Hinzufügen…",
-    "emptyState": "Keine Ausgabe erfasst.",
-    "summary": "{count, plural, =0 {Keine Ausgabe} one {1 Ausgabe · {total}} other {# Ausgaben · {total}}}",
-    "deleteAria": "{label} löschen",
-    "toastCreated": "Ausgabe hinzugefügt",
-    "toastDeleted": "Ausgabe gelöscht"
-  },
-  "settings": {
-    "metaTitle": "Einstellungen",
-    "metaDescription": "Verwalte dein Profil, die 2FA-Sicherheit und deine persönlichen Daten.",
-    "title": "Einstellungen",
-    "description": "Profil, Sicherheit und persönliche Daten.",
-    "profile": {
-    "title": "Profil",
-    "description": "Diese Informationen personalisieren dein Cockpit.",
-    "emailLabel": "E-Mail",
-    "displayNameLabel": "Anzeigename",
-    "localeLabel": "Sprache",
-    "localeOptions": {
-      "fr-BE": "Français (Belgique)",
-      "fr-FR": "Français (France)",
-      "en-GB": "English"
-    },
-    "submit": "Speichern",
-    "submitting": "Speichern…",
-    "toastSaved": "Profil aktualisiert"
-    },
-    "mfa": {
-    "title": "Sicherheit — 2FA",
-    "description": "Ein Einmalcode, generiert von einer Authenticator-App (Authy, 1Password, Google Authenticator).",
-    "emptyState": "Kein 2FA-Faktor aktiv. Aktiviere ihn, um dein Konto zu schützen.",
-    "enrollButton": "2FA aktivieren",
-    "enrolling": "Vorbereiten…",
-    "scanInstruction": "Scanne diesen QR-Code in deiner Authenticator-App und gib dann den 6-stelligen Code ein.",
-    "qrAlt": "QR-Code für die Authenticator-App",
-    "manualEntry": "Manuelle Eingabe",
-    "codeLabel": "6-stelliger Code",
-    "verifyButton": "Prüfen und aktivieren",
-    "verifying": "Prüfen…",
-    "cancel": "Abbrechen",
-    "defaultFactorName": "TOTP-App",
-    "activeLabel": "Aktiv",
-    "disableButton": "Deaktivieren",
-    "toastEnabled": "MFA aktiviert",
-    "toastDisabled": "MFA deaktiviert"
-    },
-    "data": {
-    "title": "Meine Daten",
-    "description": "DSGVO-Datenübertragbarkeit (Art. 20) — lade ein vollständiges JSON mit allem herunter, was Ankora über dich hat.",
-    "exportButton": "Meine Daten herunterladen",
-    "exporting": "Generieren…",
-    "toastDownloaded": "Export heruntergeladen"
-    },
-    "danger": {
-    "scheduledTitle": "Löschung läuft",
-    "scheduledBody": "Dein Konto wird am <strong>{date}</strong> gelöscht. Du kannst jederzeit bis dahin widerrufen.",
-    "viewStatus": "Status anzeigen",
-    "title": "Gefahrenzone",
-    "description": "Endgültige Löschung des Kontos. 30 Tage Gnadenfrist zum Widerrufen — danach wird alles gelöscht (Audit-Logs pseudonymisiert).",
-    "reasonLabel": "Grund (optional)",
-    "reasonPlaceholder": "Hilf uns, uns zu verbessern…",
-    "confirmLabel": "Tippe zur Bestätigung deine E-Mail-Adresse ein: <code>{email}</code>",
-    "submit": "Mein Konto löschen",
-    "submitting": "Planen…",
-    "toastScheduled": "Löschung geplant — du hast 30 Tage zum Widerrufen"
-    }
-  },
-  "simulator": {
-    "title": "Simulator",
-    "subtitle": "Miss die Auswirkung einer Änderung, ohne deine echten Daten anzurühren.",
-    "scenario": {
-    "title": "Szenario",
-    "description": "Wähle eine zu simulierende Aktion.",
-    "modes": {
-      "cancel": "Fixkosten kündigen",
-      "negotiate": "Neu verhandeln",
-      "add": "Fixkosten hinzufügen"
-    }
-    },
-    "fields": {
-    "charge": "Fixkosten",
-    "chargePlaceholder": "Auswählen…",
-    "newAmount": "Neuer Betrag (€)",
-    "label": "Bezeichnung",
-    "amount": "Betrag (€)",
-    "frequency": "Frequenz",
-    "month": "Monat"
-    },
-    "impact": {
-    "title": "Auswirkung",
-    "empty": "Vervollständige das Szenario, um die Auswirkung zu sehen.",
-    "currentMonthly": "Aktuell / Monat",
-    "projectedMonthly": "Prognose / Monat",
-    "annualSavings": "Jährliche Ersparnis",
-    "monthlyChange": "{sign}{percent}% / Monat"
-    }
-  },
-  "deletionStatus": {
-    "title": "Konto-Löschung",
-    "subtitle": "Detaillierter Status deines Antrags und Widerrufsfrist.",
-    "metaTitle": "Löschstatus",
-    "metaDescription": "Status des Löschungsantrags deines Ankora-Kontos.",
-    "statusLabel": "Status:",
-    "requestedOn": "Beantragt am {date}.",
-    "statusPending": "Ausstehend",
-    "statusCancelled": "Widerrufen",
-    "statusCompleted": "Abgeschlossen",
-    "scheduledFor": "Löschung geplant",
-    "daysLeft": "Verbleibende Tage",
-    "auditLogs": "Audit-Logs",
-    "auditLogsValue": "Pseudonymisiert, niemals gelöscht",
-    "daysCount": "{days, plural, =0 {Heute} one {# Tag} other {# Tage}}",
-    "backToSettings": "Zurück zu den Einstellungen",
-    "cancelledOn": "Antrag widerrufen am {date}. Dein Konto bleibt erhalten.",
-    "cancelledNoDate": "Antrag widerrufen. Dein Konto bleibt erhalten.",
-    "cancelButton": "Löschung widerrufen",
-    "cancelling": "Widerrufen…",
-    "toastCancelled": "Antrag widerrufen — dein Konto bleibt erhalten"
-  }
-  },
-  "glossary": {
-  "title": "Glossary",
-  "subtitle": "15 essential terms for understanding your budgeting and personal finances.",
-  "metaTitle": "Glossary — Financial Terms",
-  "metaDescription": "Glossary of 15 essential budgeting terms: smoothed budget, bucket account, emergency fund, and more.",
-  "breadcrumb": {
-    "home": "Home",
-    "glossary": "Glossary"
-  },
-  "section": {
-    "whyItMatters": "Why It Matters",
-    "example": "Concrete Example",
-    "relatedTerms": "Related Terms"
-  }
-  },
-  "errors": {
-  "generic": "Ein Fehler ist aufgetreten. Versuche es erneut.",
-  "session": {
-    "expired": "Session abgelaufen. Melde dich erneut an.",
-    "rateLimited": "Zu viele Anfragen. Warte eine Minute."
-  },
-  "auth": {
-    "invalidCredentials": "E-Mail oder Passwort falsch.",
-    "signupFailed": "Registrierung nicht möglich. Versuche es später erneut.",
-    "googleFailed": "Google-Anmeldung nicht verfügbar. Versuche es später erneut.",
-    "rateLimited": "Zu viele Versuche. Versuche es in einigen Minuten erneut.",
-    "serviceTemporarilyUnavailable": "Dienst vorübergehend nicht verfügbar. Versuche es in einigen Minuten erneut.",
-    "passwordResetFailed": "Passwort konnte nicht aktualisiert werden.",
-    "linkExpired": "Link abgelaufen. Fordere einen neuen Link an.",
-    "mfaEnrollFailed": "Aktivierung nicht möglich.",
-    "mfaChallengeFailed": "MFA-Challenge nicht möglich.",
-    "mfaCodeInvalid": "Code falsch. Versuche es erneut.",
-    "mfaDisableFailed": "2FA konnte nicht deaktiviert werden."
-  },
-  "db": {
-    "workspaceNotFound": "Kein bearbeitbarer Workspace.",
-    "updateFailed": "Aktualisierung nicht möglich.",
-    "notEditable": "Du hast keine Bearbeitungsrechte für diesen Bereich."
-  },
-  "validation": {
-    "generic": "Ungültige Daten.",
-    "auth": {
-    "email": {
-      "invalid": "Ungültige E-Mail-Adresse."
-    },
-    "password": {
-      "required": "Passwort erforderlich.",
-      "tooShort": "Mindestens 12 Zeichen.",
-      "tooLong": "Maximal 128 Zeichen.",
-      "lowercase": "Mindestens ein Kleinbuchstabe.",
-      "uppercase": "Mindestens ein Großbuchstabe.",
-      "digit": "Mindestens eine Ziffer."
-    },
-    "passwordConfirm": {
-      "mismatch": "Die Passwörter stimmen nicht überein."
-    },
-    "acceptTos": {
-      "required": "Du musst die AGB akzeptieren."
-    },
-    "acceptPrivacy": {
-      "required": "Du musst die Datenschutzerklärung akzeptieren."
-    }
-    },
-    "charge": {
-    "label": {
-      "required": "Bezeichnung erforderlich.",
-      "tooLong": "Maximal 120 Zeichen."
-    },
-    "amount": {
-      "invalid": "Ungültiger Betrag.",
-      "negative": "Der Betrag muss ≥ 0 sein.",
-      "tooHigh": "Betrag zu hoch."
+    "monthsShort": {
+      "1": "Jan",
+      "2": "Feb",
+      "3": "Mrz",
+      "4": "Apr",
+      "5": "Mai",
+      "6": "Jun",
+      "7": "Jul",
+      "8": "Aug",
+      "9": "Sep",
+      "10": "Okt",
+      "11": "Nov",
+      "12": "Dez"
     },
     "frequency": {
-      "invalid": "Ungültige Frequenz."
-    },
-    "dueMonth": {
-      "range": "Monat zwischen 1 und 12."
-    },
-    "paidFrom": {
-      "invalid": "Ungültiges Belastungskonto."
+      "monthly": "Monatlich",
+      "quarterly": "Vierteljährlich",
+      "semiannual": "Halbjährlich",
+      "annual": "Jährlich"
     }
+  },
+  "ui": {
+    "scrollToTop": "Nach oben scrollen",
+    "localeSwitcher": {
+      "label": "Sprache",
+      "aria": "Sprache ändern",
+      "options": {
+        "fr-BE": "Français (BE)",
+        "nl-BE": "Nederlands (BE)",
+        "en": "English",
+        "es-ES": "Español",
+        "de-DE": "Deutsch"
+      }
     },
-    "account": {
-    "kind": {
-      "invalid": "Ungültiger Kontotyp."
-    },
-    "balance": {
-      "invalid": "Ungültiger Saldo.",
-      "outOfRange": "Wert außerhalb des Bereichs."
-    },
-    "label": {
-      "required": "Bezeichnung erforderlich.",
-      "tooLong": "Maximal 80 Zeichen."
+    "action": {
+      "submit": "Bestätigen",
+      "submitting": "Bestätigung…",
+      "save": "Speichern",
+      "saving": "Speichern…",
+      "cancel": "Abbrechen",
+      "cancelling": "Abbrechen…",
+      "delete": "Löschen",
+      "deleting": "Löschen…",
+      "create": "Erstellen",
+      "creating": "Erstellen…",
+      "update": "Aktualisieren",
+      "updating": "Aktualisieren…",
+      "send": "Senden",
+      "sending": "Senden…",
+      "verify": "Prüfen",
+      "verifying": "Prüfen…",
+      "generate": "Generieren",
+      "generating": "Generieren…",
+      "download": "Herunterladen",
+      "downloading": "Herunterladen…",
+      "preparing": "Vorbereiten…",
+      "confirm": "Bestätigen",
+      "close": "Schließen"
     }
+  },
+  "landing": {
+    "mktnav": {
+      "links": {
+        "product": "Produit",
+        "simulator": "Simulateur",
+        "pricing": "Tarifs",
+        "security": "Sécurité",
+        "journal": "Journal"
+      },
+      "ctaLogin": "Se connecter",
+      "ctaSignup": "Essayer gratuitement"
     },
-    "workspace": {
-    "name": {
-      "required": "Name erforderlich.",
-      "tooLong": "Maximal 80 Zeichen."
+    "hero": {
+      "badge": "Nouveau · Simulateur what-if",
+      "h1Lead": "Ton ancrage",
+      "h1Highlight": "financier.",
+      "description": "Ankora sépare tes provisions affectées de ta réserve libre, projette six mois devant, et te laisse simuler l'impact de chaque décision — en clair, sans jargon.",
+      "ctaPrimary": "Ouvrir mon cockpit",
+      "ctaSecondary": "Voir le simulateur",
+      "trust": {
+        "encrypted": "Données chiffrées en Belgique",
+        "noSale": "Aucune vente de données",
+        "languages": "FR · NL · EN"
+      },
+      "mockup": {
+        "eyebrow": "Aperçu cockpit",
+        "browserUrl": "Ankora · cockpit",
+        "kpis": {
+          "netRemaining": {
+            "label": "Net restant",
+            "sub": "avril · après provisions"
+          },
+          "provisions": {
+            "label": "Provisions",
+            "sub": "67 % des 2 480 € planifiés"
+          },
+          "reserve": {
+            "label": "Réserve",
+            "sub": "+120 € vs. mars"
+          }
+        }
+      },
+      "waterfall": {
+        "income": "Revenus",
+        "incomeAmount": "+2 466 €",
+        "expenses": "Dépenses courantes",
+        "expensesAmount": "−1 959 €",
+        "provisionsCaption": "dont {amount} € lissés vers provisions affectées",
+        "available": "Argent disponible",
+        "availableAmount": "+507 €",
+        "ariaLabel": "Cascade illustrative : 2 466 € de revenus, 1 959 € de dépenses courantes (dont 59 € lissés en provisions), 507 € disponibles."
+      }
     },
-    "income": {
-      "invalid": "Ungültiges Einkommen.",
-      "negative": "Muss ≥ 0 sein.",
-      "tooHigh": "Einkommen zu hoch."
+    "principles": {
+      "eyebrow": "Trois principes",
+      "h2": "Une façon honnête de parler d'argent.",
+      "description": "Ankora n'essaye pas de te vendre un placement ou une carte. On sépare, on projette, on simule. C'est tout. Toi seul décides.",
+      "items": {
+        "provisions": {
+          "title": "Provisions affectées",
+          "description": "Chaque euro réservé a un nom : mutuelle, taxe circulation, entretien chaudière. Rien ne fuit sans que tu le saches."
+        },
+        "reserve": {
+          "title": "Réserve libre",
+          "description": "Ce qui reste vraiment à toi, après les engagements. Le vrai chiffre — pas l'illusion du solde brut."
+        },
+        "whatIf": {
+          "title": "Simulateur what-if",
+          "description": "Renégocier l'électricité ? Changer de fournisseur ? Ankora te montre l'impact sur 12 mois avant que tu décides."
+        }
+      }
     },
-    "transfer": {
-      "invalid": "Ungültiger Betrag.",
-      "negative": "Muss ≥ 0 sein.",
-      "tooHigh": "Betrag zu hoch."
+    "feature": {
+      "eyebrow": "Cashflow waterfall",
+      "h3Line1": "Du salaire au net disponible.",
+      "h3Line2": "En un seul coup d'œil.",
+      "description": "Plus de mystère sur où va ton argent. Chaque étape est visible : revenus, dépenses courantes, argent disponible. Tu vois immédiatement si un poste dérape.",
+      "ctaPrimary": "Voir un exemple",
+      "ctaSecondary": "Comment ça marche ?"
+    },
+    "whatif": {
+      "title": "Et si tu changeais une seule chose ?",
+      "subtitle": "Bouge le curseur. Vois l'impact sur ta réserve libre, sur six mois. C'est ce que fait Ankora à chaque décision financière.",
+      "badge": "Démo · pas de compte requis",
+      "scenarios": {
+        "gsm": {
+          "label": "Renégocier mon GSM",
+          "hint": "Forfait actuel : 42 €/mois · marché : 18–28 €/mois"
+        },
+        "elec": {
+          "label": "Changer de fournisseur d'électricité",
+          "hint": "Conso actuelle : 168 €/mois · 3 offres moins chères dans ta zone"
+        },
+        "stream": {
+          "label": "Couper deux streamings",
+          "hint": "5 abonnements actifs · usage réel : 2 sur 30 jours"
+        }
+      },
+      "controls": {
+        "scenario": "Scénario",
+        "savings": "Économie mensuelle",
+        "slider_aria": "Économie mensuelle pour {label}"
+      },
+      "annual": {
+        "eyebrow": "Sur 12 mois",
+        "fleche": "Ankora pourrait flécher {amount} €/mois vers ton épargne longue."
+      },
+      "chart": {
+        "title": "Réserve libre · projection",
+        "subtitle": "6 mois à partir d'aujourd'hui",
+        "legend": {
+          "baseline": "Sans changement",
+          "scenario": "Avec ton choix"
+        },
+        "aria": "Graphique projection sur 6 mois de la réserve libre, avec et sans le changement choisi",
+        "months": {
+          "may": "mai",
+          "jun": "juin",
+          "jul": "juil",
+          "aug": "août",
+          "sep": "sept",
+          "oct": "oct"
+        },
+        "thresholds": {
+          "danger": "⚠️ Découvert estimé",
+          "fragile": "Zone fragile",
+          "comfortable": "Zone confortable"
+        }
+      },
+      "caveat": "Démo basée sur des hypothèses moyennes. Ankora ne fournit pas de conseil en placement. Aucun import bancaire — tu saisis tes charges manuellement."
+    },
+    "pricing": {
+      "eyebrow": "Transparent dès le départ",
+      "h2": "Gratuit pendant la Phase 1.",
+      "phaseBadge": "Phase 1 · construction",
+      "price": "0 €",
+      "period": "pour l'instant, et sans date limite",
+      "body": "On construit d'abord le cockpit. Pas de carte demandée, pas de limite de temps, pas de fonctionnalité bridée. Export RGPD à tout moment.",
+      "features": {
+        "cockpit": "Cockpit complet, provisions et réserve libre",
+        "simulator": "Simulateur what-if illimité",
+        "manualEntry": "Saisie manuelle · tes données restent en Belgique",
+        "export": "Export RGPD en un clic"
+      },
+      "ctaPrimary": "Ouvrir mon cockpit",
+      "roadmap": {
+        "title": "Tu rejoins Ankora pendant sa Phase 1 ?",
+        "body": "Ton compte garde un accès complet au cockpit core à vie, gratuitement. Une offre Pro avec features avancées (comptes illimités, exports consolidés, support prioritaire) arrivera post-v1.0 — tu auras le choix d'upgrader ou de rester sur ton plan actuel.",
+        "link": "Lire la roadmap →"
+      }
+    },
+    "footerCta": {
+      "h2Lead": "Commence par ce qui est",
+      "h2Highlight": "déjà à toi.",
+      "description": "30 jours d'essai, pas de carte, export RGPD à tout moment. On fait simple parce que c'est déjà assez compliqué comme ça.",
+      "ctaPrimary": "Ouvrir mon cockpit"
+    },
+    "footer": {
+      "links": {
+        "terms": "Conditions",
+        "privacy": "Confidentialité",
+        "security": "Sécurité",
+        "contact": "Contact"
+      },
+      "copyright": "Ankora · éditeur ancré à Bruxelles · 2026"
+    },
+    "faqHeading": "Häufige Fragen",
+    "faq": {
+      "advice": {
+        "q": "Ist Ankora ein Finanzberatungstool?",
+        "a": "Nein. Ankora ist ein Tool für Budgetorganisation und finanzielle Bildung. Es bietet keine Anlageempfehlungen oder personalisierte Finanzberatung."
+      },
+      "storage": {
+        "q": "Wo werden meine Daten gespeichert?",
+        "a": "Deine Daten werden in der Europäischen Union gehostet (Supabase, EU-Region) mit Verschlüsselung im Ruhezustand und strikter Nutzer-Isolation über Row Level Security."
+      },
+      "sharing": {
+        "q": "Kann ich meine Daten teilen?",
+        "a": "Standardmäßig ist dein Bereich zu 100 % privat. Optionale geteilte Töpfe (Reise, gemeinsames Projekt) kommen in einer nächsten Version — du entscheidest ausdrücklich, was du teilst und mit wem."
+      }
     }
-    },
-    "expense": {
-    "label": {
-      "required": "Bezeichnung erforderlich.",
-      "tooLong": "Maximal 120 Zeichen."
-    },
-    "amount": {
-      "invalid": "Ungültiger Betrag.",
-      "negative": "Muss ≥ 0 sein.",
-      "tooHigh": "Betrag zu hoch."
-    },
-    "date": {
-      "format": "Erwartetes Format: YYYY-MM-DD."
-    },
-    "category": {
-      "invalid": "Ungültige Kategorie."
+  },
+  "faq": {
+    "metaTitle": "FAQ",
+    "metaDescription": "Häufige Fragen zu Ankora: Sicherheit, Daten, Funktionsweise, Datenschutz.",
+    "title": "Häufige Fragen",
+    "subtitle": "Alles, was du über Ankora wissen musst, bevor du loslegst.",
+    "items": {
+      "bankConnection": {
+        "q": "Verbindet sich Ankora mit meiner Bank?",
+        "a": "Nein. Ankora nutzt die PSD2-Richtlinie nicht. Du trägst deine Fixkosten und Ausgaben manuell ein. Diese Wahl stellt sicher, dass du Eigentümer deiner Daten bleibst und keine sensiblen Bankinformationen gespeichert werden."
+      },
+      "dataLocation": {
+        "q": "Wo werden meine Daten gehostet?",
+        "a": "Alle deine Daten werden in der Europäischen Union gehostet (Supabase EU-Region, Vercel EU-Region, Upstash EU). Es findet keine Übertragung außerhalb der EU statt."
+      },
+      "smoothing": {
+        "q": "Wie funktioniert die Verteilung?",
+        "a": "Ankora nimmt deine vierteljährlichen, halbjährlichen und jährlichen Fixkosten und verteilt sie auf 12 Monate. So weißt du, wie viel du jeden Monat zurücklegen musst, um alle zukünftigen Rechnungen stressfrei zu decken."
+      },
+      "deletion": {
+        "q": "Kann ich mein Konto löschen?",
+        "a": "Ja, jederzeit unter Einstellungen → Datenschutz. Die Löschung wird 30 Tage nach deinem Antrag wirksam (du kannst sie in diesem Zeitraum widerrufen). Alle deine Finanzdaten werden gelöscht, die Sicherheitslogs werden pseudonymisiert."
+      },
+      "export": {
+        "q": "Kann ich meine Daten exportieren?",
+        "a": "Ja. Die Schaltfläche „Meine Daten herunterladen“ in den Einstellungen liefert dir eine vollständige JSON-Datei mit allem, was Ankora über dich hat. Konform mit dem Recht auf Datenübertragbarkeit der DSGVO (Art. 20)."
+      },
+      "advice": {
+        "q": "Gibt Ankora Finanzberatung?",
+        "a": "Nein. Ankora ist ein Tool für Budgetbildung und Organisation. Wir geben keine Anlageberatung (regulatorische Einschränkung FSMA Belgien). Für jede Anlageentscheidung wende dich an eine zugelassene Fachperson."
+      },
+      "ai": {
+        "q": "Gibt es künstliche Intelligenz?",
+        "a": "In Phase 1 nein. Die Berechnungen sind deterministisch und auditierbar. In Phase 2 ermöglicht dir eine optionale BYOK-Schicht (Bring Your Own Key), deinen eigenen Anthropic- oder OpenRouter-Schlüssel für Vorschläge zu verbinden — ohne Mehrkosten auf Ankora-Seite."
+      },
+      "sharing": {
+        "q": "Kann ich meinen Bereich mit meinen Kindern oder Freunden teilen?",
+        "a": "In Phase 1 hat jeder Nutzer einen privaten, standardmäßig isolierten Bereich. In Phase 2 fügen wir die Möglichkeit hinzu, „geteilte Töpfe“ zu erstellen (per Einladung, mit Viewer/Editor-Rollen), ohne jemals deine persönlichen Daten zu vermischen."
+      }
     }
+  },
+  "legal": {
+    "versionLine": "Version {version} — letzte Aktualisierung: {date}",
+    "lastUpdatedLine": "Letzte Aktualisierung: {date}",
+    "cgu": {
+      "metaTitle": "Allgemeine Nutzungsbedingungen",
+      "metaDescription": "AGB von Ankora — Regeln für die Nutzung des Dienstes.",
+      "title": "Allgemeine Nutzungsbedingungen",
+      "s1": {
+        "heading": "1. Zweck",
+        "body": "Ankora ist ein Tool für Budgetorganisation und finanzielle Bildung für Privatpersonen. Es ermöglicht, Fixkosten und Ausgaben manuell einzutragen, sie über das Jahr zu verteilen und den Liquiditätsbedarf vorauszuplanen."
+      },
+      "s2": {
+        "heading": "2. Was Ankora NICHT ist",
+        "item1": "Ankora ist <b>kein Dienst für Anlage-</b> oder Investitionsberatung.",
+        "item2": "Ankora ist <b>kein Bankdienst</b> und hält keine Gelder.",
+        "item3": "Ankora ist <b>kein PSD2-Aggregator</b> — keine Verbindung zu deinen Bankkonten.",
+        "item4": "Ankora ist <b>keine professionelle Buchhaltungssoftware</b>.",
+        "outro": "Die angezeigten Informationen sind Schätzungen auf Basis deiner Eingaben. Sie stellen keine personalisierte Finanzberatung dar. Für wichtige Entscheidungen wende dich an eine zugelassene Fachperson."
+      },
+      "s3": {
+        "heading": "3. Konto",
+        "item1": "Du musst volljährig sein oder die Zustimmung eines gesetzlichen Vertreters haben.",
+        "item2": "Ein Konto pro natürlicher Person.",
+        "item3": "Passwort mindestens 12 Zeichen, gemischt.",
+        "item4": "Du bist für die Vertraulichkeit deiner Zugangsdaten verantwortlich."
+      },
+      "s4": {
+        "heading": "4. Akzeptable Nutzung",
+        "intro": "Du verpflichtest dich, nicht:",
+        "item1": "den Dienst für illegale Zwecke zu nutzen,",
+        "item2": "Sicherheitsmaßnahmen zu umgehen,",
+        "item3": "den Zugriff ohne ausdrückliche Erlaubnis zu automatisieren,",
+        "item4": "dein Konto mit Dritten zu teilen."
+      },
+      "s5": {
+        "heading": "5. Geistiges Eigentum",
+        "body": "Du bleibst Eigentümer deiner Daten. Ankora behält das Eigentum an seinem Code, seiner Marke, seinem Design und seiner Dokumentation."
+      },
+      "s6": {
+        "heading": "6. Haftung",
+        "body": "Ankora wird „wie besehen“ bereitgestellt. Der Herausgeber kann nicht für Finanzentscheidungen verantwortlich gemacht werden, die auf Grundlage der angezeigten Informationen getroffen werden. Keine Garantie für 100 % Verfügbarkeit."
+      },
+      "s7": {
+        "heading": "7. Kündigung",
+        "body": "Du kannst dein Konto jederzeit unter Einstellungen → Datenschutz löschen. Die Löschung wird 30 Tage nach dem Antrag wirksam (widerrufbare Frist)."
+      },
+      "s8": {
+        "heading": "8. Anwendbares Recht",
+        "body": "Diese AGB unterliegen belgischem Recht. Zuständiges Gericht: Brüssel."
+      },
+      "draft": "Unsere Allgemeinen Nutzungsbedingungen werden derzeit erstellt.",
+      "contact": "Bei Fragen kontaktiere uns: thierryvm@gmail.com",
+      "backHome": "Zurück zur Startseite"
+    },
+    "privacy": {
+      "metaTitle": "Datenschutzerklärung",
+      "metaDescription": "Datenschutzerklärung von Ankora — EU-Hosting, DSGVO, Rechte der Nutzer.",
+      "title": "Datenschutzerklärung",
+      "s1": {
+        "heading": "1. Verantwortlicher",
+        "body": "Ankora, herausgegeben von Thierry Van Mele (Belgien). Kontakt: <mail>thierryvm@gmail.com</mail>."
+      },
+      "s2": {
+        "heading": "2. Erhobene Daten",
+        "intro": "Ankora erhebt nur die für die Bereitstellung des Dienstes unbedingt erforderlichen Daten:",
+        "item1": "<b>Identität</b>: E-Mail-Adresse, Anzeigename (optional).",
+        "item2": "<b>Von dir eingegebene Finanzdaten</b>: Fixkosten, Ausgaben, Kategorien, deklariertes Einkommen, Sparguthaben.",
+        "item3": "<b>Technische Daten</b>: IP-Adresse, User-Agent (nur für Sicherheitslogs).",
+        "item4": "<b>Einwilligungen</b>: Zeitstempel, Version, Umfang (AGB, Datenschutz, Cookies).",
+        "outro": "Ankora verbindet sich mit keiner Bank (keine PSD2-Aggregation). Du gibst deine Fixkosten und Ausgaben selbst ein."
+      },
+      "s3": {
+        "heading": "3. Rechtsgrundlagen (DSGVO Art. 6)",
+        "item1": "<b>Vertrag</b>: Bereitstellung des Dienstes (Konto, Finanzdaten).",
+        "item2": "<b>Einwilligung</b>: Analytics-/Marketing-Cookies, Newsletter.",
+        "item3": "<b>Gesetzliche Pflicht</b>: Sicherheitslogs (Aufbewahrung 12 Monate).",
+        "item4": "<b>Berechtigtes Interesse</b>: Betrugsprävention, Aufrechterhaltung der Sicherheit."
+      },
+      "s4": {
+        "heading": "4. Hosting und Auftragsverarbeiter",
+        "item1": "<b>Supabase</b> (Datenbank, Auth) — EU-Region (Frankfurt oder Paris).",
+        "item2": "<b>Vercel</b> (Frontend-Hosting) — EU-Region (Dublin).",
+        "item3": "<b>Upstash</b> (Rate Limiting) — EU-Region.",
+        "outro": "Es werden keine Daten außerhalb der EU/EWR übertragen."
+      },
+      "s5": {
+        "heading": "5. Aufbewahrungsdauer",
+        "item1": "Aktives Konto: solange du den Dienst nutzt.",
+        "item2": "Gelöschtes Konto: Löschung wirksam 30 Tage nach deinem Antrag (widerrufbare Frist).",
+        "item3": "Sicherheitslogs: maximal 12 Monate, nach Kontolöschung pseudonymisiert."
+      },
+      "s6": {
+        "heading": "6. Deine Rechte (DSGVO Art. 15-22)",
+        "item1": "<b>Auskunft</b>: Sieh deine Daten jederzeit in deinem Bereich ein.",
+        "item2": "<b>Berichtigung</b>: Ändere Profil und Daten auf den entsprechenden Seiten.",
+        "item3": "<b>Löschung</b>: Schaltfläche „Mein Konto löschen“ unter Einstellungen → Datenschutz.",
+        "item4": "<b>Datenübertragbarkeit</b>: Schaltfläche „Meine Daten herunterladen“ — vollständiger JSON-Export.",
+        "item5": "<b>Widerspruch / Einschränkung</b>: Lehne nicht-essenzielle Cookies jederzeit ab oder widerrufe sie.",
+        "item6": "<b>Beschwerde</b>: bei der <apd>Datenschutzbehörde</apd> (Belgien)."
+      },
+      "s7": {
+        "heading": "7. Sicherheit",
+        "item1": "Verschlüsselung im Transit (TLS 1.3) und im Ruhezustand.",
+        "item2": "Row Level Security Supabase auf allen Tabellen.",
+        "item3": "Rate Limiting, strikte CSP, Append-only-Audit-Log.",
+        "item4": "Authentifizierung per starkem Passwort + MFA verfügbar."
+      },
+      "s8": {
+        "heading": "8. Cookies",
+        "body": "Siehe die <link>Cookie-Richtlinie</link>."
+      },
+      "s9": {
+        "heading": "9. Änderungen",
+        "body": "Jede wesentliche Änderung dieser Richtlinie wird per E-Mail mitgeteilt und erfordert deine erneute Einwilligung, um den Dienst weiterhin zu nutzen."
+      },
+      "draft": "Unsere Datenschutzerklärung wird derzeit erstellt.",
+      "contact": "Bei Fragen kontaktiere uns: thierryvm@gmail.com",
+      "backHome": "Zurück zur Startseite"
+    },
+    "cookies": {
+      "metaTitle": "Cookie-Richtlinie",
+      "metaDescription": "Cookie-Richtlinie von Ankora — volle Granularität, alles ablehnbar außer essenziell.",
+      "title": "Cookie-Richtlinie",
+      "categoriesHeading": "Kategorien",
+      "essentialHeading": "Essenziell (immer aktiv)",
+      "essentialBody": "Unverzichtbar für den Betrieb: Authentifizierungs-Session, Theme-Präferenz, Anti-CSRF.",
+      "essentialItem1": "<code>sb-*</code> — Supabase-Session (Auth)",
+      "essentialItem2": "<code>ankora-theme</code> — Präferenz hell/dunkel",
+      "analyticsHeading": "Analytics (standardmäßig deaktiviert)",
+      "analyticsBody1": "Nur wenn du deine Einwilligung gibst. Aggregierte Nutzungsmessung, ohne persönliche Kennung.",
+      "analyticsBody2": "Ankora nutzt kein Google Analytics. Die Vercel-Metriken sind aggregiert und anonymisiert.",
+      "marketingHeading": "Marketing (standardmäßig deaktiviert)",
+      "marketingBody": "Ankora nutzt derzeit keine Marketing-Cookies.",
+      "manageHeading": "Deine Präferenzen verwalten",
+      "manageBody1": "Du kannst deine Einwilligungen jederzeit unter <b>Einstellungen → Datenschutz</b> ändern oder indem du im Footer auf „Cookies verwalten“ klickst.",
+      "manageBody2": "Das Ablehnen nicht-essenzieller Cookies beeinträchtigt das Erlebnis nicht: Ankora bleibt voll funktionsfähig.",
+      "lifetimeHeading": "Lebensdauer",
+      "lifetimeItem1": "Session: Ende der Navigation",
+      "lifetimeItem2": "Präferenzen: 12 Monate",
+      "lifetimeItem3": "Analytics: 6 Monate (falls akzeptiert)",
+      "draft": "Diese Cookie-Richtlinienseite wird derzeit erstellt.",
+      "contact": "Bei Fragen kontaktiere uns: thierryvm@gmail.com",
+      "backHome": "Zurück zur Startseite"
+    }
+  },
+  "offline": {
+    "metaTitle": "Offline",
+    "metaDescription": "Du bist derzeit offline. Verbinde dich erneut, um auf Ankora zuzugreifen.",
+    "title": "Du bist offline",
+    "message": "Verbinde dich erneut, um auf dein Cockpit zuzugreifen. Deine Daten bleiben unversehrt.",
+    "retry": "Erneut versuchen"
+  },
+  "consent": {
+    "title": "Cookies und Datenschutz",
+    "body": "Wir verwenden nur essenzielle Cookies, um dich anzumelden. Analyse-Cookies sind standardmäßig deaktiviert — du kannst sie aktivieren, wenn du uns helfen möchtest, Ankora zu verbessern. Du kannst deine Meinung jederzeit über <link>die Cookie-Richtlinie</link> ändern.",
+    "essentialOnly": "Nur essenziell",
+    "acceptAnalytics": "Analysen akzeptieren"
+  },
+  "footer": {
+    "copyright": "© {year} — Alle Rechte vorbehalten",
+    "cgu": "AGB",
+    "privacy": "Datenschutz",
+    "cookies": "Cookies verwalten",
+    "faq": "FAQ",
+    "copyrightNotice": "© {year} Ankora™. Alle Rechte vorbehalten."
+  },
+  "auth": {
+    "login": {
+      "title": "Anmelden",
+      "subtitle": "Finde dein Ankora-Cockpit wieder.",
+      "metaTitle": "Anmeldung",
+      "emailLabel": "E-Mail",
+      "passwordLabel": "Passwort",
+      "forgotLink": "Passwort vergessen?",
+      "submit": "Anmelden",
+      "submitting": "Anmelden…",
+      "noAccount": "Noch kein Konto?",
+      "signupLink": "Konto erstellen",
+      "dividerOr": "oder",
+      "dividerOrEmail": "oder mit deiner E-Mail",
+      "passwordUpdatedBanner": "Passwort aktualisiert. Du kannst dich anmelden."
+    },
+    "signup": {
+      "title": "Konto erstellen",
+      "subtitle": "Starte dein Finanz-Cockpit in weniger als 2 Minuten.",
+      "pageTitle": "Mein Cockpit erstellen",
+      "pageDescription": "Wenige Sekunden. Keine Kreditkarte.",
+      "emailLabel": "E-Mail",
+      "passwordLabel": "Passwort",
+      "passwordHint": "Mindestens 12 Zeichen, 1 Großbuchstabe, 1 Kleinbuchstabe, 1 Ziffer.",
+      "passwordConfirmLabel": "Passwort bestätigen",
+      "acceptTosPrefix": "Ich akzeptiere die",
+      "acceptTosLink": "AGB",
+      "acceptPrivacyPrefix": "Ich akzeptiere die",
+      "acceptPrivacyLink": "Datenschutzerklärung",
+      "submit": "Mein Konto erstellen",
+      "submitting": "Erstellen…",
+      "haveAccount": "Schon ein Konto?",
+      "loginLink": "Anmelden",
+      "dividerOr": "oder",
+      "dividerOrEmail": "oder mit deiner E-Mail",
+      "googleCta": "Mein Konto mit Google erstellen",
+      "googleTerms": "Wenn du mit Google fortfährst, akzeptierst du unsere <cgu>AGB</cgu> und unsere <privacy>Datenschutzerklärung</privacy>."
+    },
+    "forgot": {
+      "title": "Passwort vergessen",
+      "subtitle": "Gib deine E-Mail ein, wir senden dir einen sicheren Link.",
+      "emailLabel": "E-Mail",
+      "submit": "Link senden",
+      "submitting": "Senden…",
+      "sentMessage": "Falls diese E-Mail existiert, wurde soeben ein Zurücksetzungs-Link gesendet.",
+      "backToLogin": "Zurück zur Anmeldung"
+    },
+    "reset": {
+      "title": "Neues Passwort",
+      "subtitle": "Wähle ein starkes Passwort für dein Konto.",
+      "passwordLabel": "Neues Passwort",
+      "passwordConfirmLabel": "Bestätigen",
+      "submit": "Aktualisieren",
+      "submitting": "Aktualisieren…"
+    },
+    "google": {
+      "label": "Mit Google fortfahren",
+      "redirecting": "Weiterleitung…"
+    },
+    "checkEmail": {
+      "title": "Prüfe dein Postfach",
+      "metaTitle": "Prüfe deine E-Mail",
+      "body": "Wir haben dir soeben einen Bestätigungslink gesendet. Klicke darauf, um dein Konto zu aktivieren.",
+      "backToLogin": "Zurück zur Anmeldung"
+    }
+  },
+  "onboarding": {
+    "defaultWorkspaceName": "Mein Bereich",
+    "previous": "Zurück",
+    "next": "Weiter",
+    "finish": "Fertigstellen",
+    "finishing": "Speichern…",
+    "validation": {
+      "workspaceNameRequired": "Gib deinem Bereich einen Namen.",
+      "incomeInvalid": "Gib ein gültiges Einkommen an (≥ 0)."
+    },
+    "step1": {
+      "title": "Benenne deinen Bereich",
+      "description": "Du kannst ihn später in den Einstellungen ändern.",
+      "nameLabel": "Name des Bereichs"
+    },
+    "step2": {
+      "title": "Dein Nettoeinkommen (monatlich)",
+      "description": "Dient als Basis, um dir die monatlichen Überweisungen vorzuschlagen.",
+      "incomeLabel": "Nettoeinkommen monatlich (€)"
+    },
+    "step3": {
+      "title": "Deine ersten Fixkosten (optional)",
+      "description": "Füge eine Miete, eine Versicherung, ein Abo hinzu…",
+      "labelLabel": "Bezeichnung",
+      "labelPlaceholder": "Miete, Autoversicherung…",
+      "amountLabel": "Betrag (€)",
+      "frequencyLabel": "Frequenz",
+      "dueMonthLabel": "Referenzmonat",
+      "skipLater": "Ich trage meine Fixkosten später ein"
+    }
+  },
+  "app": {
+    "dashboard": {
+      "metaTitle": "Dashboard",
+      "headerTitle": "{month} — dein Cockpit",
+      "emptyTitle": "Beginne mit dem Hinzufügen deiner Fixkosten",
+      "emptyDescription": "Miete, Versicherungen, Abos — Ankora verteilt sie für dich auf 12 Monate.",
+      "emptyCta": "Fixkosten hinzufügen",
+      "kpiProvisionsMonthly": "Rücklagen / Monat",
+      "kpiProvisionsAnnualHint": "Jährlich: {amount}",
+      "kpiHealth": "Rücklagen-Status",
+      "kpiHealthTargetHint": "Ziel: {amount}",
+      "kpiSuggestedTransfer": "Vorgeschlagene Überweisung",
+      "kpiSuggestedTransferToSavings": "Zurückzulegen",
+      "kpiSuggestedTransferFromSavings": "Von den Ersparnissen abzuheben",
+      "kpiBillsMonth": "Rechnungen {month}",
+      "kpiBillsHint": "Cash-Ausgang diesen Monat",
+      "healthHealthy": "Gesund",
+      "healthWarning": "Zu beobachten",
+      "healthCritical": "Kritisch",
+      "planTitle": "Plan des Monats — {month}",
+      "planDescription": "Die Überweisungen, die du zu Monatsbeginn auf deinen drei Konten ausführen musst.",
+      "planAdjustAccounts": "Meine Konten anpassen",
+      "missingSetupTitle": "Richte zuerst deine Konten ein",
+      "missingSetupDescription": "Um deine Intelligente Überweisung zu berechnen, benötigt Ankora dein monatliches Einkommen und den festen Betrag, den du auf Alltag überweist.",
+      "missingSetupCta": "Meine Konten einrichten",
+      "transferPrincipalToVieCourante": "Hauptkonto → Alltag",
+      "transferVieCouranteHint": "Umschlag für Einkäufe, Benzin, Restaurants.",
+      "transferPrincipalToEpargne": "Hauptkonto → Sparen",
+      "transferEpargneToPrincipal": "Sparen → Hauptkonto",
+      "transferEpargneHint": "Rücklage {provision} − Rechnungen {bills}",
+      "transferPrincipalRemaining": "Restbetrag Hauptkonto",
+      "transferPrincipalRemainingHint": "Nach Gehalt, Überweisungen und Rechnungen Hauptkonto ({bills}).",
+      "ctaCharges": "Meine Fixkosten",
+      "ctaExpenses": "Meine Ausgaben",
+      "ctaSimulator": "Simulieren",
+      "expensesTitle": "Ausgaben — {month}",
+      "expensesCount": "{count, plural, =0 {Keine Ausgaben diesen Monat} one {1 Ausgabe diesen Monat} other {# Ausgaben diesen Monat}}",
+      "expensesEmpty": "Keine Ausgaben für diesen Monat erfasst.",
+      "expensesViewAll": "Alle Ausgaben anzeigen →"
+    },
+    "charges": {
+      "title": "Meine Fixkosten",
+      "subtitle": "Jede Fixkost wird automatisch auf 12 Monate verteilt.",
+      "addFormTitle": "Fixkosten hinzufügen",
+      "emptyState": "Noch keine Fixkosten.",
+      "labelLabel": "Bezeichnung",
+      "amountLabel": "Betrag (€)",
+      "frequencyLabel": "Frequenz",
+      "dueMonthLabel": "Referenzmonat",
+      "addButton": "Hinzufügen",
+      "adding": "Hinzufügen…",
+      "count": "{count, plural, =0 {keine Fixkosten} one {1 Fixkosten-Eintrag} other {# Fixkosten-Einträge}}",
+      "referenceFormat": "{frequency} · Ref. {month}",
+      "deleteAria": "{label} löschen",
+      "toastCreated": "Fixkosten hinzugefügt",
+      "toastDeleted": "Fixkosten gelöscht"
+    },
+    "accounts": {
+      "metaTitle": "Meine Konten",
+      "metaDescription": "Verfolge die Salden deiner Konten Hauptkonto, Alltag und Sparen. Stelle dein monatliches Einkommen und deine Überweisung auf Alltag ein.",
+      "title": "Meine Konten",
+      "subtitle": "Gib deine echten Salden ein, damit Ankora deine intelligente Überweisung jeden Monat präzise berechnen kann.",
+      "balancesHeading": "Aktuelle Salden",
+      "amountLabel": "Betrag (€)",
+      "saveButton": "Speichern",
+      "saving": "Speichern…",
+      "income": {
+        "title": "Nettoeinkommen (monatlich)",
+        "description": "Das Gehalt, das jeden Monat auf deinem Hauptkonto eingeht. Dient zur Berechnung dessen, was dir nach Fixkosten und Überweisung auf Alltag bleibt.",
+        "placeholder": "Z. B. 2500",
+        "toastSaved": "Monatliches Einkommen aktualisiert"
+      },
+      "transfer": {
+        "title": "Monatliche Überweisung auf Alltag",
+        "description": "Fester Betrag, der jeden Monat vom Hauptkonto auf dein Alltag-Konto überwiesen wird. Das ist das Geld für Einkäufe, Benzin und Restaurants.",
+        "placeholder": "Z. B. 500",
+        "toastSaved": "Monatliche Überweisung aktualisiert"
+      },
+      "balance": {
+        "invalidAmount": "Gib einen gültigen Betrag ein.",
+        "saveLabel": "Aktualisieren",
+        "srLabel": "Aktueller Saldo von {label}",
+        "toastSaved": "{name} aktualisiert"
+      },
+      "kind": {
+        "principal": {
+          "description": "Erhält das Gehalt, zahlt die monatlichen Fixkosten."
+        },
+        "vieCourante": {
+          "description": "Budget des Alltags (Einkäufe, Benzin, Restaurants)."
+        },
+        "epargne": {
+          "description": "Verteilt die vierteljährlichen und jährlichen Rechnungen."
+        }
+      },
+      "types": {
+        "income_bills": "Salary & Bills",
+        "provisions": "Annual Provisions",
+        "daily_card": "Groceries, Gas & Leisure"
+      },
+      "defaults": {
+        "income_bills": "Main Account",
+        "provisions": "Savings Account",
+        "daily_card": "Daily Card"
+      }
+    },
+    "expenses": {
+      "title": "Meine Ausgaben",
+      "subtitle": "Die Ausgaben abseits wiederkehrender Fixkosten — Einkäufe, Restaurant, Freizeit…",
+      "addFormTitle": "Ausgabe hinzufügen",
+      "labelLabel": "Bezeichnung",
+      "amountLabel": "Betrag (€)",
+      "dateLabel": "Datum",
+      "addButton": "Hinzufügen",
+      "adding": "Hinzufügen…",
+      "emptyState": "Keine Ausgabe erfasst.",
+      "summary": "{count, plural, =0 {Keine Ausgabe} one {1 Ausgabe · {total}} other {# Ausgaben · {total}}}",
+      "deleteAria": "{label} löschen",
+      "toastCreated": "Ausgabe hinzugefügt",
+      "toastDeleted": "Ausgabe gelöscht"
     },
     "settings": {
-    "displayName": {
-      "required": "Name erforderlich.",
-      "tooLong": "Maximal 80 Zeichen."
+      "metaTitle": "Einstellungen",
+      "metaDescription": "Verwalte dein Profil, die 2FA-Sicherheit und deine persönlichen Daten.",
+      "title": "Einstellungen",
+      "description": "Profil, Sicherheit und persönliche Daten.",
+      "profile": {
+        "title": "Profil",
+        "description": "Diese Informationen personalisieren dein Cockpit.",
+        "emailLabel": "E-Mail",
+        "displayNameLabel": "Anzeigename",
+        "localeLabel": "Sprache",
+        "localeOptions": {
+          "fr-BE": "Français (Belgique)",
+          "fr-FR": "Français (France)",
+          "en-GB": "English"
+        },
+        "submit": "Speichern",
+        "submitting": "Speichern…",
+        "toastSaved": "Profil aktualisiert"
+      },
+      "mfa": {
+        "title": "Sicherheit — 2FA",
+        "description": "Ein Einmalcode, generiert von einer Authenticator-App (Authy, 1Password, Google Authenticator).",
+        "emptyState": "Kein 2FA-Faktor aktiv. Aktiviere ihn, um dein Konto zu schützen.",
+        "enrollButton": "2FA aktivieren",
+        "enrolling": "Vorbereiten…",
+        "scanInstruction": "Scanne diesen QR-Code in deiner Authenticator-App und gib dann den 6-stelligen Code ein.",
+        "qrAlt": "QR-Code für die Authenticator-App",
+        "manualEntry": "Manuelle Eingabe",
+        "codeLabel": "6-stelliger Code",
+        "verifyButton": "Prüfen und aktivieren",
+        "verifying": "Prüfen…",
+        "cancel": "Abbrechen",
+        "defaultFactorName": "TOTP-App",
+        "activeLabel": "Aktiv",
+        "disableButton": "Deaktivieren",
+        "toastEnabled": "MFA aktiviert",
+        "toastDisabled": "MFA deaktiviert"
+      },
+      "data": {
+        "title": "Meine Daten",
+        "description": "DSGVO-Datenübertragbarkeit (Art. 20) — lade ein vollständiges JSON mit allem herunter, was Ankora über dich hat.",
+        "exportButton": "Meine Daten herunterladen",
+        "exporting": "Generieren…",
+        "toastDownloaded": "Export heruntergeladen"
+      },
+      "danger": {
+        "scheduledTitle": "Löschung läuft",
+        "scheduledBody": "Dein Konto wird am <strong>{date}</strong> gelöscht. Du kannst jederzeit bis dahin widerrufen.",
+        "viewStatus": "Status anzeigen",
+        "title": "Gefahrenzone",
+        "description": "Endgültige Löschung des Kontos. 30 Tage Gnadenfrist zum Widerrufen — danach wird alles gelöscht (Audit-Logs pseudonymisiert).",
+        "reasonLabel": "Grund (optional)",
+        "reasonPlaceholder": "Hilf uns, uns zu verbessern…",
+        "confirmLabel": "Tippe zur Bestätigung deine E-Mail-Adresse ein: <code>{email}</code>",
+        "submit": "Mein Konto löschen",
+        "submitting": "Planen…",
+        "toastScheduled": "Löschung geplant — du hast 30 Tage zum Widerrufen"
+      }
+    },
+    "simulator": {
+      "title": "Simulator",
+      "subtitle": "Miss die Auswirkung einer Änderung, ohne deine echten Daten anzurühren.",
+      "scenario": {
+        "title": "Szenario",
+        "description": "Wähle eine zu simulierende Aktion.",
+        "modes": {
+          "cancel": "Fixkosten kündigen",
+          "negotiate": "Neu verhandeln",
+          "add": "Fixkosten hinzufügen"
+        }
+      },
+      "fields": {
+        "charge": "Fixkosten",
+        "chargePlaceholder": "Auswählen…",
+        "newAmount": "Neuer Betrag (€)",
+        "label": "Bezeichnung",
+        "amount": "Betrag (€)",
+        "frequency": "Frequenz",
+        "month": "Monat"
+      },
+      "impact": {
+        "title": "Auswirkung",
+        "empty": "Vervollständige das Szenario, um die Auswirkung zu sehen.",
+        "currentMonthly": "Aktuell / Monat",
+        "projectedMonthly": "Prognose / Monat",
+        "annualSavings": "Jährliche Ersparnis",
+        "monthlyChange": "{sign}{percent}% / Monat"
+      }
+    },
+    "deletionStatus": {
+      "title": "Konto-Löschung",
+      "subtitle": "Detaillierter Status deines Antrags und Widerrufsfrist.",
+      "metaTitle": "Löschstatus",
+      "metaDescription": "Status des Löschungsantrags deines Ankora-Kontos.",
+      "statusLabel": "Status:",
+      "requestedOn": "Beantragt am {date}.",
+      "statusPending": "Ausstehend",
+      "statusCancelled": "Widerrufen",
+      "statusCompleted": "Abgeschlossen",
+      "scheduledFor": "Löschung geplant",
+      "daysLeft": "Verbleibende Tage",
+      "auditLogs": "Audit-Logs",
+      "auditLogsValue": "Pseudonymisiert, niemals gelöscht",
+      "daysCount": "{days, plural, =0 {Heute} one {# Tag} other {# Tage}}",
+      "backToSettings": "Zurück zu den Einstellungen",
+      "cancelledOn": "Antrag widerrufen am {date}. Dein Konto bleibt erhalten.",
+      "cancelledNoDate": "Antrag widerrufen. Dein Konto bleibt erhalten.",
+      "cancelButton": "Löschung widerrufen",
+      "cancelling": "Widerrufen…",
+      "toastCancelled": "Antrag widerrufen — dein Konto bleibt erhalten"
+    },
+    "cockpit": {
+      "capaciteEpargneReelle": {
+        "title": "Real Savings Capacity",
+        "messagePositive": "This is what you truly have left every month, with no surprises.",
+        "messageNegative": "Warning — your overall lifestyle exceeds your income.",
+        "tooltip": "This subtracts every charge (smoothed over the year) and your daily allowance from your monthly income. That is what is actually left for savings or unexpected expenses."
+      },
+      "santeProvisions": {
+        "title": "Provisions Health",
+        "cibleTheorique": "Ideal theoretical target:",
+        "soldeActuel": "Current balance:",
+        "statutAJour": "On track ✨",
+        "deficit": "Deficit detected:",
+        "rattrapageDescription": "Includes +{amount} € to recover the deficit over 3 months.",
+        "tooltip": "The algorithm computes how much your Savings account should hold today to absorb all upcoming periodic charges smoothly."
+      },
+      "virements": {
+        "title": "Transfer Assistant",
+        "provisionsMensuelles": "Monthly provisions:",
+        "facturesAnnuelles": "Periodic bills this month:",
+        "aVirer": "Transfer to Savings:",
+        "aRecuperer": "Pull from Savings:",
+        "aucun": "No transfer needed this month. Provisions exactly cover the periodic bills.",
+        "descriptionAVirer": "Covers your monthly provisions, minus the bills due this month.",
+        "descriptionDepuis": "This month’s periodic bills exceed your provision. Use your savings!",
+        "detailHeader": "Breakdown of the {amount} € provisions:"
+      },
+      "notifications": {
+        "transferToSavings": "Remember to transfer {amount} € to Savings this month.",
+        "transferFromSavings": "You need to pull {amount} € from Savings to cover this month’s bills.",
+        "chargeOverdue": "{label} is overdue (was due on {day}).",
+        "chargeDueSoon": "{label} due in {days} day(s)."
+      }
+    }
+  },
+  "glossary": {
+    "title": "Glossary",
+    "subtitle": "15 essential terms for understanding your budgeting and personal finances.",
+    "metaTitle": "Glossary — Financial Terms",
+    "metaDescription": "Glossary of 15 essential budgeting terms: smoothed budget, bucket account, emergency fund, and more.",
+    "breadcrumb": {
+      "home": "Home",
+      "glossary": "Glossary"
+    },
+    "section": {
+      "whyItMatters": "Why It Matters",
+      "example": "Concrete Example",
+      "relatedTerms": "Related Terms"
+    }
+  },
+  "errors": {
+    "generic": "Ein Fehler ist aufgetreten. Versuche es erneut.",
+    "session": {
+      "expired": "Session abgelaufen. Melde dich erneut an.",
+      "rateLimited": "Zu viele Anfragen. Warte eine Minute."
+    },
+    "auth": {
+      "invalidCredentials": "E-Mail oder Passwort falsch.",
+      "signupFailed": "Registrierung nicht möglich. Versuche es später erneut.",
+      "googleFailed": "Google-Anmeldung nicht verfügbar. Versuche es später erneut.",
+      "rateLimited": "Zu viele Versuche. Versuche es in einigen Minuten erneut.",
+      "serviceTemporarilyUnavailable": "Dienst vorübergehend nicht verfügbar. Versuche es in einigen Minuten erneut.",
+      "passwordResetFailed": "Passwort konnte nicht aktualisiert werden.",
+      "linkExpired": "Link abgelaufen. Fordere einen neuen Link an.",
+      "mfaEnrollFailed": "Aktivierung nicht möglich.",
+      "mfaChallengeFailed": "MFA-Challenge nicht möglich.",
+      "mfaCodeInvalid": "Code falsch. Versuche es erneut.",
+      "mfaDisableFailed": "2FA konnte nicht deaktiviert werden."
+    },
+    "db": {
+      "workspaceNotFound": "Kein bearbeitbarer Workspace.",
+      "updateFailed": "Aktualisierung nicht möglich.",
+      "notEditable": "Du hast keine Bearbeitungsrechte für diesen Bereich."
+    },
+    "validation": {
+      "generic": "Ungültige Daten.",
+      "auth": {
+        "email": {
+          "invalid": "Ungültige E-Mail-Adresse."
+        },
+        "password": {
+          "required": "Passwort erforderlich.",
+          "tooShort": "Mindestens 12 Zeichen.",
+          "tooLong": "Maximal 128 Zeichen.",
+          "lowercase": "Mindestens ein Kleinbuchstabe.",
+          "uppercase": "Mindestens ein Großbuchstabe.",
+          "digit": "Mindestens eine Ziffer."
+        },
+        "passwordConfirm": {
+          "mismatch": "Die Passwörter stimmen nicht überein."
+        },
+        "acceptTos": {
+          "required": "Du musst die AGB akzeptieren."
+        },
+        "acceptPrivacy": {
+          "required": "Du musst die Datenschutzerklärung akzeptieren."
+        }
+      },
+      "charge": {
+        "label": {
+          "required": "Bezeichnung erforderlich.",
+          "tooLong": "Maximal 120 Zeichen."
+        },
+        "amount": {
+          "invalid": "Ungültiger Betrag.",
+          "negative": "Der Betrag muss ≥ 0 sein.",
+          "tooHigh": "Betrag zu hoch."
+        },
+        "frequency": {
+          "invalid": "Ungültige Frequenz."
+        },
+        "dueMonth": {
+          "range": "Monat zwischen 1 und 12."
+        },
+        "paidFrom": {
+          "invalid": "Ungültiges Belastungskonto."
+        }
+      },
+      "account": {
+        "kind": {
+          "invalid": "Ungültiger Kontotyp."
+        },
+        "balance": {
+          "invalid": "Ungültiger Saldo.",
+          "outOfRange": "Wert außerhalb des Bereichs."
+        },
+        "label": {
+          "required": "Bezeichnung erforderlich.",
+          "tooLong": "Maximal 80 Zeichen."
+        }
+      },
+      "workspace": {
+        "name": {
+          "required": "Name erforderlich.",
+          "tooLong": "Maximal 80 Zeichen."
+        },
+        "income": {
+          "invalid": "Ungültiges Einkommen.",
+          "negative": "Muss ≥ 0 sein.",
+          "tooHigh": "Einkommen zu hoch."
+        },
+        "transfer": {
+          "invalid": "Ungültiger Betrag.",
+          "negative": "Muss ≥ 0 sein.",
+          "tooHigh": "Betrag zu hoch."
+        }
+      },
+      "expense": {
+        "label": {
+          "required": "Bezeichnung erforderlich.",
+          "tooLong": "Maximal 120 Zeichen."
+        },
+        "amount": {
+          "invalid": "Ungültiger Betrag.",
+          "negative": "Muss ≥ 0 sein.",
+          "tooHigh": "Betrag zu hoch."
+        },
+        "date": {
+          "format": "Erwartetes Format: YYYY-MM-DD."
+        },
+        "category": {
+          "invalid": "Ungültige Kategorie."
+        }
+      },
+      "settings": {
+        "displayName": {
+          "required": "Name erforderlich.",
+          "tooLong": "Maximal 80 Zeichen."
+        },
+        "locale": {
+          "invalid": "Ungültige Sprache."
+        },
+        "factorId": {
+          "invalid": "Ungültige Kennung."
+        },
+        "mfaCode": {
+          "invalid": "6-stelliger Code."
+        },
+        "deletion": {
+          "confirm": "Diese Adresse stimmt nicht mit deinem Konto überein."
+        }
+      },
+      "onboarding": {
+        "workspace": {
+          "required": "Name erforderlich.",
+          "tooLong": "Maximal 80 Zeichen."
+        },
+        "income": {
+          "invalid": "Ungültiges Einkommen.",
+          "negative": "Muss ≥ 0 sein.",
+          "tooHigh": "Einkommen zu hoch."
+        },
+        "firstCharge": {
+          "label": {
+            "required": "Bezeichnung erforderlich.",
+            "tooLong": "Maximal 120 Zeichen."
+          },
+          "amount": {
+            "invalid": "Ungültiger Betrag.",
+            "negative": "Muss ≥ 0 sein.",
+            "tooHigh": "Betrag zu hoch."
+          },
+          "dueMonth": {
+            "range": "Monat zwischen 1 und 12."
+          }
+        }
+      }
+    },
+    "charges": {
+      "createFailed": "Fixkosten konnten nicht erstellt werden.",
+      "updateFailed": "Fixkosten konnten nicht aktualisiert werden.",
+      "deleteFailed": "Fixkosten konnten nicht gelöscht werden."
+    },
+    "accounts": {
+      "balanceUpdateFailed": "Saldo konnte nicht aktualisiert werden.",
+      "renameFailed": "Konto konnte nicht umbenannt werden.",
+      "incomeUpdateFailed": "Einkommen konnte nicht aktualisiert werden.",
+      "transferUpdateFailed": "Überweisung konnte nicht aktualisiert werden."
+    },
+    "expenses": {
+      "createFailed": "Ausgabe konnte nicht erstellt werden.",
+      "deleteFailed": "Ausgabe konnte nicht gelöscht werden."
+    },
+    "settings": {
+      "profileUpdateFailed": "Profil konnte nicht aktualisiert werden.",
+      "deletionRequestFailed": "Löschung konnte nicht geplant werden.",
+      "deletionCancelFailed": "Antrag konnte nicht widerrufen werden.",
+      "exportLimited": "Export auf einmal alle 5 Minuten begrenzt."
+    },
+    "onboarding": {
+      "workspaceNotFound": "Workspace nicht gefunden. Kontaktiere den Support.",
+      "workspaceUpdateFailed": "Workspace konnte nicht aktualisiert werden.",
+      "chargeFailed": "Workspace erstellt, aber Fixkosten nicht gespeichert."
     },
     "locale": {
       "invalid": "Ungültige Sprache."
-    },
-    "factorId": {
-      "invalid": "Ungültige Kennung."
-    },
-    "mfaCode": {
-      "invalid": "6-stelliger Code."
-    },
-    "deletion": {
-      "confirm": "Diese Adresse stimmt nicht mit deinem Konto überein."
     }
-    },
-    "onboarding": {
-    "workspace": {
-      "required": "Name erforderlich.",
-      "tooLong": "Maximal 80 Zeichen."
-    },
-    "income": {
-      "invalid": "Ungültiges Einkommen.",
-      "negative": "Muss ≥ 0 sein.",
-      "tooHigh": "Einkommen zu hoch."
-    },
-    "firstCharge": {
-      "label": {
-      "required": "Bezeichnung erforderlich.",
-      "tooLong": "Maximal 120 Zeichen."
-      },
-      "amount": {
-      "invalid": "Ungültiger Betrag.",
-      "negative": "Muss ≥ 0 sein.",
-      "tooHigh": "Betrag zu hoch."
-      },
-      "dueMonth": {
-      "range": "Monat zwischen 1 und 12."
-      }
-    }
-    }
-  },
-  "charges": {
-    "createFailed": "Fixkosten konnten nicht erstellt werden.",
-    "updateFailed": "Fixkosten konnten nicht aktualisiert werden.",
-    "deleteFailed": "Fixkosten konnten nicht gelöscht werden."
-  },
-  "accounts": {
-    "balanceUpdateFailed": "Saldo konnte nicht aktualisiert werden.",
-    "renameFailed": "Konto konnte nicht umbenannt werden.",
-    "incomeUpdateFailed": "Einkommen konnte nicht aktualisiert werden.",
-    "transferUpdateFailed": "Überweisung konnte nicht aktualisiert werden."
-  },
-  "expenses": {
-    "createFailed": "Ausgabe konnte nicht erstellt werden.",
-    "deleteFailed": "Ausgabe konnte nicht gelöscht werden."
-  },
-  "settings": {
-    "profileUpdateFailed": "Profil konnte nicht aktualisiert werden.",
-    "deletionRequestFailed": "Löschung konnte nicht geplant werden.",
-    "deletionCancelFailed": "Antrag konnte nicht widerrufen werden.",
-    "exportLimited": "Export auf einmal alle 5 Minuten begrenzt."
-  },
-  "onboarding": {
-    "workspaceNotFound": "Workspace nicht gefunden. Kontaktiere den Support.",
-    "workspaceUpdateFailed": "Workspace konnte nicht aktualisiert werden.",
-    "chargeFailed": "Workspace erstellt, aber Fixkosten nicht gespeichert."
-  },
-  "locale": {
-    "invalid": "Ungültige Sprache."
-  }
   },
   "opengraphImage": {
-  "trustHosting": "🇧🇪 Belgien · EU-gehostet",
-  "trustNoBank": "Keine Bankaggregation",
-  "trustFree": "0 € Phase 1"
+    "trustHosting": "🇧🇪 Belgien · EU-gehostet",
+    "trustNoBank": "Keine Bankaggregation",
+    "trustFree": "0 € Phase 1"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,1024 +1,1068 @@
 {
   "common": {
-  "appName": "Ankora",
-  "tagline": "Your financial anchor",
-  "description": "Ankora helps you smooth your bills, anticipate every invoice and stay in control of your budget. A clear, secure cockpit — no investment advice.",
-  "homeAria": "Ankora home",
-  "a11y": {
-    "skipToMain": "Skip to main content"
-  },
-  "nav": {
-    "mainLabel": "Main navigation",
-    "appLabel": "App navigation",
-    "mobileLabel": "Mobile navigation",
-    "footerLabel": "Footer",
-    "menu": "Menu",
-    "close": "Close",
-    "lightMode": "Light mode",
-    "darkMode": "Dark mode",
-    "features": "Features",
-    "faq": "FAQ",
-    "login": "Log in",
-    "signup": "Sign up",
-    "myCockpit": "My cockpit",
-    "dashboard": "Dashboard",
-    "accounts": "Accounts",
-    "charges": "Bills",
-    "settings": "Settings"
-  },
-  "actions": {
-    "retry": "Retry",
-    "back": "Back"
-  },
-  "months": {
-    "1": "January",
-    "2": "February",
-    "3": "March",
-    "4": "April",
-    "5": "May",
-    "6": "June",
-    "7": "July",
-    "8": "August",
-    "9": "September",
-    "10": "October",
-    "11": "November",
-    "12": "December"
-  },
-  "monthsShort": {
-    "1": "Jan",
-    "2": "Feb",
-    "3": "Mar",
-    "4": "Apr",
-    "5": "May",
-    "6": "Jun",
-    "7": "Jul",
-    "8": "Aug",
-    "9": "Sep",
-    "10": "Oct",
-    "11": "Nov",
-    "12": "Dec"
-  },
-  "frequency": {
-    "monthly": "Monthly",
-    "quarterly": "Quarterly",
-    "semiannual": "Semi-annual",
-    "annual": "Annual"
-  }
-  },
-  "ui": {
-  "scrollToTop": "Scroll back to top",
-  "localeSwitcher": {
-    "label": "Language",
-    "aria": "Change language",
-    "options": {
-    "fr-BE": "Français (BE)",
-    "nl-BE": "Nederlands (BE)",
-    "en": "English",
-    "es-ES": "Español",
-    "de-DE": "Deutsch"
-    }
-  },
-  "action": {
-    "submit": "Confirm",
-    "submitting": "Confirming…",
-    "save": "Save",
-    "saving": "Saving…",
-    "cancel": "Cancel",
-    "cancelling": "Cancelling…",
-    "delete": "Delete",
-    "deleting": "Deleting…",
-    "create": "Create",
-    "creating": "Creating…",
-    "update": "Update",
-    "updating": "Updating…",
-    "send": "Send",
-    "sending": "Sending…",
-    "verify": "Verify",
-    "verifying": "Verifying…",
-    "generate": "Generate",
-    "generating": "Generating…",
-    "download": "Download",
-    "downloading": "Downloading…",
-    "preparing": "Preparing…",
-    "confirm": "Confirm",
-    "close": "Close"
-  }
-  },
-  "landing": {
-  "mktnav": {
-    "links": {
-    "product": "Product",
-    "simulator": "Simulator",
-    "pricing": "Pricing",
-    "security": "Security",
-    "journal": "Journal"
+    "appName": "Ankora",
+    "tagline": "Your financial anchor",
+    "description": "Ankora helps you smooth your bills, anticipate every invoice and stay in control of your budget. A clear, secure cockpit — no investment advice.",
+    "homeAria": "Ankora home",
+    "a11y": {
+      "skipToMain": "Skip to main content"
     },
-    "ctaLogin": "Log in",
-    "ctaSignup": "Try for free"
-  },
-  "hero": {
-    "badge": "New · What-if simulator",
-    "h1Lead": "Your financial",
-    "h1Highlight": "anchor.",
-    "description": "Ankora separates your earmarked provisions from your free reserve, projects six months ahead, and lets you simulate the impact of every decision — clearly, without jargon.",
-    "ctaPrimary": "Open my cockpit",
-    "ctaSecondary": "See the simulator",
-    "trust": {
-    "encrypted": "Data encrypted in Belgium",
-    "noSale": "No data selling",
-    "languages": "FR · NL · EN"
+    "nav": {
+      "mainLabel": "Main navigation",
+      "appLabel": "App navigation",
+      "mobileLabel": "Mobile navigation",
+      "footerLabel": "Footer",
+      "menu": "Menu",
+      "close": "Close",
+      "lightMode": "Light mode",
+      "darkMode": "Dark mode",
+      "features": "Features",
+      "faq": "FAQ",
+      "login": "Log in",
+      "signup": "Sign up",
+      "myCockpit": "My cockpit",
+      "dashboard": "Dashboard",
+      "accounts": "Accounts",
+      "charges": "Bills",
+      "settings": "Settings"
     },
-    "mockup": {
-    "eyebrow": "Cockpit preview",
-    "browserUrl": "Ankora · cockpit",
-    "kpis": {
-      "netRemaining": {
-      "label": "Net remaining",
-      "sub": "April · after provisions"
-      },
-      "provisions": {
-      "label": "Provisions",
-      "sub": "67% of €2,480 planned"
-      },
-      "reserve": {
-      "label": "Reserve",
-      "sub": "+€120 vs. March"
-      }
-    }
+    "actions": {
+      "retry": "Retry",
+      "back": "Back"
     },
-    "waterfall": {
-    "income": "Income",
-    "incomeAmount": "+2,466 €",
-    "expenses": "Daily expenses",
-    "expensesAmount": "−1,959 €",
-    "provisionsCaption": "of which {amount} € smoothed into earmarked provisions",
-    "available": "Available money",
-    "availableAmount": "+507 €",
-    "ariaLabel": "Illustrative cascade: 2,466 € income, 1,959 € daily expenses (of which 59 € smoothed into provisions), 507 € available."
-    }
-  },
-  "principles": {
-    "eyebrow": "Three principles",
-    "h2": "An honest way to talk about money.",
-    "description": "Ankora isn't trying to sell you an investment or a card. We separate, we project, we simulate. That's it. You alone decide.",
-    "items": {
-    "provisions": {
-      "title": "Earmarked provisions",
-      "description": "Every reserved euro has a name: insurance, road tax, boiler maintenance. Nothing slips away without you knowing."
-    },
-    "reserve": {
-      "title": "Free reserve",
-      "description": "What's actually yours, after commitments. The real number — not the illusion of a gross balance."
-    },
-    "whatIf": {
-      "title": "What-if simulator",
-      "description": "Renegotiate electricity? Switch provider? Ankora shows you the impact over 12 months before you decide."
-    }
-    }
-  },
-  "feature": {
-    "eyebrow": "Cashflow waterfall",
-    "h3Line1": "From salary to net available.",
-    "h3Line2": "At a single glance.",
-    "description": "No more mystery about where your money goes. Every step is visible: income, daily expenses, available money. You see immediately if anything drifts.",
-    "ctaPrimary": "See an example",
-    "ctaSecondary": "How does it work?"
-  },
-  "whatif": {
-    "title": "What if you changed one thing?",
-    "subtitle": "Move the slider. See the impact on your free reserve, over six months. That's what Ankora does for every financial decision.",
-    "badge": "Demo · no account needed",
-    "scenarios": {
-    "gsm": {
-      "label": "Renegotiate my mobile plan",
-      "hint": "Current plan: €42/month · market: €18–28/month"
-    },
-    "elec": {
-      "label": "Switch electricity provider",
-      "hint": "Current bill: €168/month · 3 cheaper offers in your area"
-    },
-    "stream": {
-      "label": "Cut two streaming subscriptions",
-      "hint": "5 active subscriptions · actual use: 2 over 30 days"
-    }
-    },
-    "controls": {
-    "scenario": "Scenario",
-    "savings": "Monthly savings",
-    "slider_aria": "Monthly savings for {label}"
-    },
-    "annual": {
-    "eyebrow": "Over 12 months",
-    "fleche": "Ankora could route {amount} €/month towards your long-term savings."
-    },
-    "chart": {
-    "title": "Free reserve · projection",
-    "subtitle": "6 months from today",
-    "legend": {
-      "baseline": "Without change",
-      "scenario": "With your choice"
-    },
-    "aria": "6-month projection chart of free reserve, with and without the chosen change",
     "months": {
-      "may": "May",
-      "jun": "Jun",
-      "jul": "Jul",
-      "aug": "Aug",
-      "sep": "Sep",
-      "oct": "Oct"
+      "1": "January",
+      "2": "February",
+      "3": "March",
+      "4": "April",
+      "5": "May",
+      "6": "June",
+      "7": "July",
+      "8": "August",
+      "9": "September",
+      "10": "October",
+      "11": "November",
+      "12": "December"
     },
-    "thresholds": {
-      "danger": "⚠️ Estimated overdraft",
-      "fragile": "Fragile zone",
-      "comfortable": "Comfortable zone"
-    }
-    },
-    "caveat": "Demo based on average assumptions. Ankora does not provide investment advice. No bank import — you enter your expenses manually."
-  },
-  "pricing": {
-    "eyebrow": "Transparent from the start",
-    "h2": "Free during Phase 1.",
-    "phaseBadge": "Phase 1 · building",
-    "price": "€0",
-    "period": "for now, with no end date",
-    "body": "We're building the cockpit first. No card asked, no time limit, no feature gating. GDPR export anytime.",
-    "features": {
-    "cockpit": "Full cockpit, provisions and free reserve",
-    "simulator": "Unlimited what-if simulator",
-    "manualEntry": "Manual entry · your data stays in Belgium",
-    "export": "GDPR export in one click"
-    },
-    "ctaPrimary": "Open my cockpit",
-    "roadmap": {
-    "title": "Joining Ankora during Phase 1?",
-    "body": "Your account keeps full lifetime access to the core cockpit, free. A Pro tier with advanced features (unlimited accounts, consolidated exports, priority support) will arrive post-v1.0 — you'll choose to upgrade or stay on your current plan.",
-    "link": "Read the roadmap →"
-    }
-  },
-  "footerCta": {
-    "h2Lead": "Start with what's",
-    "h2Highlight": "already yours.",
-    "description": "30-day trial, no card, GDPR export anytime. We keep it simple because it's already complicated enough.",
-    "ctaPrimary": "Open my cockpit"
-  },
-  "footer": {
-    "links": {
-    "terms": "Terms",
-    "privacy": "Privacy",
-    "security": "Security",
-    "contact": "Contact"
-    },
-    "copyright": "Ankora · Brussels-anchored editor · 2026"
-  },
-  "faqHeading": "Frequently asked questions",
-  "faq": {
-    "advice": {
-    "q": "Is Ankora a financial advice tool?",
-    "a": "No. Ankora is a budgeting and financial education tool. It does not provide investment recommendations or personalised financial advice."
-    },
-    "storage": {
-    "q": "Where is my data stored?",
-    "a": "Your data is hosted in the European Union (Supabase, EU region) with encryption at rest and strict per-user isolation via Row Level Security."
-    },
-    "sharing": {
-    "q": "Can I share my data?",
-    "a": "By default, your space is 100% private. Optional shared pockets (trips, joint projects) are coming in a future release — you'll explicitly choose what you share, and with whom."
-    }
-  }
-  },
-  "faq": {
-  "metaTitle": "FAQ",
-  "metaDescription": "Frequently asked questions about Ankora: security, data, how it works, privacy.",
-  "title": "Frequently asked questions",
-  "subtitle": "Everything you need to know about Ankora before getting started.",
-  "items": {
-    "bankConnection": {
-    "q": "Does Ankora connect to my bank?",
-    "a": "No. Ankora does not use the PSD2 directive. You enter your bills and expenses manually. This choice guarantees you remain the owner of your data and that no sensitive banking information is stored."
-    },
-    "dataLocation": {
-    "q": "Where is my data hosted?",
-    "a": "All your data is hosted in the European Union (Supabase EU region, Vercel EU region, Upstash EU). No data is transferred outside the EU."
-    },
-    "smoothing": {
-    "q": "How does smoothing work?",
-    "a": "Ankora takes your quarterly, semi-annual and annual bills and spreads them across 12 months. You know exactly how much to set aside each month to cover all your future bills, stress-free."
-    },
-    "deletion": {
-    "q": "Can I delete my account?",
-    "a": "Yes, at any time from Settings → Privacy. Deletion takes effect 30 days after your request (you can cancel during this period). All your financial data is wiped, security logs are pseudonymised."
-    },
-    "export": {
-    "q": "Can I export my data?",
-    "a": "Yes. The \"Download my data\" button in Settings gives you a complete JSON file of everything Ankora holds about you. Compliant with the GDPR right to portability (art. 20)."
-    },
-    "advice": {
-    "q": "Does Ankora provide financial advice?",
-    "a": "No. Ankora is a budgeting education and organisation tool. We do not issue any investment advice (FSMA Belgium regulatory constraint). For any investment decision, consult an authorised professional."
-    },
-    "ai": {
-    "q": "Is there any artificial intelligence?",
-    "a": "In Phase 1, no. Calculations are deterministic and auditable. In Phase 2, an optional BYOK (Bring Your Own Key) layer will let you connect your own Anthropic or OpenRouter key for suggestions — no extra cost on Ankora's side."
-    },
-    "sharing": {
-    "q": "Can I share my space with my children or friends?",
-    "a": "In Phase 1, each user has a private space, isolated by default. In Phase 2, we'll add the ability to create \"shared pockets\" (by invitation, with viewer/editor roles) without ever mixing your personal data."
-    }
-  }
-  },
-  "legal": {
-  "versionLine": "Version {version} — last updated: {date}",
-  "lastUpdatedLine": "Last updated: {date}",
-  "cgu": {
-    "metaTitle": "Terms of service",
-    "metaDescription": "Ankora's terms of service — rules for using the service.",
-    "title": "Terms of service",
-    "s1": {
-    "heading": "1. Purpose",
-    "body": "Ankora is a budgeting and financial education tool for individuals. It lets you manually enter your bills and expenses, smooth them across the year, and anticipate cash-flow needs."
-    },
-    "s2": {
-    "heading": "2. What Ankora is NOT",
-    "item1": "Ankora is <b>not an investment advisory service</b>.",
-    "item2": "Ankora is <b>not a banking service</b> and holds no funds.",
-    "item3": "Ankora is <b>not a PSD2 aggregator</b> — no connection to your bank accounts.",
-    "item4": "Ankora is <b>not professional accounting software</b>.",
-    "outro": "The information displayed consists of estimates based on your inputs. It does not constitute personalised financial advice. For any important decision, consult an authorised professional."
-    },
-    "s3": {
-    "heading": "3. Account",
-    "item1": "You must be of legal age or have authorisation from a legal representative.",
-    "item2": "One account per individual.",
-    "item3": "Password: minimum 12 characters, mixed case.",
-    "item4": "You are responsible for keeping your credentials confidential."
-    },
-    "s4": {
-    "heading": "4. Acceptable use",
-    "intro": "You agree not to:",
-    "item1": "use the service for illegal purposes,",
-    "item2": "attempt to circumvent security measures,",
-    "item3": "automate access without explicit authorisation,",
-    "item4": "share your account with a third party."
-    },
-    "s5": {
-    "heading": "5. Intellectual property",
-    "body": "You remain the owner of your data. Ankora retains ownership of its code, brand, design and documentation."
-    },
-    "s6": {
-    "heading": "6. Liability",
-    "body": "Ankora is provided \"as is\". The publisher cannot be held liable for financial decisions made on the basis of the information displayed. No 100% availability is guaranteed."
-    },
-    "s7": {
-    "heading": "7. Termination",
-    "body": "You can delete your account at any time from Settings → Privacy. Deletion takes effect 30 days after the request (cancellable during that period)."
-    },
-    "s8": {
-    "heading": "8. Governing law",
-    "body": "These terms are governed by Belgian law. Competent court: Brussels."
-    },
-    "draft": "Our terms of service are being drafted.",
-    "contact": "For any questions, contact us: thierryvm@gmail.com",
-    "backHome": "Back to home"
-  },
-  "privacy": {
-    "metaTitle": "Privacy policy",
-    "metaDescription": "Ankora's privacy policy — EU hosting, GDPR, user rights.",
-    "title": "Privacy policy",
-    "s1": {
-    "heading": "1. Data controller",
-    "body": "Ankora, published by Thierry Van Mele (Belgium). Contact: <mail>thierryvm@gmail.com</mail>."
-    },
-    "s2": {
-    "heading": "2. Data collected",
-    "intro": "Ankora collects only the data strictly necessary to provide the service:",
-    "item1": "<b>Identity</b>: email address, display name (optional).",
-    "item2": "<b>Financial data you enter</b>: bills, expenses, categories, declared income, savings balance.",
-    "item3": "<b>Technical data</b>: IP address, user-agent (for security logs only).",
-    "item4": "<b>Consents</b>: timestamp, version, scope (terms, privacy, cookies).",
-    "outro": "Ankora does not connect to any bank (no PSD2 aggregation). You enter your bills and expenses yourself."
-    },
-    "s3": {
-    "heading": "3. Legal bases (GDPR art. 6)",
-    "item1": "<b>Contract</b>: providing the service (account, financial data).",
-    "item2": "<b>Consent</b>: analytics/marketing cookies, newsletter.",
-    "item3": "<b>Legal obligation</b>: security logs (12-month retention).",
-    "item4": "<b>Legitimate interest</b>: fraud prevention, security maintenance."
-    },
-    "s4": {
-    "heading": "4. Hosting and subprocessors",
-    "item1": "<b>Supabase</b> (database, auth) — EU region (Frankfurt or Paris).",
-    "item2": "<b>Vercel</b> (frontend hosting) — EU region (Dublin).",
-    "item3": "<b>Upstash</b> (rate limiting) — EU region.",
-    "outro": "No data is transferred outside the EU/EEA."
-    },
-    "s5": {
-    "heading": "5. Retention period",
-    "item1": "Active account: for as long as you use the service.",
-    "item2": "Deleted account: deletion takes effect 30 days after your request (cancellable grace period).",
-    "item3": "Security logs: 12 months maximum, pseudonymised after account deletion."
-    },
-    "s6": {
-    "heading": "6. Your rights (GDPR art. 15-22)",
-    "item1": "<b>Access</b>: view your data at any time in your space.",
-    "item2": "<b>Rectification</b>: edit profile and data in the dedicated pages.",
-    "item3": "<b>Erasure</b>: \"Delete my account\" button in Settings → Privacy.",
-    "item4": "<b>Portability</b>: \"Download my data\" button — full JSON export.",
-    "item5": "<b>Objection / Restriction</b>: refuse or withdraw non-essential cookies at any time.",
-    "item6": "<b>Complaint</b>: with the <apd>Data Protection Authority</apd> (Belgium)."
-    },
-    "s7": {
-    "heading": "7. Security",
-    "item1": "Encryption in transit (TLS 1.3) and at rest.",
-    "item2": "Supabase Row Level Security on all tables.",
-    "item3": "Rate limiting, strict CSP, append-only audit log.",
-    "item4": "Strong password authentication + MFA available."
-    },
-    "s8": {
-    "heading": "8. Cookies",
-    "body": "See the <link>cookie policy</link>."
-    },
-    "s9": {
-    "heading": "9. Changes",
-    "body": "Any material change to this policy is notified by email and requires your renewed consent to keep using the service."
-    },
-    "draft": "Our privacy policy is being drafted.",
-    "contact": "For any questions, contact us: thierryvm@gmail.com",
-    "backHome": "Back to home"
-  },
-  "cookies": {
-    "metaTitle": "Cookie policy",
-    "metaDescription": "Ankora's cookie policy — full granularity, everything refusable except essentials.",
-    "title": "Cookie policy",
-    "categoriesHeading": "Categories",
-    "essentialHeading": "Essential (always active)",
-    "essentialBody": "Required for the service to work: authentication session, theme preference, anti-CSRF.",
-    "essentialItem1": "<code>sb-*</code> — Supabase session (auth)",
-    "essentialItem2": "<code>ankora-theme</code> — light/dark preference",
-    "analyticsHeading": "Analytics (off by default)",
-    "analyticsBody1": "Only if you give your consent. Aggregated usage measurement, with no personal identifier.",
-    "analyticsBody2": "Ankora does not use Google Analytics. Vercel metrics are aggregated and anonymised.",
-    "marketingHeading": "Marketing (off by default)",
-    "marketingBody": "Ankora currently uses no marketing cookies.",
-    "manageHeading": "Manage your preferences",
-    "manageBody1": "You can change your consents at any time in <b>Settings → Privacy</b> or by clicking \"Manage cookies\" in the footer.",
-    "manageBody2": "Declining non-essential cookies does not degrade the experience: Ankora remains fully functional.",
-    "lifetimeHeading": "Lifetime",
-    "lifetimeItem1": "Session: end of browsing",
-    "lifetimeItem2": "Preferences: 12 months",
-    "lifetimeItem3": "Analytics: 6 months (if accepted)",
-    "draft": "This cookie policy page is being drafted.",
-    "contact": "For any questions, contact us: thierryvm@gmail.com",
-    "backHome": "Back to home"
-  }
-  },
-  "offline": {
-  "metaTitle": "Offline",
-  "metaDescription": "You are currently offline. Reconnect to access Ankora.",
-  "title": "You are offline",
-  "message": "Reconnect to access your cockpit. Your data stays intact.",
-  "retry": "Retry"
-  },
-  "consent": {
-  "title": "Cookies and privacy",
-  "body": "We only use essential cookies to log you in. Analytics cookies are off by default — you can turn them on if you want to help us improve Ankora. You can change your mind at any time via <link>the cookie policy</link>.",
-  "essentialOnly": "Essential only",
-  "acceptAnalytics": "Accept analytics"
-  },
-  "footer": {
-  "copyright": "© {year} — All rights reserved",
-  "cgu": "Terms",
-  "privacy": "Privacy",
-  "cookies": "Manage cookies",
-  "faq": "FAQ",
-  "copyrightNotice": "© {year} Ankora™. All rights reserved."
-  },
-  "auth": {
-  "login": {
-    "title": "Log in",
-    "subtitle": "Get back to your Ankora cockpit.",
-    "metaTitle": "Log in",
-    "emailLabel": "Email",
-    "passwordLabel": "Password",
-    "forgotLink": "Forgot your password?",
-    "submit": "Log in",
-    "submitting": "Logging in…",
-    "noAccount": "No account yet?",
-    "signupLink": "Sign up",
-    "dividerOr": "or",
-    "dividerOrEmail": "or with your email",
-    "passwordUpdatedBanner": "Password updated. You can log in."
-  },
-  "signup": {
-    "title": "Sign up",
-    "subtitle": "Launch your financial cockpit in under 2 minutes.",
-    "pageTitle": "Create my cockpit",
-    "pageDescription": "A few seconds. No credit card.",
-    "emailLabel": "Email",
-    "passwordLabel": "Password",
-    "passwordHint": "At least 12 characters, 1 uppercase, 1 lowercase, 1 digit.",
-    "passwordConfirmLabel": "Confirm password",
-    "acceptTosPrefix": "I accept the",
-    "acceptTosLink": "Terms",
-    "acceptPrivacyPrefix": "I accept the",
-    "acceptPrivacyLink": "privacy policy",
-    "submit": "Create my account",
-    "submitting": "Creating…",
-    "haveAccount": "Already have an account?",
-    "loginLink": "Log in",
-    "dividerOr": "or",
-    "dividerOrEmail": "or with your email",
-    "googleCta": "Sign up with Google",
-    "googleTerms": "By continuing with Google, you accept our <cgu>Terms</cgu> and <privacy>privacy policy</privacy>."
-  },
-  "forgot": {
-    "title": "Forgot password",
-    "subtitle": "Enter your email, we'll send you a secure link.",
-    "emailLabel": "Email",
-    "submit": "Send the link",
-    "submitting": "Sending…",
-    "sentMessage": "If this email exists, a reset link has just been sent.",
-    "backToLogin": "Back to login"
-  },
-  "reset": {
-    "title": "New password",
-    "subtitle": "Choose a strong password for your account.",
-    "passwordLabel": "New password",
-    "passwordConfirmLabel": "Confirm",
-    "submit": "Update",
-    "submitting": "Updating…"
-  },
-  "google": {
-    "label": "Continue with Google",
-    "redirecting": "Redirecting…"
-  },
-  "checkEmail": {
-    "title": "Check your inbox",
-    "metaTitle": "Check your email",
-    "body": "We've just sent you a confirmation link. Click it to activate your account.",
-    "backToLogin": "Back to login"
-  }
-  },
-  "onboarding": {
-  "defaultWorkspaceName": "My space",
-  "previous": "Back",
-  "next": "Continue",
-  "finish": "Finish",
-  "finishing": "Saving…",
-  "validation": {
-    "workspaceNameRequired": "Give your space a name.",
-    "incomeInvalid": "Enter a valid income (≥ 0)."
-  },
-  "step1": {
-    "title": "Name your space",
-    "description": "You can change it later in settings.",
-    "nameLabel": "Space name"
-  },
-  "step2": {
-    "title": "Your net monthly income",
-    "description": "Used as the basis for suggesting your monthly transfers.",
-    "incomeLabel": "Net monthly income (€)"
-  },
-  "step3": {
-    "title": "Your first bill (optional)",
-    "description": "Add rent, insurance, a subscription…",
-    "labelLabel": "Label",
-    "labelPlaceholder": "Rent, car insurance…",
-    "amountLabel": "Amount (€)",
-    "frequencyLabel": "Frequency",
-    "dueMonthLabel": "Reference month",
-    "skipLater": "I'll enter my bills later"
-  }
-  },
-  "app": {
-  "dashboard": {
-    "metaTitle": "Dashboard",
-    "headerTitle": "{month} — your cockpit",
-    "emptyTitle": "Start by adding your bills",
-    "emptyDescription": "Rent, insurance, subscriptions — Ankora smooths them over 12 months for you.",
-    "emptyCta": "Add a bill",
-    "kpiProvisionsMonthly": "Reserves / month",
-    "kpiProvisionsAnnualHint": "Annual: {amount}",
-    "kpiHealth": "Reserve health",
-    "kpiHealthTargetHint": "Target: {amount}",
-    "kpiSuggestedTransfer": "Suggested transfer",
-    "kpiSuggestedTransferToSavings": "To set aside",
-    "kpiSuggestedTransferFromSavings": "To withdraw from savings",
-    "kpiBillsMonth": "{month} bills",
-    "kpiBillsHint": "Cash out this month",
-    "healthHealthy": "Healthy",
-    "healthWarning": "Watch",
-    "healthCritical": "Critical",
-    "planTitle": "Month plan — {month}",
-    "planDescription": "The transfers to run at the start of the month across your three accounts.",
-    "planAdjustAccounts": "Adjust my accounts",
-    "missingSetupTitle": "Set up your accounts first",
-    "missingSetupDescription": "To calculate your Smart Transfer, Ankora needs your monthly income and the fixed amount you send to Daily Spending.",
-    "missingSetupCta": "Set up my accounts",
-    "transferPrincipalToVieCourante": "Main → Daily Spending",
-    "transferVieCouranteHint": "Envelope for groceries, fuel, dining.",
-    "transferPrincipalToEpargne": "Main → Savings",
-    "transferEpargneToPrincipal": "Savings → Main",
-    "transferEpargneHint": "Reserve {provision} − bills {bills}",
-    "transferPrincipalRemaining": "Main remaining",
-    "transferPrincipalRemainingHint": "After salary, transfers and Main bills ({bills}).",
-    "ctaCharges": "My bills",
-    "ctaExpenses": "My expenses",
-    "ctaSimulator": "Simulate",
-    "expensesTitle": "Expenses — {month}",
-    "expensesCount": "{count, plural, =0 {No expenses this month} one {1 expense this month} other {# expenses this month}}",
-    "expensesEmpty": "No expenses recorded for this month.",
-    "expensesViewAll": "View all expenses →"
-  },
-  "charges": {
-    "title": "My bills",
-    "subtitle": "Every bill is automatically smoothed over 12 months.",
-    "addFormTitle": "Add a bill",
-    "emptyState": "No bills yet.",
-    "labelLabel": "Label",
-    "amountLabel": "Amount (€)",
-    "frequencyLabel": "Frequency",
-    "dueMonthLabel": "Reference month",
-    "addButton": "Add",
-    "adding": "Adding…",
-    "count": "{count, plural, =0 {no bills} one {1 bill} other {# bills}}",
-    "referenceFormat": "{frequency} · ref. {month}",
-    "deleteAria": "Delete {label}",
-    "toastCreated": "Bill added",
-    "toastDeleted": "Bill deleted"
-  },
-  "accounts": {
-    "metaTitle": "My accounts",
-    "metaDescription": "Track the balances of your Main, Daily Spending and Savings accounts. Set your monthly income and your transfer to Daily Spending.",
-    "title": "My accounts",
-    "subtitle": "Enter your real balances so Ankora can accurately calculate your smart transfer each month.",
-    "balancesHeading": "Current balances",
-    "amountLabel": "Amount (€)",
-    "saveButton": "Save",
-    "saving": "Saving…",
-    "income": {
-    "title": "Net monthly income",
-    "description": "The salary that lands every month in your Main account. Used to calculate what's left after bills and the transfer to Daily Spending.",
-    "placeholder": "e.g. 2500",
-    "toastSaved": "Monthly income updated"
-    },
-    "transfer": {
-    "title": "Monthly transfer to Daily Spending",
-    "description": "Fixed amount transferred every month from Main to your Daily Spending account. This is what covers groceries, fuel and dining.",
-    "placeholder": "e.g. 500",
-    "toastSaved": "Monthly transfer updated"
-    },
-    "balance": {
-    "invalidAmount": "Enter a valid amount.",
-    "saveLabel": "Update",
-    "srLabel": "Current balance of {label}",
-    "toastSaved": "{name} updated"
-    },
-    "kind": {
-    "principal": {
-      "description": "Receives the salary, pays fixed monthly bills."
-    },
-    "vieCourante": {
-      "description": "Day-to-day budget (groceries, fuel, dining)."
-    },
-    "epargne": {
-      "description": "Smooths quarterly and annual bills."
-    }
-    }
-  },
-  "expenses": {
-    "title": "My expenses",
-    "subtitle": "Spending outside recurring bills — groceries, dining, leisure…",
-    "addFormTitle": "Add an expense",
-    "labelLabel": "Label",
-    "amountLabel": "Amount (€)",
-    "dateLabel": "Date",
-    "addButton": "Add",
-    "adding": "Adding…",
-    "emptyState": "No expenses recorded.",
-    "summary": "{count, plural, =0 {No expenses} one {1 expense · {total}} other {# expenses · {total}}}",
-    "deleteAria": "Delete {label}",
-    "toastCreated": "Expense added",
-    "toastDeleted": "Expense deleted"
-  },
-  "settings": {
-    "metaTitle": "Settings",
-    "metaDescription": "Manage your profile, 2FA security and personal data.",
-    "title": "Settings",
-    "description": "Profile, security and personal data.",
-    "profile": {
-    "title": "Profile",
-    "description": "This information personalizes your cockpit.",
-    "emailLabel": "Email",
-    "displayNameLabel": "Display name",
-    "localeLabel": "Language",
-    "localeOptions": {
-      "fr-BE": "Français (Belgique)",
-      "fr-FR": "Français (France)",
-      "en-GB": "English"
-    },
-    "submit": "Save",
-    "submitting": "Saving…",
-    "toastSaved": "Profile updated"
-    },
-    "mfa": {
-    "title": "Security — 2FA",
-    "description": "A one-time code generated by an authenticator app (Authy, 1Password, Google Authenticator).",
-    "emptyState": "No active 2FA factor. Turn it on to protect your account.",
-    "enrollButton": "Enable 2FA",
-    "enrolling": "Preparing…",
-    "scanInstruction": "Scan this QR code in your authenticator app, then enter the 6-digit code.",
-    "qrAlt": "QR code for the authenticator app",
-    "manualEntry": "Manual entry",
-    "codeLabel": "6-digit code",
-    "verifyButton": "Verify and enable",
-    "verifying": "Verifying…",
-    "cancel": "Cancel",
-    "defaultFactorName": "TOTP app",
-    "activeLabel": "Active",
-    "disableButton": "Disable",
-    "toastEnabled": "MFA enabled",
-    "toastDisabled": "MFA disabled"
-    },
-    "data": {
-    "title": "My data",
-    "description": "GDPR portability (art. 20) — download a full JSON of everything Ankora holds about you.",
-    "exportButton": "Download my data",
-    "exporting": "Generating…",
-    "toastDownloaded": "Export downloaded"
-    },
-    "danger": {
-    "scheduledTitle": "Deletion in progress",
-    "scheduledBody": "Your account will be deleted on <strong>{date}</strong>. You can cancel any time until then.",
-    "viewStatus": "View status",
-    "title": "Danger zone",
-    "description": "Permanent account deletion. 30-day grace period to cancel — after that, everything is wiped (audit logs pseudonymised).",
-    "reasonLabel": "Reason (optional)",
-    "reasonPlaceholder": "Help us improve…",
-    "confirmLabel": "To confirm, type your email address: <code>{email}</code>",
-    "submit": "Delete my account",
-    "submitting": "Scheduling…",
-    "toastScheduled": "Deletion scheduled — you have 30 days to cancel"
-    }
-  },
-  "simulator": {
-    "title": "Simulator",
-    "subtitle": "Measure the impact of a change without touching your real data.",
-    "scenario": {
-    "title": "Scenario",
-    "description": "Choose an action to simulate.",
-    "modes": {
-      "cancel": "Cancel a bill",
-      "negotiate": "Renegotiate",
-      "add": "Add a bill"
-    }
-    },
-    "fields": {
-    "charge": "Bill",
-    "chargePlaceholder": "Select…",
-    "newAmount": "New amount (€)",
-    "label": "Label",
-    "amount": "Amount (€)",
-    "frequency": "Frequency",
-    "month": "Month"
-    },
-    "impact": {
-    "title": "Impact",
-    "empty": "Complete the scenario to see the impact.",
-    "currentMonthly": "Current / month",
-    "projectedMonthly": "Projected / month",
-    "annualSavings": "Annual savings",
-    "monthlyChange": "{sign}{percent}% / month"
-    }
-  },
-  "deletionStatus": {
-    "title": "Account deletion",
-    "subtitle": "Detailed status of your request and cancellation period.",
-    "metaTitle": "Deletion status",
-    "metaDescription": "Status of your Ankora account deletion request.",
-    "statusLabel": "Status:",
-    "requestedOn": "Requested on {date}.",
-    "statusPending": "Pending",
-    "statusCancelled": "Cancelled",
-    "statusCompleted": "Completed",
-    "scheduledFor": "Deletion scheduled",
-    "daysLeft": "Days left",
-    "auditLogs": "Audit logs",
-    "auditLogsValue": "Pseudonymised, never deleted",
-    "daysCount": "{days, plural, =0 {Today} one {# day} other {# days}}",
-    "backToSettings": "Back to settings",
-    "cancelledOn": "Request cancelled on {date}. Your account is preserved.",
-    "cancelledNoDate": "Request cancelled. Your account is preserved.",
-    "cancelButton": "Cancel deletion",
-    "cancelling": "Cancelling…",
-    "toastCancelled": "Request cancelled — your account is preserved"
-  }
-  },
-  "glossary": {
-  "title": "Glossary",
-  "subtitle": "15 essential terms for understanding your budgeting and personal finances.",
-  "metaTitle": "Glossary — Financial Terms",
-  "metaDescription": "Glossary of 15 essential budgeting terms: smoothed budget, bucket account, emergency fund, and more.",
-  "breadcrumb": {
-    "home": "Home",
-    "glossary": "Glossary"
-  },
-  "section": {
-    "whyItMatters": "Why It Matters",
-    "example": "Concrete Example",
-    "relatedTerms": "Related Terms"
-  }
-  },
-  "errors": {
-  "generic": "Something went wrong. Try again.",
-  "session": {
-    "expired": "Session expired. Log in again.",
-    "rateLimited": "Too many requests. Wait a minute."
-  },
-  "auth": {
-    "invalidCredentials": "Incorrect email or password.",
-    "signupFailed": "Sign-up failed. Try again later.",
-    "googleFailed": "Google login unavailable. Try again later.",
-    "rateLimited": "Too many attempts. Try again in a few minutes.",
-    "serviceTemporarilyUnavailable": "Service temporarily unavailable. Try again in a few minutes.",
-    "passwordResetFailed": "Unable to update the password.",
-    "linkExpired": "Link expired. Request a new link.",
-    "mfaEnrollFailed": "Unable to start enrolment.",
-    "mfaChallengeFailed": "MFA challenge failed.",
-    "mfaCodeInvalid": "Incorrect code. Try again.",
-    "mfaDisableFailed": "Unable to disable 2FA."
-  },
-  "db": {
-    "workspaceNotFound": "No editable workspace.",
-    "updateFailed": "Update failed.",
-    "notEditable": "You don't have edit rights on this space."
-  },
-  "validation": {
-    "generic": "Invalid data.",
-    "auth": {
-    "email": {
-      "invalid": "Invalid email address."
-    },
-    "password": {
-      "required": "Password required.",
-      "tooShort": "At least 12 characters.",
-      "tooLong": "Maximum 128 characters.",
-      "lowercase": "At least one lowercase letter.",
-      "uppercase": "At least one uppercase letter.",
-      "digit": "At least one digit."
-    },
-    "passwordConfirm": {
-      "mismatch": "Passwords do not match."
-    },
-    "acceptTos": {
-      "required": "You must accept the Terms."
-    },
-    "acceptPrivacy": {
-      "required": "You must accept the privacy policy."
-    }
-    },
-    "charge": {
-    "label": {
-      "required": "Label required.",
-      "tooLong": "Maximum 120 characters."
-    },
-    "amount": {
-      "invalid": "Invalid amount.",
-      "negative": "Amount must be ≥ 0.",
-      "tooHigh": "Amount too high."
+    "monthsShort": {
+      "1": "Jan",
+      "2": "Feb",
+      "3": "Mar",
+      "4": "Apr",
+      "5": "May",
+      "6": "Jun",
+      "7": "Jul",
+      "8": "Aug",
+      "9": "Sep",
+      "10": "Oct",
+      "11": "Nov",
+      "12": "Dec"
     },
     "frequency": {
-      "invalid": "Invalid frequency."
-    },
-    "dueMonth": {
-      "range": "Month between 1 and 12."
-    },
-    "paidFrom": {
-      "invalid": "Invalid debit account."
+      "monthly": "Monthly",
+      "quarterly": "Quarterly",
+      "semiannual": "Semi-annual",
+      "annual": "Annual"
     }
+  },
+  "ui": {
+    "scrollToTop": "Scroll back to top",
+    "localeSwitcher": {
+      "label": "Language",
+      "aria": "Change language",
+      "options": {
+        "fr-BE": "Français (BE)",
+        "nl-BE": "Nederlands (BE)",
+        "en": "English",
+        "es-ES": "Español",
+        "de-DE": "Deutsch"
+      }
     },
-    "account": {
-    "kind": {
-      "invalid": "Invalid account type."
-    },
-    "balance": {
-      "invalid": "Invalid balance.",
-      "outOfRange": "Value out of range."
-    },
-    "label": {
-      "required": "Label required.",
-      "tooLong": "Maximum 80 characters."
+    "action": {
+      "submit": "Confirm",
+      "submitting": "Confirming…",
+      "save": "Save",
+      "saving": "Saving…",
+      "cancel": "Cancel",
+      "cancelling": "Cancelling…",
+      "delete": "Delete",
+      "deleting": "Deleting…",
+      "create": "Create",
+      "creating": "Creating…",
+      "update": "Update",
+      "updating": "Updating…",
+      "send": "Send",
+      "sending": "Sending…",
+      "verify": "Verify",
+      "verifying": "Verifying…",
+      "generate": "Generate",
+      "generating": "Generating…",
+      "download": "Download",
+      "downloading": "Downloading…",
+      "preparing": "Preparing…",
+      "confirm": "Confirm",
+      "close": "Close"
     }
+  },
+  "landing": {
+    "mktnav": {
+      "links": {
+        "product": "Product",
+        "simulator": "Simulator",
+        "pricing": "Pricing",
+        "security": "Security",
+        "journal": "Journal"
+      },
+      "ctaLogin": "Log in",
+      "ctaSignup": "Try for free"
     },
-    "workspace": {
-    "name": {
-      "required": "Name required.",
-      "tooLong": "Maximum 80 characters."
+    "hero": {
+      "badge": "New · What-if simulator",
+      "h1Lead": "Your financial",
+      "h1Highlight": "anchor.",
+      "description": "Ankora separates your earmarked provisions from your free reserve, projects six months ahead, and lets you simulate the impact of every decision — clearly, without jargon.",
+      "ctaPrimary": "Open my cockpit",
+      "ctaSecondary": "See the simulator",
+      "trust": {
+        "encrypted": "Data encrypted in Belgium",
+        "noSale": "No data selling",
+        "languages": "FR · NL · EN"
+      },
+      "mockup": {
+        "eyebrow": "Cockpit preview",
+        "browserUrl": "Ankora · cockpit",
+        "kpis": {
+          "netRemaining": {
+            "label": "Net remaining",
+            "sub": "April · after provisions"
+          },
+          "provisions": {
+            "label": "Provisions",
+            "sub": "67% of €2,480 planned"
+          },
+          "reserve": {
+            "label": "Reserve",
+            "sub": "+€120 vs. March"
+          }
+        }
+      },
+      "waterfall": {
+        "income": "Income",
+        "incomeAmount": "+2,466 €",
+        "expenses": "Daily expenses",
+        "expensesAmount": "−1,959 €",
+        "provisionsCaption": "of which {amount} € smoothed into earmarked provisions",
+        "available": "Available money",
+        "availableAmount": "+507 €",
+        "ariaLabel": "Illustrative cascade: 2,466 € income, 1,959 € daily expenses (of which 59 € smoothed into provisions), 507 € available."
+      }
     },
-    "income": {
-      "invalid": "Invalid income.",
-      "negative": "Must be ≥ 0.",
-      "tooHigh": "Income too high."
+    "principles": {
+      "eyebrow": "Three principles",
+      "h2": "An honest way to talk about money.",
+      "description": "Ankora isn't trying to sell you an investment or a card. We separate, we project, we simulate. That's it. You alone decide.",
+      "items": {
+        "provisions": {
+          "title": "Earmarked provisions",
+          "description": "Every reserved euro has a name: insurance, road tax, boiler maintenance. Nothing slips away without you knowing."
+        },
+        "reserve": {
+          "title": "Free reserve",
+          "description": "What's actually yours, after commitments. The real number — not the illusion of a gross balance."
+        },
+        "whatIf": {
+          "title": "What-if simulator",
+          "description": "Renegotiate electricity? Switch provider? Ankora shows you the impact over 12 months before you decide."
+        }
+      }
     },
-    "transfer": {
-      "invalid": "Invalid amount.",
-      "negative": "Must be ≥ 0.",
-      "tooHigh": "Amount too high."
+    "feature": {
+      "eyebrow": "Cashflow waterfall",
+      "h3Line1": "From salary to net available.",
+      "h3Line2": "At a single glance.",
+      "description": "No more mystery about where your money goes. Every step is visible: income, daily expenses, available money. You see immediately if anything drifts.",
+      "ctaPrimary": "See an example",
+      "ctaSecondary": "How does it work?"
+    },
+    "whatif": {
+      "title": "What if you changed one thing?",
+      "subtitle": "Move the slider. See the impact on your free reserve, over six months. That's what Ankora does for every financial decision.",
+      "badge": "Demo · no account needed",
+      "scenarios": {
+        "gsm": {
+          "label": "Renegotiate my mobile plan",
+          "hint": "Current plan: €42/month · market: €18–28/month"
+        },
+        "elec": {
+          "label": "Switch electricity provider",
+          "hint": "Current bill: €168/month · 3 cheaper offers in your area"
+        },
+        "stream": {
+          "label": "Cut two streaming subscriptions",
+          "hint": "5 active subscriptions · actual use: 2 over 30 days"
+        }
+      },
+      "controls": {
+        "scenario": "Scenario",
+        "savings": "Monthly savings",
+        "slider_aria": "Monthly savings for {label}"
+      },
+      "annual": {
+        "eyebrow": "Over 12 months",
+        "fleche": "Ankora could route {amount} €/month towards your long-term savings."
+      },
+      "chart": {
+        "title": "Free reserve · projection",
+        "subtitle": "6 months from today",
+        "legend": {
+          "baseline": "Without change",
+          "scenario": "With your choice"
+        },
+        "aria": "6-month projection chart of free reserve, with and without the chosen change",
+        "months": {
+          "may": "May",
+          "jun": "Jun",
+          "jul": "Jul",
+          "aug": "Aug",
+          "sep": "Sep",
+          "oct": "Oct"
+        },
+        "thresholds": {
+          "danger": "⚠️ Estimated overdraft",
+          "fragile": "Fragile zone",
+          "comfortable": "Comfortable zone"
+        }
+      },
+      "caveat": "Demo based on average assumptions. Ankora does not provide investment advice. No bank import — you enter your expenses manually."
+    },
+    "pricing": {
+      "eyebrow": "Transparent from the start",
+      "h2": "Free during Phase 1.",
+      "phaseBadge": "Phase 1 · building",
+      "price": "€0",
+      "period": "for now, with no end date",
+      "body": "We're building the cockpit first. No card asked, no time limit, no feature gating. GDPR export anytime.",
+      "features": {
+        "cockpit": "Full cockpit, provisions and free reserve",
+        "simulator": "Unlimited what-if simulator",
+        "manualEntry": "Manual entry · your data stays in Belgium",
+        "export": "GDPR export in one click"
+      },
+      "ctaPrimary": "Open my cockpit",
+      "roadmap": {
+        "title": "Joining Ankora during Phase 1?",
+        "body": "Your account keeps full lifetime access to the core cockpit, free. A Pro tier with advanced features (unlimited accounts, consolidated exports, priority support) will arrive post-v1.0 — you'll choose to upgrade or stay on your current plan.",
+        "link": "Read the roadmap →"
+      }
+    },
+    "footerCta": {
+      "h2Lead": "Start with what's",
+      "h2Highlight": "already yours.",
+      "description": "30-day trial, no card, GDPR export anytime. We keep it simple because it's already complicated enough.",
+      "ctaPrimary": "Open my cockpit"
+    },
+    "footer": {
+      "links": {
+        "terms": "Terms",
+        "privacy": "Privacy",
+        "security": "Security",
+        "contact": "Contact"
+      },
+      "copyright": "Ankora · Brussels-anchored editor · 2026"
+    },
+    "faqHeading": "Frequently asked questions",
+    "faq": {
+      "advice": {
+        "q": "Is Ankora a financial advice tool?",
+        "a": "No. Ankora is a budgeting and financial education tool. It does not provide investment recommendations or personalised financial advice."
+      },
+      "storage": {
+        "q": "Where is my data stored?",
+        "a": "Your data is hosted in the European Union (Supabase, EU region) with encryption at rest and strict per-user isolation via Row Level Security."
+      },
+      "sharing": {
+        "q": "Can I share my data?",
+        "a": "By default, your space is 100% private. Optional shared pockets (trips, joint projects) are coming in a future release — you'll explicitly choose what you share, and with whom."
+      }
     }
-    },
-    "expense": {
-    "label": {
-      "required": "Label required.",
-      "tooLong": "Maximum 120 characters."
-    },
-    "amount": {
-      "invalid": "Invalid amount.",
-      "negative": "Must be ≥ 0.",
-      "tooHigh": "Amount too high."
-    },
-    "date": {
-      "format": "Expected format: YYYY-MM-DD."
-    },
-    "category": {
-      "invalid": "Invalid category."
+  },
+  "faq": {
+    "metaTitle": "FAQ",
+    "metaDescription": "Frequently asked questions about Ankora: security, data, how it works, privacy.",
+    "title": "Frequently asked questions",
+    "subtitle": "Everything you need to know about Ankora before getting started.",
+    "items": {
+      "bankConnection": {
+        "q": "Does Ankora connect to my bank?",
+        "a": "No. Ankora does not use the PSD2 directive. You enter your bills and expenses manually. This choice guarantees you remain the owner of your data and that no sensitive banking information is stored."
+      },
+      "dataLocation": {
+        "q": "Where is my data hosted?",
+        "a": "All your data is hosted in the European Union (Supabase EU region, Vercel EU region, Upstash EU). No data is transferred outside the EU."
+      },
+      "smoothing": {
+        "q": "How does smoothing work?",
+        "a": "Ankora takes your quarterly, semi-annual and annual bills and spreads them across 12 months. You know exactly how much to set aside each month to cover all your future bills, stress-free."
+      },
+      "deletion": {
+        "q": "Can I delete my account?",
+        "a": "Yes, at any time from Settings → Privacy. Deletion takes effect 30 days after your request (you can cancel during this period). All your financial data is wiped, security logs are pseudonymised."
+      },
+      "export": {
+        "q": "Can I export my data?",
+        "a": "Yes. The \"Download my data\" button in Settings gives you a complete JSON file of everything Ankora holds about you. Compliant with the GDPR right to portability (art. 20)."
+      },
+      "advice": {
+        "q": "Does Ankora provide financial advice?",
+        "a": "No. Ankora is a budgeting education and organisation tool. We do not issue any investment advice (FSMA Belgium regulatory constraint). For any investment decision, consult an authorised professional."
+      },
+      "ai": {
+        "q": "Is there any artificial intelligence?",
+        "a": "In Phase 1, no. Calculations are deterministic and auditable. In Phase 2, an optional BYOK (Bring Your Own Key) layer will let you connect your own Anthropic or OpenRouter key for suggestions — no extra cost on Ankora's side."
+      },
+      "sharing": {
+        "q": "Can I share my space with my children or friends?",
+        "a": "In Phase 1, each user has a private space, isolated by default. In Phase 2, we'll add the ability to create \"shared pockets\" (by invitation, with viewer/editor roles) without ever mixing your personal data."
+      }
     }
+  },
+  "legal": {
+    "versionLine": "Version {version} — last updated: {date}",
+    "lastUpdatedLine": "Last updated: {date}",
+    "cgu": {
+      "metaTitle": "Terms of service",
+      "metaDescription": "Ankora's terms of service — rules for using the service.",
+      "title": "Terms of service",
+      "s1": {
+        "heading": "1. Purpose",
+        "body": "Ankora is a budgeting and financial education tool for individuals. It lets you manually enter your bills and expenses, smooth them across the year, and anticipate cash-flow needs."
+      },
+      "s2": {
+        "heading": "2. What Ankora is NOT",
+        "item1": "Ankora is <b>not an investment advisory service</b>.",
+        "item2": "Ankora is <b>not a banking service</b> and holds no funds.",
+        "item3": "Ankora is <b>not a PSD2 aggregator</b> — no connection to your bank accounts.",
+        "item4": "Ankora is <b>not professional accounting software</b>.",
+        "outro": "The information displayed consists of estimates based on your inputs. It does not constitute personalised financial advice. For any important decision, consult an authorised professional."
+      },
+      "s3": {
+        "heading": "3. Account",
+        "item1": "You must be of legal age or have authorisation from a legal representative.",
+        "item2": "One account per individual.",
+        "item3": "Password: minimum 12 characters, mixed case.",
+        "item4": "You are responsible for keeping your credentials confidential."
+      },
+      "s4": {
+        "heading": "4. Acceptable use",
+        "intro": "You agree not to:",
+        "item1": "use the service for illegal purposes,",
+        "item2": "attempt to circumvent security measures,",
+        "item3": "automate access without explicit authorisation,",
+        "item4": "share your account with a third party."
+      },
+      "s5": {
+        "heading": "5. Intellectual property",
+        "body": "You remain the owner of your data. Ankora retains ownership of its code, brand, design and documentation."
+      },
+      "s6": {
+        "heading": "6. Liability",
+        "body": "Ankora is provided \"as is\". The publisher cannot be held liable for financial decisions made on the basis of the information displayed. No 100% availability is guaranteed."
+      },
+      "s7": {
+        "heading": "7. Termination",
+        "body": "You can delete your account at any time from Settings → Privacy. Deletion takes effect 30 days after the request (cancellable during that period)."
+      },
+      "s8": {
+        "heading": "8. Governing law",
+        "body": "These terms are governed by Belgian law. Competent court: Brussels."
+      },
+      "draft": "Our terms of service are being drafted.",
+      "contact": "For any questions, contact us: thierryvm@gmail.com",
+      "backHome": "Back to home"
+    },
+    "privacy": {
+      "metaTitle": "Privacy policy",
+      "metaDescription": "Ankora's privacy policy — EU hosting, GDPR, user rights.",
+      "title": "Privacy policy",
+      "s1": {
+        "heading": "1. Data controller",
+        "body": "Ankora, published by Thierry Van Mele (Belgium). Contact: <mail>thierryvm@gmail.com</mail>."
+      },
+      "s2": {
+        "heading": "2. Data collected",
+        "intro": "Ankora collects only the data strictly necessary to provide the service:",
+        "item1": "<b>Identity</b>: email address, display name (optional).",
+        "item2": "<b>Financial data you enter</b>: bills, expenses, categories, declared income, savings balance.",
+        "item3": "<b>Technical data</b>: IP address, user-agent (for security logs only).",
+        "item4": "<b>Consents</b>: timestamp, version, scope (terms, privacy, cookies).",
+        "outro": "Ankora does not connect to any bank (no PSD2 aggregation). You enter your bills and expenses yourself."
+      },
+      "s3": {
+        "heading": "3. Legal bases (GDPR art. 6)",
+        "item1": "<b>Contract</b>: providing the service (account, financial data).",
+        "item2": "<b>Consent</b>: analytics/marketing cookies, newsletter.",
+        "item3": "<b>Legal obligation</b>: security logs (12-month retention).",
+        "item4": "<b>Legitimate interest</b>: fraud prevention, security maintenance."
+      },
+      "s4": {
+        "heading": "4. Hosting and subprocessors",
+        "item1": "<b>Supabase</b> (database, auth) — EU region (Frankfurt or Paris).",
+        "item2": "<b>Vercel</b> (frontend hosting) — EU region (Dublin).",
+        "item3": "<b>Upstash</b> (rate limiting) — EU region.",
+        "outro": "No data is transferred outside the EU/EEA."
+      },
+      "s5": {
+        "heading": "5. Retention period",
+        "item1": "Active account: for as long as you use the service.",
+        "item2": "Deleted account: deletion takes effect 30 days after your request (cancellable grace period).",
+        "item3": "Security logs: 12 months maximum, pseudonymised after account deletion."
+      },
+      "s6": {
+        "heading": "6. Your rights (GDPR art. 15-22)",
+        "item1": "<b>Access</b>: view your data at any time in your space.",
+        "item2": "<b>Rectification</b>: edit profile and data in the dedicated pages.",
+        "item3": "<b>Erasure</b>: \"Delete my account\" button in Settings → Privacy.",
+        "item4": "<b>Portability</b>: \"Download my data\" button — full JSON export.",
+        "item5": "<b>Objection / Restriction</b>: refuse or withdraw non-essential cookies at any time.",
+        "item6": "<b>Complaint</b>: with the <apd>Data Protection Authority</apd> (Belgium)."
+      },
+      "s7": {
+        "heading": "7. Security",
+        "item1": "Encryption in transit (TLS 1.3) and at rest.",
+        "item2": "Supabase Row Level Security on all tables.",
+        "item3": "Rate limiting, strict CSP, append-only audit log.",
+        "item4": "Strong password authentication + MFA available."
+      },
+      "s8": {
+        "heading": "8. Cookies",
+        "body": "See the <link>cookie policy</link>."
+      },
+      "s9": {
+        "heading": "9. Changes",
+        "body": "Any material change to this policy is notified by email and requires your renewed consent to keep using the service."
+      },
+      "draft": "Our privacy policy is being drafted.",
+      "contact": "For any questions, contact us: thierryvm@gmail.com",
+      "backHome": "Back to home"
+    },
+    "cookies": {
+      "metaTitle": "Cookie policy",
+      "metaDescription": "Ankora's cookie policy — full granularity, everything refusable except essentials.",
+      "title": "Cookie policy",
+      "categoriesHeading": "Categories",
+      "essentialHeading": "Essential (always active)",
+      "essentialBody": "Required for the service to work: authentication session, theme preference, anti-CSRF.",
+      "essentialItem1": "<code>sb-*</code> — Supabase session (auth)",
+      "essentialItem2": "<code>ankora-theme</code> — light/dark preference",
+      "analyticsHeading": "Analytics (off by default)",
+      "analyticsBody1": "Only if you give your consent. Aggregated usage measurement, with no personal identifier.",
+      "analyticsBody2": "Ankora does not use Google Analytics. Vercel metrics are aggregated and anonymised.",
+      "marketingHeading": "Marketing (off by default)",
+      "marketingBody": "Ankora currently uses no marketing cookies.",
+      "manageHeading": "Manage your preferences",
+      "manageBody1": "You can change your consents at any time in <b>Settings → Privacy</b> or by clicking \"Manage cookies\" in the footer.",
+      "manageBody2": "Declining non-essential cookies does not degrade the experience: Ankora remains fully functional.",
+      "lifetimeHeading": "Lifetime",
+      "lifetimeItem1": "Session: end of browsing",
+      "lifetimeItem2": "Preferences: 12 months",
+      "lifetimeItem3": "Analytics: 6 months (if accepted)",
+      "draft": "This cookie policy page is being drafted.",
+      "contact": "For any questions, contact us: thierryvm@gmail.com",
+      "backHome": "Back to home"
+    }
+  },
+  "offline": {
+    "metaTitle": "Offline",
+    "metaDescription": "You are currently offline. Reconnect to access Ankora.",
+    "title": "You are offline",
+    "message": "Reconnect to access your cockpit. Your data stays intact.",
+    "retry": "Retry"
+  },
+  "consent": {
+    "title": "Cookies and privacy",
+    "body": "We only use essential cookies to log you in. Analytics cookies are off by default — you can turn them on if you want to help us improve Ankora. You can change your mind at any time via <link>the cookie policy</link>.",
+    "essentialOnly": "Essential only",
+    "acceptAnalytics": "Accept analytics"
+  },
+  "footer": {
+    "copyright": "© {year} — All rights reserved",
+    "cgu": "Terms",
+    "privacy": "Privacy",
+    "cookies": "Manage cookies",
+    "faq": "FAQ",
+    "copyrightNotice": "© {year} Ankora™. All rights reserved."
+  },
+  "auth": {
+    "login": {
+      "title": "Log in",
+      "subtitle": "Get back to your Ankora cockpit.",
+      "metaTitle": "Log in",
+      "emailLabel": "Email",
+      "passwordLabel": "Password",
+      "forgotLink": "Forgot your password?",
+      "submit": "Log in",
+      "submitting": "Logging in…",
+      "noAccount": "No account yet?",
+      "signupLink": "Sign up",
+      "dividerOr": "or",
+      "dividerOrEmail": "or with your email",
+      "passwordUpdatedBanner": "Password updated. You can log in."
+    },
+    "signup": {
+      "title": "Sign up",
+      "subtitle": "Launch your financial cockpit in under 2 minutes.",
+      "pageTitle": "Create my cockpit",
+      "pageDescription": "A few seconds. No credit card.",
+      "emailLabel": "Email",
+      "passwordLabel": "Password",
+      "passwordHint": "At least 12 characters, 1 uppercase, 1 lowercase, 1 digit.",
+      "passwordConfirmLabel": "Confirm password",
+      "acceptTosPrefix": "I accept the",
+      "acceptTosLink": "Terms",
+      "acceptPrivacyPrefix": "I accept the",
+      "acceptPrivacyLink": "privacy policy",
+      "submit": "Create my account",
+      "submitting": "Creating…",
+      "haveAccount": "Already have an account?",
+      "loginLink": "Log in",
+      "dividerOr": "or",
+      "dividerOrEmail": "or with your email",
+      "googleCta": "Sign up with Google",
+      "googleTerms": "By continuing with Google, you accept our <cgu>Terms</cgu> and <privacy>privacy policy</privacy>."
+    },
+    "forgot": {
+      "title": "Forgot password",
+      "subtitle": "Enter your email, we'll send you a secure link.",
+      "emailLabel": "Email",
+      "submit": "Send the link",
+      "submitting": "Sending…",
+      "sentMessage": "If this email exists, a reset link has just been sent.",
+      "backToLogin": "Back to login"
+    },
+    "reset": {
+      "title": "New password",
+      "subtitle": "Choose a strong password for your account.",
+      "passwordLabel": "New password",
+      "passwordConfirmLabel": "Confirm",
+      "submit": "Update",
+      "submitting": "Updating…"
+    },
+    "google": {
+      "label": "Continue with Google",
+      "redirecting": "Redirecting…"
+    },
+    "checkEmail": {
+      "title": "Check your inbox",
+      "metaTitle": "Check your email",
+      "body": "We've just sent you a confirmation link. Click it to activate your account.",
+      "backToLogin": "Back to login"
+    }
+  },
+  "onboarding": {
+    "defaultWorkspaceName": "My space",
+    "previous": "Back",
+    "next": "Continue",
+    "finish": "Finish",
+    "finishing": "Saving…",
+    "validation": {
+      "workspaceNameRequired": "Give your space a name.",
+      "incomeInvalid": "Enter a valid income (≥ 0)."
+    },
+    "step1": {
+      "title": "Name your space",
+      "description": "You can change it later in settings.",
+      "nameLabel": "Space name"
+    },
+    "step2": {
+      "title": "Your net monthly income",
+      "description": "Used as the basis for suggesting your monthly transfers.",
+      "incomeLabel": "Net monthly income (€)"
+    },
+    "step3": {
+      "title": "Your first bill (optional)",
+      "description": "Add rent, insurance, a subscription…",
+      "labelLabel": "Label",
+      "labelPlaceholder": "Rent, car insurance…",
+      "amountLabel": "Amount (€)",
+      "frequencyLabel": "Frequency",
+      "dueMonthLabel": "Reference month",
+      "skipLater": "I'll enter my bills later"
+    }
+  },
+  "app": {
+    "dashboard": {
+      "metaTitle": "Dashboard",
+      "headerTitle": "{month} — your cockpit",
+      "emptyTitle": "Start by adding your bills",
+      "emptyDescription": "Rent, insurance, subscriptions — Ankora smooths them over 12 months for you.",
+      "emptyCta": "Add a bill",
+      "kpiProvisionsMonthly": "Reserves / month",
+      "kpiProvisionsAnnualHint": "Annual: {amount}",
+      "kpiHealth": "Reserve health",
+      "kpiHealthTargetHint": "Target: {amount}",
+      "kpiSuggestedTransfer": "Suggested transfer",
+      "kpiSuggestedTransferToSavings": "To set aside",
+      "kpiSuggestedTransferFromSavings": "To withdraw from savings",
+      "kpiBillsMonth": "{month} bills",
+      "kpiBillsHint": "Cash out this month",
+      "healthHealthy": "Healthy",
+      "healthWarning": "Watch",
+      "healthCritical": "Critical",
+      "planTitle": "Month plan — {month}",
+      "planDescription": "The transfers to run at the start of the month across your three accounts.",
+      "planAdjustAccounts": "Adjust my accounts",
+      "missingSetupTitle": "Set up your accounts first",
+      "missingSetupDescription": "To calculate your Smart Transfer, Ankora needs your monthly income and the fixed amount you send to Daily Spending.",
+      "missingSetupCta": "Set up my accounts",
+      "transferPrincipalToVieCourante": "Main → Daily Spending",
+      "transferVieCouranteHint": "Envelope for groceries, fuel, dining.",
+      "transferPrincipalToEpargne": "Main → Savings",
+      "transferEpargneToPrincipal": "Savings → Main",
+      "transferEpargneHint": "Reserve {provision} − bills {bills}",
+      "transferPrincipalRemaining": "Main remaining",
+      "transferPrincipalRemainingHint": "After salary, transfers and Main bills ({bills}).",
+      "ctaCharges": "My bills",
+      "ctaExpenses": "My expenses",
+      "ctaSimulator": "Simulate",
+      "expensesTitle": "Expenses — {month}",
+      "expensesCount": "{count, plural, =0 {No expenses this month} one {1 expense this month} other {# expenses this month}}",
+      "expensesEmpty": "No expenses recorded for this month.",
+      "expensesViewAll": "View all expenses →"
+    },
+    "charges": {
+      "title": "My bills",
+      "subtitle": "Every bill is automatically smoothed over 12 months.",
+      "addFormTitle": "Add a bill",
+      "emptyState": "No bills yet.",
+      "labelLabel": "Label",
+      "amountLabel": "Amount (€)",
+      "frequencyLabel": "Frequency",
+      "dueMonthLabel": "Reference month",
+      "addButton": "Add",
+      "adding": "Adding…",
+      "count": "{count, plural, =0 {no bills} one {1 bill} other {# bills}}",
+      "referenceFormat": "{frequency} · ref. {month}",
+      "deleteAria": "Delete {label}",
+      "toastCreated": "Bill added",
+      "toastDeleted": "Bill deleted"
+    },
+    "accounts": {
+      "metaTitle": "My accounts",
+      "metaDescription": "Track the balances of your Main, Daily Spending and Savings accounts. Set your monthly income and your transfer to Daily Spending.",
+      "title": "My accounts",
+      "subtitle": "Enter your real balances so Ankora can accurately calculate your smart transfer each month.",
+      "balancesHeading": "Current balances",
+      "amountLabel": "Amount (€)",
+      "saveButton": "Save",
+      "saving": "Saving…",
+      "income": {
+        "title": "Net monthly income",
+        "description": "The salary that lands every month in your Main account. Used to calculate what's left after bills and the transfer to Daily Spending.",
+        "placeholder": "e.g. 2500",
+        "toastSaved": "Monthly income updated"
+      },
+      "transfer": {
+        "title": "Monthly transfer to Daily Spending",
+        "description": "Fixed amount transferred every month from Main to your Daily Spending account. This is what covers groceries, fuel and dining.",
+        "placeholder": "e.g. 500",
+        "toastSaved": "Monthly transfer updated"
+      },
+      "balance": {
+        "invalidAmount": "Enter a valid amount.",
+        "saveLabel": "Update",
+        "srLabel": "Current balance of {label}",
+        "toastSaved": "{name} updated"
+      },
+      "kind": {
+        "principal": {
+          "description": "Receives the salary, pays fixed monthly bills."
+        },
+        "vieCourante": {
+          "description": "Day-to-day budget (groceries, fuel, dining)."
+        },
+        "epargne": {
+          "description": "Smooths quarterly and annual bills."
+        }
+      },
+      "types": {
+        "income_bills": "Salary & Bills",
+        "provisions": "Annual Provisions",
+        "daily_card": "Groceries, Gas & Leisure"
+      },
+      "defaults": {
+        "income_bills": "Main Account",
+        "provisions": "Savings Account",
+        "daily_card": "Daily Card"
+      }
+    },
+    "expenses": {
+      "title": "My expenses",
+      "subtitle": "Spending outside recurring bills — groceries, dining, leisure…",
+      "addFormTitle": "Add an expense",
+      "labelLabel": "Label",
+      "amountLabel": "Amount (€)",
+      "dateLabel": "Date",
+      "addButton": "Add",
+      "adding": "Adding…",
+      "emptyState": "No expenses recorded.",
+      "summary": "{count, plural, =0 {No expenses} one {1 expense · {total}} other {# expenses · {total}}}",
+      "deleteAria": "Delete {label}",
+      "toastCreated": "Expense added",
+      "toastDeleted": "Expense deleted"
     },
     "settings": {
-    "displayName": {
-      "required": "Name required.",
-      "tooLong": "Maximum 80 characters."
+      "metaTitle": "Settings",
+      "metaDescription": "Manage your profile, 2FA security and personal data.",
+      "title": "Settings",
+      "description": "Profile, security and personal data.",
+      "profile": {
+        "title": "Profile",
+        "description": "This information personalizes your cockpit.",
+        "emailLabel": "Email",
+        "displayNameLabel": "Display name",
+        "localeLabel": "Language",
+        "localeOptions": {
+          "fr-BE": "Français (Belgique)",
+          "fr-FR": "Français (France)",
+          "en-GB": "English"
+        },
+        "submit": "Save",
+        "submitting": "Saving…",
+        "toastSaved": "Profile updated"
+      },
+      "mfa": {
+        "title": "Security — 2FA",
+        "description": "A one-time code generated by an authenticator app (Authy, 1Password, Google Authenticator).",
+        "emptyState": "No active 2FA factor. Turn it on to protect your account.",
+        "enrollButton": "Enable 2FA",
+        "enrolling": "Preparing…",
+        "scanInstruction": "Scan this QR code in your authenticator app, then enter the 6-digit code.",
+        "qrAlt": "QR code for the authenticator app",
+        "manualEntry": "Manual entry",
+        "codeLabel": "6-digit code",
+        "verifyButton": "Verify and enable",
+        "verifying": "Verifying…",
+        "cancel": "Cancel",
+        "defaultFactorName": "TOTP app",
+        "activeLabel": "Active",
+        "disableButton": "Disable",
+        "toastEnabled": "MFA enabled",
+        "toastDisabled": "MFA disabled"
+      },
+      "data": {
+        "title": "My data",
+        "description": "GDPR portability (art. 20) — download a full JSON of everything Ankora holds about you.",
+        "exportButton": "Download my data",
+        "exporting": "Generating…",
+        "toastDownloaded": "Export downloaded"
+      },
+      "danger": {
+        "scheduledTitle": "Deletion in progress",
+        "scheduledBody": "Your account will be deleted on <strong>{date}</strong>. You can cancel any time until then.",
+        "viewStatus": "View status",
+        "title": "Danger zone",
+        "description": "Permanent account deletion. 30-day grace period to cancel — after that, everything is wiped (audit logs pseudonymised).",
+        "reasonLabel": "Reason (optional)",
+        "reasonPlaceholder": "Help us improve…",
+        "confirmLabel": "To confirm, type your email address: <code>{email}</code>",
+        "submit": "Delete my account",
+        "submitting": "Scheduling…",
+        "toastScheduled": "Deletion scheduled — you have 30 days to cancel"
+      }
+    },
+    "simulator": {
+      "title": "Simulator",
+      "subtitle": "Measure the impact of a change without touching your real data.",
+      "scenario": {
+        "title": "Scenario",
+        "description": "Choose an action to simulate.",
+        "modes": {
+          "cancel": "Cancel a bill",
+          "negotiate": "Renegotiate",
+          "add": "Add a bill"
+        }
+      },
+      "fields": {
+        "charge": "Bill",
+        "chargePlaceholder": "Select…",
+        "newAmount": "New amount (€)",
+        "label": "Label",
+        "amount": "Amount (€)",
+        "frequency": "Frequency",
+        "month": "Month"
+      },
+      "impact": {
+        "title": "Impact",
+        "empty": "Complete the scenario to see the impact.",
+        "currentMonthly": "Current / month",
+        "projectedMonthly": "Projected / month",
+        "annualSavings": "Annual savings",
+        "monthlyChange": "{sign}{percent}% / month"
+      }
+    },
+    "deletionStatus": {
+      "title": "Account deletion",
+      "subtitle": "Detailed status of your request and cancellation period.",
+      "metaTitle": "Deletion status",
+      "metaDescription": "Status of your Ankora account deletion request.",
+      "statusLabel": "Status:",
+      "requestedOn": "Requested on {date}.",
+      "statusPending": "Pending",
+      "statusCancelled": "Cancelled",
+      "statusCompleted": "Completed",
+      "scheduledFor": "Deletion scheduled",
+      "daysLeft": "Days left",
+      "auditLogs": "Audit logs",
+      "auditLogsValue": "Pseudonymised, never deleted",
+      "daysCount": "{days, plural, =0 {Today} one {# day} other {# days}}",
+      "backToSettings": "Back to settings",
+      "cancelledOn": "Request cancelled on {date}. Your account is preserved.",
+      "cancelledNoDate": "Request cancelled. Your account is preserved.",
+      "cancelButton": "Cancel deletion",
+      "cancelling": "Cancelling…",
+      "toastCancelled": "Request cancelled — your account is preserved"
+    },
+    "cockpit": {
+      "capaciteEpargneReelle": {
+        "title": "Real Savings Capacity",
+        "messagePositive": "This is what you truly have left every month, with no surprises.",
+        "messageNegative": "Warning — your overall lifestyle exceeds your income.",
+        "tooltip": "This subtracts every charge (smoothed over the year) and your daily allowance from your monthly income. That is what is actually left for savings or unexpected expenses."
+      },
+      "santeProvisions": {
+        "title": "Provisions Health",
+        "cibleTheorique": "Ideal theoretical target:",
+        "soldeActuel": "Current balance:",
+        "statutAJour": "On track ✨",
+        "deficit": "Deficit detected:",
+        "rattrapageDescription": "Includes +{amount} € to recover the deficit over 3 months.",
+        "tooltip": "The algorithm computes how much your Savings account should hold today to absorb all upcoming periodic charges smoothly."
+      },
+      "virements": {
+        "title": "Transfer Assistant",
+        "provisionsMensuelles": "Monthly provisions:",
+        "facturesAnnuelles": "Periodic bills this month:",
+        "aVirer": "Transfer to Savings:",
+        "aRecuperer": "Pull from Savings:",
+        "aucun": "No transfer needed this month. Provisions exactly cover the periodic bills.",
+        "descriptionAVirer": "Covers your monthly provisions, minus the bills due this month.",
+        "descriptionDepuis": "This month’s periodic bills exceed your provision. Use your savings!",
+        "detailHeader": "Breakdown of the {amount} € provisions:"
+      },
+      "notifications": {
+        "transferToSavings": "Remember to transfer {amount} € to Savings this month.",
+        "transferFromSavings": "You need to pull {amount} € from Savings to cover this month’s bills.",
+        "chargeOverdue": "{label} is overdue (was due on {day}).",
+        "chargeDueSoon": "{label} due in {days} day(s)."
+      }
+    }
+  },
+  "glossary": {
+    "title": "Glossary",
+    "subtitle": "15 essential terms for understanding your budgeting and personal finances.",
+    "metaTitle": "Glossary — Financial Terms",
+    "metaDescription": "Glossary of 15 essential budgeting terms: smoothed budget, bucket account, emergency fund, and more.",
+    "breadcrumb": {
+      "home": "Home",
+      "glossary": "Glossary"
+    },
+    "section": {
+      "whyItMatters": "Why It Matters",
+      "example": "Concrete Example",
+      "relatedTerms": "Related Terms"
+    }
+  },
+  "errors": {
+    "generic": "Something went wrong. Try again.",
+    "session": {
+      "expired": "Session expired. Log in again.",
+      "rateLimited": "Too many requests. Wait a minute."
+    },
+    "auth": {
+      "invalidCredentials": "Incorrect email or password.",
+      "signupFailed": "Sign-up failed. Try again later.",
+      "googleFailed": "Google login unavailable. Try again later.",
+      "rateLimited": "Too many attempts. Try again in a few minutes.",
+      "serviceTemporarilyUnavailable": "Service temporarily unavailable. Try again in a few minutes.",
+      "passwordResetFailed": "Unable to update the password.",
+      "linkExpired": "Link expired. Request a new link.",
+      "mfaEnrollFailed": "Unable to start enrolment.",
+      "mfaChallengeFailed": "MFA challenge failed.",
+      "mfaCodeInvalid": "Incorrect code. Try again.",
+      "mfaDisableFailed": "Unable to disable 2FA."
+    },
+    "db": {
+      "workspaceNotFound": "No editable workspace.",
+      "updateFailed": "Update failed.",
+      "notEditable": "You don't have edit rights on this space."
+    },
+    "validation": {
+      "generic": "Invalid data.",
+      "auth": {
+        "email": {
+          "invalid": "Invalid email address."
+        },
+        "password": {
+          "required": "Password required.",
+          "tooShort": "At least 12 characters.",
+          "tooLong": "Maximum 128 characters.",
+          "lowercase": "At least one lowercase letter.",
+          "uppercase": "At least one uppercase letter.",
+          "digit": "At least one digit."
+        },
+        "passwordConfirm": {
+          "mismatch": "Passwords do not match."
+        },
+        "acceptTos": {
+          "required": "You must accept the Terms."
+        },
+        "acceptPrivacy": {
+          "required": "You must accept the privacy policy."
+        }
+      },
+      "charge": {
+        "label": {
+          "required": "Label required.",
+          "tooLong": "Maximum 120 characters."
+        },
+        "amount": {
+          "invalid": "Invalid amount.",
+          "negative": "Amount must be ≥ 0.",
+          "tooHigh": "Amount too high."
+        },
+        "frequency": {
+          "invalid": "Invalid frequency."
+        },
+        "dueMonth": {
+          "range": "Month between 1 and 12."
+        },
+        "paidFrom": {
+          "invalid": "Invalid debit account."
+        }
+      },
+      "account": {
+        "kind": {
+          "invalid": "Invalid account type."
+        },
+        "balance": {
+          "invalid": "Invalid balance.",
+          "outOfRange": "Value out of range."
+        },
+        "label": {
+          "required": "Label required.",
+          "tooLong": "Maximum 80 characters."
+        }
+      },
+      "workspace": {
+        "name": {
+          "required": "Name required.",
+          "tooLong": "Maximum 80 characters."
+        },
+        "income": {
+          "invalid": "Invalid income.",
+          "negative": "Must be ≥ 0.",
+          "tooHigh": "Income too high."
+        },
+        "transfer": {
+          "invalid": "Invalid amount.",
+          "negative": "Must be ≥ 0.",
+          "tooHigh": "Amount too high."
+        }
+      },
+      "expense": {
+        "label": {
+          "required": "Label required.",
+          "tooLong": "Maximum 120 characters."
+        },
+        "amount": {
+          "invalid": "Invalid amount.",
+          "negative": "Must be ≥ 0.",
+          "tooHigh": "Amount too high."
+        },
+        "date": {
+          "format": "Expected format: YYYY-MM-DD."
+        },
+        "category": {
+          "invalid": "Invalid category."
+        }
+      },
+      "settings": {
+        "displayName": {
+          "required": "Name required.",
+          "tooLong": "Maximum 80 characters."
+        },
+        "locale": {
+          "invalid": "Invalid language."
+        },
+        "factorId": {
+          "invalid": "Invalid identifier."
+        },
+        "mfaCode": {
+          "invalid": "6-digit code."
+        },
+        "deletion": {
+          "confirm": "This address doesn't match your account."
+        }
+      },
+      "onboarding": {
+        "workspace": {
+          "required": "Name required.",
+          "tooLong": "Maximum 80 characters."
+        },
+        "income": {
+          "invalid": "Invalid income.",
+          "negative": "Must be ≥ 0.",
+          "tooHigh": "Income too high."
+        },
+        "firstCharge": {
+          "label": {
+            "required": "Label required.",
+            "tooLong": "Maximum 120 characters."
+          },
+          "amount": {
+            "invalid": "Invalid amount.",
+            "negative": "Must be ≥ 0.",
+            "tooHigh": "Amount too high."
+          },
+          "dueMonth": {
+            "range": "Month between 1 and 12."
+          }
+        }
+      }
+    },
+    "charges": {
+      "createFailed": "Unable to create the bill.",
+      "updateFailed": "Unable to update the bill.",
+      "deleteFailed": "Unable to delete the bill."
+    },
+    "accounts": {
+      "balanceUpdateFailed": "Unable to update the balance.",
+      "renameFailed": "Unable to rename the account.",
+      "incomeUpdateFailed": "Unable to update the income.",
+      "transferUpdateFailed": "Unable to update the transfer."
+    },
+    "expenses": {
+      "createFailed": "Unable to create the expense.",
+      "deleteFailed": "Unable to delete the expense."
+    },
+    "settings": {
+      "profileUpdateFailed": "Unable to update the profile.",
+      "deletionRequestFailed": "Unable to schedule the deletion.",
+      "deletionCancelFailed": "Unable to cancel the request.",
+      "exportLimited": "Export limited to once every 5 minutes."
+    },
+    "onboarding": {
+      "workspaceNotFound": "Workspace not found. Contact support.",
+      "workspaceUpdateFailed": "Unable to update the workspace.",
+      "chargeFailed": "Workspace created but bill not saved."
     },
     "locale": {
       "invalid": "Invalid language."
-    },
-    "factorId": {
-      "invalid": "Invalid identifier."
-    },
-    "mfaCode": {
-      "invalid": "6-digit code."
-    },
-    "deletion": {
-      "confirm": "This address doesn't match your account."
     }
-    },
-    "onboarding": {
-    "workspace": {
-      "required": "Name required.",
-      "tooLong": "Maximum 80 characters."
-    },
-    "income": {
-      "invalid": "Invalid income.",
-      "negative": "Must be ≥ 0.",
-      "tooHigh": "Income too high."
-    },
-    "firstCharge": {
-      "label": {
-      "required": "Label required.",
-      "tooLong": "Maximum 120 characters."
-      },
-      "amount": {
-      "invalid": "Invalid amount.",
-      "negative": "Must be ≥ 0.",
-      "tooHigh": "Amount too high."
-      },
-      "dueMonth": {
-      "range": "Month between 1 and 12."
-      }
-    }
-    }
-  },
-  "charges": {
-    "createFailed": "Unable to create the bill.",
-    "updateFailed": "Unable to update the bill.",
-    "deleteFailed": "Unable to delete the bill."
-  },
-  "accounts": {
-    "balanceUpdateFailed": "Unable to update the balance.",
-    "renameFailed": "Unable to rename the account.",
-    "incomeUpdateFailed": "Unable to update the income.",
-    "transferUpdateFailed": "Unable to update the transfer."
-  },
-  "expenses": {
-    "createFailed": "Unable to create the expense.",
-    "deleteFailed": "Unable to delete the expense."
-  },
-  "settings": {
-    "profileUpdateFailed": "Unable to update the profile.",
-    "deletionRequestFailed": "Unable to schedule the deletion.",
-    "deletionCancelFailed": "Unable to cancel the request.",
-    "exportLimited": "Export limited to once every 5 minutes."
-  },
-  "onboarding": {
-    "workspaceNotFound": "Workspace not found. Contact support.",
-    "workspaceUpdateFailed": "Unable to update the workspace.",
-    "chargeFailed": "Workspace created but bill not saved."
-  },
-  "locale": {
-    "invalid": "Invalid language."
-  }
   },
   "opengraphImage": {
-  "trustHosting": "🇧🇪 Belgium · EU hosted",
-  "trustNoBank": "No bank aggregation",
-  "trustFree": "0 € Phase 1"
+    "trustHosting": "🇧🇪 Belgium · EU hosted",
+    "trustNoBank": "No bank aggregation",
+    "trustFree": "0 € Phase 1"
   }
 }

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -1,1024 +1,1068 @@
 {
   "common": {
-  "appName": "Ankora",
-  "tagline": "Tu ancla financiera",
-  "description": "Ankora te ayuda a distribuir tus gastos fijos, anticipar cada factura y mantener el control de tu presupuesto. Cockpit claro y seguro, sin consejos de inversión.",
-  "homeAria": "Inicio Ankora",
-  "a11y": {
-    "skipToMain": "Ir al contenido principal"
-  },
-  "nav": {
-    "mainLabel": "Navegación principal",
-    "appLabel": "Navegación de la aplicación",
-    "mobileLabel": "Navegación móvil",
-    "footerLabel": "Pie de página",
-    "menu": "Menú",
-    "close": "Cerrar",
-    "lightMode": "Modo claro",
-    "darkMode": "Modo oscuro",
-    "features": "Funcionalidades",
-    "faq": "FAQ",
-    "login": "Iniciar sesión",
-    "signup": "Crear una cuenta",
-    "myCockpit": "Mi cockpit",
-    "dashboard": "Panel",
-    "accounts": "Cuentas",
-    "charges": "Gastos fijos",
-    "settings": "Ajustes"
-  },
-  "actions": {
-    "retry": "Reintentar",
-    "back": "Volver"
-  },
-  "months": {
-    "1": "enero",
-    "2": "febrero",
-    "3": "marzo",
-    "4": "abril",
-    "5": "mayo",
-    "6": "junio",
-    "7": "julio",
-    "8": "agosto",
-    "9": "septiembre",
-    "10": "octubre",
-    "11": "noviembre",
-    "12": "diciembre"
-  },
-  "monthsShort": {
-    "1": "ene.",
-    "2": "feb.",
-    "3": "mar.",
-    "4": "abr.",
-    "5": "may.",
-    "6": "jun.",
-    "7": "jul.",
-    "8": "ago.",
-    "9": "sept.",
-    "10": "oct.",
-    "11": "nov.",
-    "12": "dic."
-  },
-  "frequency": {
-    "monthly": "Mensual",
-    "quarterly": "Trimestral",
-    "semiannual": "Semestral",
-    "annual": "Anual"
-  }
-  },
-  "ui": {
-  "scrollToTop": "Volver arriba",
-  "localeSwitcher": {
-    "label": "Idioma",
-    "aria": "Cambiar de idioma",
-    "options": {
-    "fr-BE": "Français (BE)",
-    "nl-BE": "Nederlands (BE)",
-    "en": "English",
-    "es-ES": "Español",
-    "de-DE": "Deutsch"
-    }
-  },
-  "action": {
-    "submit": "Confirmar",
-    "submitting": "Confirmando…",
-    "save": "Guardar",
-    "saving": "Guardando…",
-    "cancel": "Cancelar",
-    "cancelling": "Cancelando…",
-    "delete": "Eliminar",
-    "deleting": "Eliminando…",
-    "create": "Crear",
-    "creating": "Creando…",
-    "update": "Actualizar",
-    "updating": "Actualizando…",
-    "send": "Enviar",
-    "sending": "Enviando…",
-    "verify": "Verificar",
-    "verifying": "Verificando…",
-    "generate": "Generar",
-    "generating": "Generando…",
-    "download": "Descargar",
-    "downloading": "Descargando…",
-    "preparing": "Preparando…",
-    "confirm": "Confirmar",
-    "close": "Cerrar"
-  }
-  },
-  "landing": {
-  "mktnav": {
-    "links": {
-    "product": "Produit",
-    "simulator": "Simulateur",
-    "pricing": "Tarifs",
-    "security": "Sécurité",
-    "journal": "Journal"
+    "appName": "Ankora",
+    "tagline": "Tu ancla financiera",
+    "description": "Ankora te ayuda a distribuir tus gastos fijos, anticipar cada factura y mantener el control de tu presupuesto. Cockpit claro y seguro, sin consejos de inversión.",
+    "homeAria": "Inicio Ankora",
+    "a11y": {
+      "skipToMain": "Ir al contenido principal"
     },
-    "ctaLogin": "Se connecter",
-    "ctaSignup": "Essayer gratuitement"
-  },
-  "hero": {
-    "badge": "Nouveau · Simulateur what-if",
-    "h1Lead": "Ton ancrage",
-    "h1Highlight": "financier.",
-    "description": "Ankora sépare tes provisions affectées de ta réserve libre, projette six mois devant, et te laisse simuler l'impact de chaque décision — en clair, sans jargon.",
-    "ctaPrimary": "Ouvrir mon cockpit",
-    "ctaSecondary": "Voir le simulateur",
-    "trust": {
-    "encrypted": "Données chiffrées en Belgique",
-    "noSale": "Aucune vente de données",
-    "languages": "FR · NL · EN"
+    "nav": {
+      "mainLabel": "Navegación principal",
+      "appLabel": "Navegación de la aplicación",
+      "mobileLabel": "Navegación móvil",
+      "footerLabel": "Pie de página",
+      "menu": "Menú",
+      "close": "Cerrar",
+      "lightMode": "Modo claro",
+      "darkMode": "Modo oscuro",
+      "features": "Funcionalidades",
+      "faq": "FAQ",
+      "login": "Iniciar sesión",
+      "signup": "Crear una cuenta",
+      "myCockpit": "Mi cockpit",
+      "dashboard": "Panel",
+      "accounts": "Cuentas",
+      "charges": "Gastos fijos",
+      "settings": "Ajustes"
     },
-    "mockup": {
-    "eyebrow": "Aperçu cockpit",
-    "browserUrl": "Ankora · cockpit",
-    "kpis": {
-      "netRemaining": {
-      "label": "Net restant",
-      "sub": "avril · après provisions"
-      },
-      "provisions": {
-      "label": "Provisions",
-      "sub": "67 % des 2 480 € planifiés"
-      },
-      "reserve": {
-      "label": "Réserve",
-      "sub": "+120 € vs. mars"
-      }
-    }
+    "actions": {
+      "retry": "Reintentar",
+      "back": "Volver"
     },
-    "waterfall": {
-    "income": "Revenus",
-    "incomeAmount": "+2 466 €",
-    "expenses": "Dépenses courantes",
-    "expensesAmount": "−1 959 €",
-    "provisionsCaption": "dont {amount} € lissés vers provisions affectées",
-    "available": "Argent disponible",
-    "availableAmount": "+507 €",
-    "ariaLabel": "Cascade illustrative : 2 466 € de revenus, 1 959 € de dépenses courantes (dont 59 € lissés en provisions), 507 € disponibles."
-    }
-  },
-  "principles": {
-    "eyebrow": "Trois principes",
-    "h2": "Une façon honnête de parler d'argent.",
-    "description": "Ankora n'essaye pas de te vendre un placement ou une carte. On sépare, on projette, on simule. C'est tout. Toi seul décides.",
-    "items": {
-    "provisions": {
-      "title": "Provisions affectées",
-      "description": "Chaque euro réservé a un nom : mutuelle, taxe circulation, entretien chaudière. Rien ne fuit sans que tu le saches."
-    },
-    "reserve": {
-      "title": "Réserve libre",
-      "description": "Ce qui reste vraiment à toi, après les engagements. Le vrai chiffre — pas l'illusion du solde brut."
-    },
-    "whatIf": {
-      "title": "Simulateur what-if",
-      "description": "Renégocier l'électricité ? Changer de fournisseur ? Ankora te montre l'impact sur 12 mois avant que tu décides."
-    }
-    }
-  },
-  "feature": {
-    "eyebrow": "Cashflow waterfall",
-    "h3Line1": "Du salaire au net disponible.",
-    "h3Line2": "En un seul coup d'œil.",
-    "description": "Plus de mystère sur où va ton argent. Chaque étape est visible : revenus, dépenses courantes, argent disponible. Tu vois immédiatement si un poste dérape.",
-    "ctaPrimary": "Voir un exemple",
-    "ctaSecondary": "Comment ça marche ?"
-  },
-  "whatif": {
-    "title": "Et si tu changeais une seule chose ?",
-    "subtitle": "Bouge le curseur. Vois l'impact sur ta réserve libre, sur six mois. C'est ce que fait Ankora à chaque décision financière.",
-    "badge": "Démo · pas de compte requis",
-    "scenarios": {
-    "gsm": {
-      "label": "Renégocier mon GSM",
-      "hint": "Forfait actuel : 42 €/mois · marché : 18–28 €/mois"
-    },
-    "elec": {
-      "label": "Changer de fournisseur d'électricité",
-      "hint": "Conso actuelle : 168 €/mois · 3 offres moins chères dans ta zone"
-    },
-    "stream": {
-      "label": "Couper deux streamings",
-      "hint": "5 abonnements actifs · usage réel : 2 sur 30 jours"
-    }
-    },
-    "controls": {
-    "scenario": "Scénario",
-    "savings": "Économie mensuelle",
-    "slider_aria": "Économie mensuelle pour {label}"
-    },
-    "annual": {
-    "eyebrow": "Sur 12 mois",
-    "fleche": "Ankora pourrait flécher {amount} €/mois vers ton épargne longue."
-    },
-    "chart": {
-    "title": "Réserve libre · projection",
-    "subtitle": "6 mois à partir d'aujourd'hui",
-    "legend": {
-      "baseline": "Sans changement",
-      "scenario": "Avec ton choix"
-    },
-    "aria": "Graphique projection sur 6 mois de la réserve libre, avec et sans le changement choisi",
     "months": {
-      "may": "mai",
-      "jun": "juin",
-      "jul": "juil",
-      "aug": "août",
-      "sep": "sept",
-      "oct": "oct"
+      "1": "enero",
+      "2": "febrero",
+      "3": "marzo",
+      "4": "abril",
+      "5": "mayo",
+      "6": "junio",
+      "7": "julio",
+      "8": "agosto",
+      "9": "septiembre",
+      "10": "octubre",
+      "11": "noviembre",
+      "12": "diciembre"
     },
-    "thresholds": {
-      "danger": "⚠️ Découvert estimé",
-      "fragile": "Zone fragile",
-      "comfortable": "Zone confortable"
-    }
-    },
-    "caveat": "Démo basée sur des hypothèses moyennes. Ankora ne fournit pas de conseil en placement. Aucun import bancaire — tu saisis tes charges manuellement."
-  },
-  "pricing": {
-    "eyebrow": "Transparent dès le départ",
-    "h2": "Gratuit pendant la Phase 1.",
-    "phaseBadge": "Phase 1 · construction",
-    "price": "0 €",
-    "period": "pour l'instant, et sans date limite",
-    "body": "On construit d'abord le cockpit. Pas de carte demandée, pas de limite de temps, pas de fonctionnalité bridée. Export RGPD à tout moment.",
-    "features": {
-    "cockpit": "Cockpit complet, provisions et réserve libre",
-    "simulator": "Simulateur what-if illimité",
-    "manualEntry": "Saisie manuelle · tes données restent en Belgique",
-    "export": "Export RGPD en un clic"
-    },
-    "ctaPrimary": "Ouvrir mon cockpit",
-    "roadmap": {
-    "title": "Tu rejoins Ankora pendant sa Phase 1 ?",
-    "body": "Ton compte garde un accès complet au cockpit core à vie, gratuitement. Une offre Pro avec features avancées (comptes illimités, exports consolidés, support prioritaire) arrivera post-v1.0 — tu auras le choix d'upgrader ou de rester sur ton plan actuel.",
-    "link": "Lire la roadmap →"
-    }
-  },
-  "footerCta": {
-    "h2Lead": "Commence par ce qui est",
-    "h2Highlight": "déjà à toi.",
-    "description": "30 jours d'essai, pas de carte, export RGPD à tout moment. On fait simple parce que c'est déjà assez compliqué comme ça.",
-    "ctaPrimary": "Ouvrir mon cockpit"
-  },
-  "footer": {
-    "links": {
-    "terms": "Conditions",
-    "privacy": "Confidentialité",
-    "security": "Sécurité",
-    "contact": "Contact"
-    },
-    "copyright": "Ankora · éditeur ancré à Bruxelles · 2026"
-  },
-  "faqHeading": "Preguntas frecuentes",
-  "faq": {
-    "advice": {
-    "q": "¿Ankora es una herramienta de asesoramiento financiero?",
-    "a": "No. Ankora es una herramienta de organización y educación presupuestaria. No proporciona recomendaciones de inversión ni asesoramiento financiero personalizado."
-    },
-    "storage": {
-    "q": "¿Dónde se almacenan mis datos?",
-    "a": "Tus datos están alojados en la Unión Europea (Supabase, región UE) con cifrado en reposo y aislamiento estricto por usuario mediante Row Level Security."
-    },
-    "sharing": {
-    "q": "¿Puedo compartir mis datos?",
-    "a": "Por defecto, tu espacio es 100 % privado. Los bolsillos compartidos opcionales (viaje, proyecto común) llegarán en una próxima versión — tú elegirás explícitamente qué compartes y con quién."
-    }
-  }
-  },
-  "faq": {
-  "metaTitle": "FAQ",
-  "metaDescription": "Preguntas frecuentes sobre Ankora: seguridad, datos, funcionamiento, privacidad.",
-  "title": "Preguntas frecuentes",
-  "subtitle": "Todo lo que necesitas saber sobre Ankora antes de empezar.",
-  "items": {
-    "bankConnection": {
-    "q": "¿Ankora se conecta a mi banco?",
-    "a": "No. Ankora no utiliza la directiva PSD2. Introduces manualmente tus gastos fijos y gastos. Esta elección garantiza que sigues siendo propietario de tus datos y que no se almacena ninguna información bancaria sensible."
-    },
-    "dataLocation": {
-    "q": "¿Dónde se alojan mis datos?",
-    "a": "Todos tus datos se alojan en la Unión Europea (Supabase región UE, Vercel región UE, Upstash UE). No se realiza ninguna transferencia fuera de la UE."
-    },
-    "smoothing": {
-    "q": "¿Cómo funciona la distribución?",
-    "a": "Ankora toma tus gastos fijos trimestrales, semestrales y anuales y los reparte en 12 meses. Así sabes cuánto apartar cada mes para cubrir todas tus futuras facturas sin estrés."
-    },
-    "deletion": {
-    "q": "¿Puedo eliminar mi cuenta?",
-    "a": "Sí, en cualquier momento desde Ajustes → Privacidad. La eliminación se hace efectiva 30 días después de tu solicitud (puedes cancelar durante ese periodo). Todos tus datos financieros se borran, los logs de seguridad se seudonimizan."
-    },
-    "export": {
-    "q": "¿Puedo exportar mis datos?",
-    "a": "Sí. El botón «Descargar mis datos» en Ajustes te proporciona un archivo JSON completo de todo lo que Ankora tiene sobre ti. Conforme al derecho de portabilidad RGPD (art. 20)."
-    },
-    "advice": {
-    "q": "¿Ankora da consejos financieros?",
-    "a": "No. Ankora es una herramienta de educación presupuestaria y organización. No emitimos ningún consejo de inversión (restricción regulatoria FSMA Bélgica). Para cualquier decisión de inversión, consulta a un profesional autorizado."
-    },
-    "ai": {
-    "q": "¿Hay inteligencia artificial?",
-    "a": "En la Fase 1, no. Los cálculos son deterministas y auditables. En la Fase 2, una capa opcional BYOK (Bring Your Own Key) te permitirá conectar tu propia clave Anthropic u OpenRouter para obtener sugerencias — sin coste adicional por parte de Ankora."
-    },
-    "sharing": {
-    "q": "¿Puedo compartir mi espacio con mis hijos o mis amigos?",
-    "a": "En la Fase 1, cada usuario tiene un espacio privado, aislado por defecto. En la Fase 2, añadiremos la posibilidad de crear «bolsillos compartidos» (por invitación, con roles viewer/editor) sin mezclar nunca tus datos personales."
-    }
-  }
-  },
-  "legal": {
-  "versionLine": "Versión {version} — última actualización: {date}",
-  "lastUpdatedLine": "Última actualización: {date}",
-  "cgu": {
-    "metaTitle": "Condiciones generales de uso",
-    "metaDescription": "CGU de Ankora — reglas de uso del servicio.",
-    "title": "Condiciones generales de uso",
-    "s1": {
-    "heading": "1. Objeto",
-    "body": "Ankora es una herramienta de organización presupuestaria y educación financiera destinada a particulares. Permite introducir manualmente los gastos fijos y gastos, distribuirlos a lo largo del año y anticipar las necesidades de tesorería."
-    },
-    "s2": {
-    "heading": "2. Lo que Ankora NO es",
-    "item1": "Ankora <b>no es un servicio de asesoramiento de inversión</b> ni de inversiones.",
-    "item2": "Ankora <b>no es un servicio bancario</b> y no custodia ningún fondo.",
-    "item3": "Ankora <b>no es un agregador PSD2</b> — sin conexión a tus cuentas bancarias.",
-    "item4": "Ankora <b>no es un software de contabilidad profesional</b>.",
-    "outro": "La información mostrada son estimaciones basadas en tus datos. No constituyen asesoramiento financiero personalizado. Para cualquier decisión importante, consulta a un profesional autorizado."
-    },
-    "s3": {
-    "heading": "3. Cuenta",
-    "item1": "Debes ser mayor de edad o contar con la autorización de un representante legal.",
-    "item2": "Una sola cuenta por persona física.",
-    "item3": "Contraseña mínima de 12 caracteres, mixta.",
-    "item4": "Eres responsable de la confidencialidad de tus credenciales."
-    },
-    "s4": {
-    "heading": "4. Uso aceptable",
-    "intro": "Te comprometes a no:",
-    "item1": "utilizar el servicio con fines ilegales,",
-    "item2": "intentar eludir las medidas de seguridad,",
-    "item3": "automatizar el acceso sin autorización explícita,",
-    "item4": "compartir tu cuenta con un tercero."
-    },
-    "s5": {
-    "heading": "5. Propiedad intelectual",
-    "body": "Sigues siendo propietario de tus datos. Ankora conserva la propiedad de su código, marca, diseño y documentación."
-    },
-    "s6": {
-    "heading": "6. Responsabilidad",
-    "body": "Ankora se proporciona «tal cual». El editor no puede ser considerado responsable de las decisiones financieras tomadas en base a la información mostrada. No se garantiza una disponibilidad del 100 %."
-    },
-    "s7": {
-    "heading": "7. Resolución",
-    "body": "Puedes eliminar tu cuenta en cualquier momento desde Ajustes → Privacidad. La eliminación es efectiva 30 días tras la solicitud (periodo cancelable)."
-    },
-    "s8": {
-    "heading": "8. Ley aplicable",
-    "body": "Estas CGU están sujetas al derecho belga. Tribunal competente: Bruselas."
-    },
-    "draft": "Nuestras condiciones generales de uso están en proceso de redacción.",
-    "contact": "Para cualquier pregunta, contáctanos: thierryvm@gmail.com",
-    "backHome": "Volver al inicio"
-  },
-  "privacy": {
-    "metaTitle": "Política de privacidad",
-    "metaDescription": "Política de privacidad de Ankora — alojamiento UE, RGPD, derechos de los usuarios.",
-    "title": "Política de privacidad",
-    "s1": {
-    "heading": "1. Responsable del tratamiento",
-    "body": "Ankora, editado por Thierry Van Mele (Bélgica). Contacto: <mail>thierryvm@gmail.com</mail>."
-    },
-    "s2": {
-    "heading": "2. Datos recogidos",
-    "intro": "Ankora recoge únicamente los datos estrictamente necesarios para prestar el servicio:",
-    "item1": "<b>Identidad</b>: dirección de email, nombre para mostrar (opcional).",
-    "item2": "<b>Datos financieros introducidos por ti</b>: gastos fijos, gastos, categorías, ingresos declarados, saldo de ahorro.",
-    "item3": "<b>Datos técnicos</b>: dirección IP, user-agent (solo para logs de seguridad).",
-    "item4": "<b>Consentimientos</b>: marca temporal, versión, alcance (CGU, privacidad, cookies).",
-    "outro": "Ankora no se conecta a ningún banco (sin agregación PSD2). Tú mismo introduces tus gastos fijos y gastos."
-    },
-    "s3": {
-    "heading": "3. Bases legales (RGPD art. 6)",
-    "item1": "<b>Contrato</b>: prestación del servicio (cuenta, datos financieros).",
-    "item2": "<b>Consentimiento</b>: cookies analíticas/marketing, newsletter.",
-    "item3": "<b>Obligación legal</b>: logs de seguridad (conservación 12 meses).",
-    "item4": "<b>Interés legítimo</b>: prevención del fraude, mantenimiento de la seguridad."
-    },
-    "s4": {
-    "heading": "4. Alojamiento y subencargados",
-    "item1": "<b>Supabase</b> (base de datos, auth) — región UE (Fráncfort o París).",
-    "item2": "<b>Vercel</b> (alojamiento frontend) — región UE (Dublín).",
-    "item3": "<b>Upstash</b> (rate limiting) — región UE.",
-    "outro": "Ningún dato se transfiere fuera de la UE/EEE."
-    },
-    "s5": {
-    "heading": "5. Plazo de conservación",
-    "item1": "Cuenta activa: mientras utilices el servicio.",
-    "item2": "Cuenta eliminada: eliminación efectiva 30 días después de tu solicitud (periodo de gracia cancelable).",
-    "item3": "Logs de seguridad: 12 meses máximo, seudonimizados tras la eliminación de la cuenta."
-    },
-    "s6": {
-    "heading": "6. Tus derechos (RGPD art. 15-22)",
-    "item1": "<b>Acceso</b>: consulta tus datos en cualquier momento desde tu espacio.",
-    "item2": "<b>Rectificación</b>: modifica perfil y datos en las páginas dedicadas.",
-    "item3": "<b>Supresión</b>: botón «Eliminar mi cuenta» en Ajustes → Privacidad.",
-    "item4": "<b>Portabilidad</b>: botón «Descargar mis datos» — exportación JSON completa.",
-    "item5": "<b>Oposición / Limitación</b>: rechaza o retira los cookies no esenciales en cualquier momento.",
-    "item6": "<b>Reclamación</b>: ante la <apd>APD belga</apd> (Bélgica)."
-    },
-    "s7": {
-    "heading": "7. Seguridad",
-    "item1": "Cifrado en tránsito (TLS 1.3) y en reposo.",
-    "item2": "Row Level Security Supabase en todas las tablas.",
-    "item3": "Rate limiting, CSP estricta, audit log append-only.",
-    "item4": "Autenticación por contraseña fuerte + MFA disponible."
-    },
-    "s8": {
-    "heading": "8. Cookies",
-    "body": "Consulta la <link>política de cookies</link>."
-    },
-    "s9": {
-    "heading": "9. Modificaciones",
-    "body": "Toda modificación material de esta política se notifica por email y requiere tu consentimiento renovado para seguir utilizando el servicio."
-    },
-    "draft": "Nuestra política de privacidad está en proceso de redacción.",
-    "contact": "Para cualquier pregunta, contáctanos: thierryvm@gmail.com",
-    "backHome": "Volver al inicio"
-  },
-  "cookies": {
-    "metaTitle": "Política de cookies",
-    "metaDescription": "Política de cookies de Ankora — granularidad total, todo rechazable salvo los esenciales.",
-    "title": "Política de cookies",
-    "categoriesHeading": "Categorías",
-    "essentialHeading": "Esenciales (siempre activos)",
-    "essentialBody": "Indispensables para el funcionamiento: sesión de autenticación, preferencia de tema, anti-CSRF.",
-    "essentialItem1": "<code>sb-*</code> — sesión Supabase (auth)",
-    "essentialItem2": "<code>ankora-theme</code> — preferencia claro/oscuro",
-    "analyticsHeading": "Analíticos (desactivados por defecto)",
-    "analyticsBody1": "Únicamente si das tu consentimiento. Medida de uso agregada, sin identificador personal.",
-    "analyticsBody2": "Ankora no utiliza Google Analytics. Las métricas de Vercel están agregadas y anonimizadas.",
-    "marketingHeading": "Marketing (desactivados por defecto)",
-    "marketingBody": "Ankora no utiliza actualmente ningún cookie de marketing.",
-    "manageHeading": "Gestionar tus preferencias",
-    "manageBody1": "Puedes modificar tus consentimientos en cualquier momento desde <b>Ajustes → Privacidad</b> o pulsando «Gestionar cookies» en el pie de página.",
-    "manageBody2": "Rechazar los cookies no esenciales no degrada la experiencia: Ankora sigue siendo totalmente funcional.",
-    "lifetimeHeading": "Duración",
-    "lifetimeItem1": "Sesión: fin de la navegación",
-    "lifetimeItem2": "Preferencias: 12 meses",
-    "lifetimeItem3": "Analíticas: 6 meses (si se aceptan)",
-    "draft": "Esta página de política de cookies está en proceso de redacción.",
-    "contact": "Para cualquier pregunta, contáctanos: thierryvm@gmail.com",
-    "backHome": "Volver al inicio"
-  }
-  },
-  "offline": {
-  "metaTitle": "Sin conexión",
-  "metaDescription": "Actualmente estás sin conexión. Reconéctate para acceder a Ankora.",
-  "title": "Estás sin conexión",
-  "message": "Reconéctate para acceder a tu cockpit. Tus datos siguen intactos.",
-  "retry": "Reintentar"
-  },
-  "consent": {
-  "title": "Cookies y privacidad",
-  "body": "Solo usamos los cookies esenciales para conectarte. Los cookies de análisis están desactivados por defecto — puedes activarlos si quieres ayudarnos a mejorar Ankora. Puedes cambiar de opinión en cualquier momento desde <link>la política de cookies</link>.",
-  "essentialOnly": "Solo esenciales",
-  "acceptAnalytics": "Aceptar los análisis"
-  },
-  "footer": {
-  "copyright": "© {year} — Todos los derechos reservados",
-  "cgu": "CGU",
-  "privacy": "Privacidad",
-  "cookies": "Gestionar cookies",
-  "faq": "FAQ",
-  "copyrightNotice": "© {year} Ankora™. Todos los derechos reservados."
-  },
-  "auth": {
-  "login": {
-    "title": "Iniciar sesión",
-    "subtitle": "Recupera tu cockpit Ankora.",
-    "metaTitle": "Conexión",
-    "emailLabel": "Email",
-    "passwordLabel": "Contraseña",
-    "forgotLink": "¿Contraseña olvidada?",
-    "submit": "Iniciar sesión",
-    "submitting": "Conectando…",
-    "noAccount": "¿Aún no tienes cuenta?",
-    "signupLink": "Crear una cuenta",
-    "dividerOr": "o",
-    "dividerOrEmail": "o con tu email",
-    "passwordUpdatedBanner": "Contraseña actualizada. Ya puedes iniciar sesión."
-  },
-  "signup": {
-    "title": "Crear una cuenta",
-    "subtitle": "Lanza tu cockpit financiero en menos de 2 minutos.",
-    "pageTitle": "Crear mi cockpit",
-    "pageDescription": "Unos segundos. Sin tarjeta bancaria.",
-    "emailLabel": "Email",
-    "passwordLabel": "Contraseña",
-    "passwordHint": "Al menos 12 caracteres, 1 mayúscula, 1 minúscula, 1 cifra.",
-    "passwordConfirmLabel": "Confirmar la contraseña",
-    "acceptTosPrefix": "Acepto las",
-    "acceptTosLink": "CGU",
-    "acceptPrivacyPrefix": "Acepto la",
-    "acceptPrivacyLink": "política de privacidad",
-    "submit": "Crear mi cuenta",
-    "submitting": "Creando…",
-    "haveAccount": "¿Ya tienes cuenta?",
-    "loginLink": "Iniciar sesión",
-    "dividerOr": "o",
-    "dividerOrEmail": "o con tu email",
-    "googleCta": "Crear mi cuenta con Google",
-    "googleTerms": "Al continuar con Google, aceptas nuestras <cgu>CGU</cgu> y nuestra <privacy>política de privacidad</privacy>."
-  },
-  "forgot": {
-    "title": "Contraseña olvidada",
-    "subtitle": "Introduce tu email y te enviaremos un enlace seguro.",
-    "emailLabel": "Email",
-    "submit": "Enviar el enlace",
-    "submitting": "Enviando…",
-    "sentMessage": "Si este email existe, acaba de enviarse un enlace de restablecimiento.",
-    "backToLogin": "Volver al inicio de sesión"
-  },
-  "reset": {
-    "title": "Nueva contraseña",
-    "subtitle": "Elige una contraseña sólida para tu cuenta.",
-    "passwordLabel": "Nueva contraseña",
-    "passwordConfirmLabel": "Confirmar",
-    "submit": "Actualizar",
-    "submitting": "Actualizando…"
-  },
-  "google": {
-    "label": "Continuar con Google",
-    "redirecting": "Redirigiendo…"
-  },
-  "checkEmail": {
-    "title": "Comprueba tu bandeja de entrada",
-    "metaTitle": "Comprueba tu email",
-    "body": "Acabamos de enviarte un enlace de confirmación. Púlsalo para activar tu cuenta.",
-    "backToLogin": "Volver al inicio de sesión"
-  }
-  },
-  "onboarding": {
-  "defaultWorkspaceName": "Mi espacio",
-  "previous": "Volver",
-  "next": "Continuar",
-  "finish": "Terminar",
-  "finishing": "Guardando…",
-  "validation": {
-    "workspaceNameRequired": "Dale un nombre a tu espacio.",
-    "incomeInvalid": "Introduce un ingreso válido (≥ 0)."
-  },
-  "step1": {
-    "title": "Nombra tu espacio",
-    "description": "Podrás modificarlo más tarde en los ajustes.",
-    "nameLabel": "Nombre del espacio"
-  },
-  "step2": {
-    "title": "Tu ingreso neto mensual",
-    "description": "Sirve de base para sugerirte las transferencias mensuales.",
-    "incomeLabel": "Ingreso neto mensual (€)"
-  },
-  "step3": {
-    "title": "Tu primer gasto fijo (opcional)",
-    "description": "Añade un alquiler, un seguro, una suscripción…",
-    "labelLabel": "Etiqueta",
-    "labelPlaceholder": "Alquiler, seguro de coche…",
-    "amountLabel": "Importe (€)",
-    "frequencyLabel": "Frecuencia",
-    "dueMonthLabel": "Mes de referencia",
-    "skipLater": "Introduciré mis gastos fijos más tarde"
-  }
-  },
-  "app": {
-  "dashboard": {
-    "metaTitle": "Panel",
-    "headerTitle": "{month} — tu cockpit",
-    "emptyTitle": "Empieza añadiendo tus gastos fijos",
-    "emptyDescription": "Alquiler, seguros, suscripciones — Ankora los distribuye en 12 meses por ti.",
-    "emptyCta": "Añadir un gasto fijo",
-    "kpiProvisionsMonthly": "Reservas / mes",
-    "kpiProvisionsAnnualHint": "Anual: {amount}",
-    "kpiHealth": "Salud de reservas",
-    "kpiHealthTargetHint": "Objetivo: {amount}",
-    "kpiSuggestedTransfer": "Transferencia sugerida",
-    "kpiSuggestedTransferToSavings": "Para apartar",
-    "kpiSuggestedTransferFromSavings": "Para retirar del ahorro",
-    "kpiBillsMonth": "Facturas {month}",
-    "kpiBillsHint": "Salida de efectivo este mes",
-    "healthHealthy": "Sano",
-    "healthWarning": "A vigilar",
-    "healthCritical": "Crítico",
-    "planTitle": "Plan del mes — {month}",
-    "planDescription": "Las transferencias que ejecutar a principios de mes en tus tres cuentas.",
-    "planAdjustAccounts": "Ajustar mis cuentas",
-    "missingSetupTitle": "Configura primero tus cuentas",
-    "missingSetupDescription": "Para calcular tu Transferencia Inteligente, Ankora necesita tu ingreso mensual y el importe fijo que envías a Día a Día.",
-    "missingSetupCta": "Configurar mis cuentas",
-    "transferPrincipalToVieCourante": "Principal → Día a Día",
-    "transferVieCouranteHint": "Sobre compra, gasolina, restaurantes.",
-    "transferPrincipalToEpargne": "Principal → Ahorro",
-    "transferEpargneToPrincipal": "Ahorro → Principal",
-    "transferEpargneHint": "Reserva {provision} − facturas {bills}",
-    "transferPrincipalRemaining": "Restante en Principal",
-    "transferPrincipalRemainingHint": "Tras el salario, las transferencias y las facturas de Principal ({bills}).",
-    "ctaCharges": "Mis gastos fijos",
-    "ctaExpenses": "Mis gastos",
-    "ctaSimulator": "Simular",
-    "expensesTitle": "Gastos — {month}",
-    "expensesCount": "{count, plural, =0 {Sin gastos este mes} one {1 gasto este mes} other {# gastos este mes}}",
-    "expensesEmpty": "No hay gastos registrados este mes.",
-    "expensesViewAll": "Ver todos los gastos →"
-  },
-  "charges": {
-    "title": "Mis gastos fijos",
-    "subtitle": "Cada gasto fijo se distribuye automáticamente en 12 meses.",
-    "addFormTitle": "Añadir un gasto fijo",
-    "emptyState": "Ningún gasto fijo por ahora.",
-    "labelLabel": "Etiqueta",
-    "amountLabel": "Importe (€)",
-    "frequencyLabel": "Frecuencia",
-    "dueMonthLabel": "Mes de referencia",
-    "addButton": "Añadir",
-    "adding": "Añadiendo…",
-    "count": "{count, plural, =0 {ningún gasto fijo} one {1 gasto fijo} other {# gastos fijos}}",
-    "referenceFormat": "{frequency} · ref. {month}",
-    "deleteAria": "Eliminar {label}",
-    "toastCreated": "Gasto fijo añadido",
-    "toastDeleted": "Gasto fijo eliminado"
-  },
-  "accounts": {
-    "metaTitle": "Mis cuentas",
-    "metaDescription": "Sigue los saldos de tus cuentas Principal, Día a Día y Ahorro. Ajusta tu ingreso mensual y tu transferencia a Día a Día.",
-    "title": "Mis cuentas",
-    "subtitle": "Introduce tus saldos reales para que Ankora calcule con precisión tu transferencia inteligente cada mes.",
-    "balancesHeading": "Saldos actuales",
-    "amountLabel": "Importe (€)",
-    "saveButton": "Guardar",
-    "saving": "Guardando…",
-    "income": {
-    "title": "Ingreso neto mensual",
-    "description": "El salario que llega cada mes a tu cuenta Principal. Sirve para calcular lo que te queda tras los gastos fijos y la transferencia a Día a Día.",
-    "placeholder": "Ej. 2500",
-    "toastSaved": "Ingreso mensual actualizado"
-    },
-    "transfer": {
-    "title": "Transferencia mensual a Día a Día",
-    "description": "Suma fija transferida cada mes desde Principal a tu cuenta Día a Día. Es lo que se usará para la compra, la gasolina y los restaurantes.",
-    "placeholder": "Ej. 500",
-    "toastSaved": "Transferencia mensual actualizada"
-    },
-    "balance": {
-    "invalidAmount": "Introduce un importe válido.",
-    "saveLabel": "Actualizar",
-    "srLabel": "Saldo actual de {label}",
-    "toastSaved": "{name} actualizado"
-    },
-    "kind": {
-    "principal": {
-      "description": "Recibe el salario, paga los gastos fijos mensuales."
-    },
-    "vieCourante": {
-      "description": "Presupuesto del día a día (compra, gasolina, restaurantes)."
-    },
-    "epargne": {
-      "description": "Distribuye las facturas trimestrales y anuales."
-    }
-    }
-  },
-  "expenses": {
-    "title": "Mis gastos",
-    "subtitle": "Las salidas fuera de los gastos fijos recurrentes — compra, restaurantes, ocio…",
-    "addFormTitle": "Añadir un gasto",
-    "labelLabel": "Etiqueta",
-    "amountLabel": "Importe (€)",
-    "dateLabel": "Fecha",
-    "addButton": "Añadir",
-    "adding": "Añadiendo…",
-    "emptyState": "Ningún gasto registrado.",
-    "summary": "{count, plural, =0 {Ningún gasto} one {1 gasto · {total}} other {# gastos · {total}}}",
-    "deleteAria": "Eliminar {label}",
-    "toastCreated": "Gasto añadido",
-    "toastDeleted": "Gasto eliminado"
-  },
-  "settings": {
-    "metaTitle": "Ajustes",
-    "metaDescription": "Gestiona tu perfil, la seguridad 2FA y tus datos personales.",
-    "title": "Ajustes",
-    "description": "Perfil, seguridad y datos personales.",
-    "profile": {
-    "title": "Perfil",
-    "description": "Estos datos personalizan tu cockpit.",
-    "emailLabel": "Email",
-    "displayNameLabel": "Nombre para mostrar",
-    "localeLabel": "Idioma",
-    "localeOptions": {
-      "fr-BE": "Français (Belgique)",
-      "fr-FR": "Français (France)",
-      "en-GB": "English"
-    },
-    "submit": "Guardar",
-    "submitting": "Guardando…",
-    "toastSaved": "Perfil actualizado"
-    },
-    "mfa": {
-    "title": "Seguridad — 2FA",
-    "description": "Un código de un solo uso generado por una app de autenticación (Authy, 1Password, Google Authenticator).",
-    "emptyState": "Ningún factor 2FA activo. Actívalo para proteger tu cuenta.",
-    "enrollButton": "Activar la 2FA",
-    "enrolling": "Preparando…",
-    "scanInstruction": "Escanea este QR en tu app de autenticación, y luego introduce el código de 6 cifras.",
-    "qrAlt": "QR para la app de autenticación",
-    "manualEntry": "Entrada manual",
-    "codeLabel": "Código de 6 cifras",
-    "verifyButton": "Verificar y activar",
-    "verifying": "Verificando…",
-    "cancel": "Cancelar",
-    "defaultFactorName": "App TOTP",
-    "activeLabel": "Activo",
-    "disableButton": "Desactivar",
-    "toastEnabled": "MFA activado",
-    "toastDisabled": "MFA desactivado"
-    },
-    "data": {
-    "title": "Mis datos",
-    "description": "Portabilidad RGPD (art. 20) — descarga un JSON completo de todo lo que Ankora tiene sobre ti.",
-    "exportButton": "Descargar mis datos",
-    "exporting": "Generando…",
-    "toastDownloaded": "Exportación descargada"
-    },
-    "danger": {
-    "scheduledTitle": "Eliminación en curso",
-    "scheduledBody": "Tu cuenta se eliminará el <strong>{date}</strong>. Puedes cancelar en cualquier momento hasta entonces.",
-    "viewStatus": "Ver el estado",
-    "title": "Zona peligrosa",
-    "description": "Eliminación definitiva de la cuenta. 30 días de gracia para cancelar — después, todo se borra (logs de auditoría seudonimizados).",
-    "reasonLabel": "Motivo (opcional)",
-    "reasonPlaceholder": "Ayúdanos a mejorar…",
-    "confirmLabel": "Para confirmar, escribe tu dirección de e-mail: <code>{email}</code>",
-    "submit": "Eliminar mi cuenta",
-    "submitting": "Programando…",
-    "toastScheduled": "Eliminación programada — tienes 30 días para cancelar"
-    }
-  },
-  "simulator": {
-    "title": "Simulador",
-    "subtitle": "Mide el impacto de un cambio sin tocar tus datos reales.",
-    "scenario": {
-    "title": "Escenario",
-    "description": "Elige una acción a simular.",
-    "modes": {
-      "cancel": "Cancelar un gasto fijo",
-      "negotiate": "Renegociar",
-      "add": "Añadir un gasto fijo"
-    }
-    },
-    "fields": {
-    "charge": "Gasto fijo",
-    "chargePlaceholder": "Selecciona…",
-    "newAmount": "Nuevo importe (€)",
-    "label": "Etiqueta",
-    "amount": "Importe (€)",
-    "frequency": "Frecuencia",
-    "month": "Mes"
-    },
-    "impact": {
-    "title": "Impacto",
-    "empty": "Completa el escenario para ver el impacto.",
-    "currentMonthly": "Actual / mes",
-    "projectedMonthly": "Proyectado / mes",
-    "annualSavings": "Ahorro anual",
-    "monthlyChange": "{sign}{percent}% / mes"
-    }
-  },
-  "deletionStatus": {
-    "title": "Eliminación de la cuenta",
-    "subtitle": "Estado detallado de tu solicitud y periodo de cancelación.",
-    "metaTitle": "Estado de la eliminación",
-    "metaDescription": "Estado de la solicitud de eliminación de tu cuenta Ankora.",
-    "statusLabel": "Estado:",
-    "requestedOn": "Solicitada el {date}.",
-    "statusPending": "Pendiente",
-    "statusCancelled": "Cancelada",
-    "statusCompleted": "Completada",
-    "scheduledFor": "Eliminación prevista",
-    "daysLeft": "Días restantes",
-    "auditLogs": "Logs de auditoría",
-    "auditLogsValue": "Seudonimizados, nunca eliminados",
-    "daysCount": "{days, plural, =0 {Hoy} one {# día} other {# días}}",
-    "backToSettings": "Volver a los ajustes",
-    "cancelledOn": "Solicitud cancelada el {date}. Tu cuenta se conserva.",
-    "cancelledNoDate": "Solicitud cancelada. Tu cuenta se conserva.",
-    "cancelButton": "Cancelar la eliminación",
-    "cancelling": "Cancelando…",
-    "toastCancelled": "Solicitud cancelada — tu cuenta se conserva"
-  }
-  },
-  "glossary": {
-  "title": "Glossary",
-  "subtitle": "15 essential terms for understanding your budgeting and personal finances.",
-  "metaTitle": "Glossary — Financial Terms",
-  "metaDescription": "Glossary of 15 essential budgeting terms: smoothed budget, bucket account, emergency fund, and more.",
-  "breadcrumb": {
-    "home": "Home",
-    "glossary": "Glossary"
-  },
-  "section": {
-    "whyItMatters": "Why It Matters",
-    "example": "Concrete Example",
-    "relatedTerms": "Related Terms"
-  }
-  },
-  "errors": {
-  "generic": "Se ha producido un error. Reinténtalo.",
-  "session": {
-    "expired": "Sesión expirada. Vuelve a iniciar sesión.",
-    "rateLimited": "Demasiadas solicitudes. Espera un minuto."
-  },
-  "auth": {
-    "invalidCredentials": "Email o contraseña incorrectos.",
-    "signupFailed": "Registro imposible. Reinténtalo más tarde.",
-    "googleFailed": "Conexión con Google no disponible. Reinténtalo más tarde.",
-    "rateLimited": "Demasiados intentos. Reinténtalo en unos minutos.",
-    "serviceTemporarilyUnavailable": "Servicio temporalmente no disponible. Reinténtalo en unos minutos.",
-    "passwordResetFailed": "No se ha podido actualizar la contraseña.",
-    "linkExpired": "Enlace expirado. Solicita un nuevo enlace.",
-    "mfaEnrollFailed": "No se ha podido iniciar el registro.",
-    "mfaChallengeFailed": "Desafío MFA imposible.",
-    "mfaCodeInvalid": "Código incorrecto. Reinténtalo.",
-    "mfaDisableFailed": "No se ha podido desactivar la 2FA."
-  },
-  "db": {
-    "workspaceNotFound": "Ningún workspace editable.",
-    "updateFailed": "Actualización imposible.",
-    "notEditable": "No tienes permisos de edición en este espacio."
-  },
-  "validation": {
-    "generic": "Datos inválidos.",
-    "auth": {
-    "email": {
-      "invalid": "Dirección de email inválida."
-    },
-    "password": {
-      "required": "Contraseña requerida.",
-      "tooShort": "Al menos 12 caracteres.",
-      "tooLong": "Máximo 128 caracteres.",
-      "lowercase": "Al menos una minúscula.",
-      "uppercase": "Al menos una mayúscula.",
-      "digit": "Al menos una cifra."
-    },
-    "passwordConfirm": {
-      "mismatch": "Las contraseñas no coinciden."
-    },
-    "acceptTos": {
-      "required": "Debes aceptar las CGU."
-    },
-    "acceptPrivacy": {
-      "required": "Debes aceptar la política de privacidad."
-    }
-    },
-    "charge": {
-    "label": {
-      "required": "Etiqueta requerida.",
-      "tooLong": "Máximo 120 caracteres."
-    },
-    "amount": {
-      "invalid": "Importe inválido.",
-      "negative": "El importe debe ser ≥ 0.",
-      "tooHigh": "Importe demasiado elevado."
+    "monthsShort": {
+      "1": "ene.",
+      "2": "feb.",
+      "3": "mar.",
+      "4": "abr.",
+      "5": "may.",
+      "6": "jun.",
+      "7": "jul.",
+      "8": "ago.",
+      "9": "sept.",
+      "10": "oct.",
+      "11": "nov.",
+      "12": "dic."
     },
     "frequency": {
-      "invalid": "Frecuencia inválida."
-    },
-    "dueMonth": {
-      "range": "Mes entre 1 y 12."
-    },
-    "paidFrom": {
-      "invalid": "Cuenta de cargo inválida."
+      "monthly": "Mensual",
+      "quarterly": "Trimestral",
+      "semiannual": "Semestral",
+      "annual": "Anual"
     }
+  },
+  "ui": {
+    "scrollToTop": "Volver arriba",
+    "localeSwitcher": {
+      "label": "Idioma",
+      "aria": "Cambiar de idioma",
+      "options": {
+        "fr-BE": "Français (BE)",
+        "nl-BE": "Nederlands (BE)",
+        "en": "English",
+        "es-ES": "Español",
+        "de-DE": "Deutsch"
+      }
     },
-    "account": {
-    "kind": {
-      "invalid": "Tipo de cuenta inválido."
-    },
-    "balance": {
-      "invalid": "Saldo inválido.",
-      "outOfRange": "Valor fuera de los límites."
-    },
-    "label": {
-      "required": "Etiqueta requerida.",
-      "tooLong": "Máximo 80 caracteres."
+    "action": {
+      "submit": "Confirmar",
+      "submitting": "Confirmando…",
+      "save": "Guardar",
+      "saving": "Guardando…",
+      "cancel": "Cancelar",
+      "cancelling": "Cancelando…",
+      "delete": "Eliminar",
+      "deleting": "Eliminando…",
+      "create": "Crear",
+      "creating": "Creando…",
+      "update": "Actualizar",
+      "updating": "Actualizando…",
+      "send": "Enviar",
+      "sending": "Enviando…",
+      "verify": "Verificar",
+      "verifying": "Verificando…",
+      "generate": "Generar",
+      "generating": "Generando…",
+      "download": "Descargar",
+      "downloading": "Descargando…",
+      "preparing": "Preparando…",
+      "confirm": "Confirmar",
+      "close": "Cerrar"
     }
+  },
+  "landing": {
+    "mktnav": {
+      "links": {
+        "product": "Produit",
+        "simulator": "Simulateur",
+        "pricing": "Tarifs",
+        "security": "Sécurité",
+        "journal": "Journal"
+      },
+      "ctaLogin": "Se connecter",
+      "ctaSignup": "Essayer gratuitement"
     },
-    "workspace": {
-    "name": {
-      "required": "Nombre requerido.",
-      "tooLong": "Máximo 80 caracteres."
+    "hero": {
+      "badge": "Nouveau · Simulateur what-if",
+      "h1Lead": "Ton ancrage",
+      "h1Highlight": "financier.",
+      "description": "Ankora sépare tes provisions affectées de ta réserve libre, projette six mois devant, et te laisse simuler l'impact de chaque décision — en clair, sans jargon.",
+      "ctaPrimary": "Ouvrir mon cockpit",
+      "ctaSecondary": "Voir le simulateur",
+      "trust": {
+        "encrypted": "Données chiffrées en Belgique",
+        "noSale": "Aucune vente de données",
+        "languages": "FR · NL · EN"
+      },
+      "mockup": {
+        "eyebrow": "Aperçu cockpit",
+        "browserUrl": "Ankora · cockpit",
+        "kpis": {
+          "netRemaining": {
+            "label": "Net restant",
+            "sub": "avril · après provisions"
+          },
+          "provisions": {
+            "label": "Provisions",
+            "sub": "67 % des 2 480 € planifiés"
+          },
+          "reserve": {
+            "label": "Réserve",
+            "sub": "+120 € vs. mars"
+          }
+        }
+      },
+      "waterfall": {
+        "income": "Revenus",
+        "incomeAmount": "+2 466 €",
+        "expenses": "Dépenses courantes",
+        "expensesAmount": "−1 959 €",
+        "provisionsCaption": "dont {amount} € lissés vers provisions affectées",
+        "available": "Argent disponible",
+        "availableAmount": "+507 €",
+        "ariaLabel": "Cascade illustrative : 2 466 € de revenus, 1 959 € de dépenses courantes (dont 59 € lissés en provisions), 507 € disponibles."
+      }
     },
-    "income": {
-      "invalid": "Ingreso inválido.",
-      "negative": "Debe ser ≥ 0.",
-      "tooHigh": "Ingreso demasiado elevado."
+    "principles": {
+      "eyebrow": "Trois principes",
+      "h2": "Une façon honnête de parler d'argent.",
+      "description": "Ankora n'essaye pas de te vendre un placement ou une carte. On sépare, on projette, on simule. C'est tout. Toi seul décides.",
+      "items": {
+        "provisions": {
+          "title": "Provisions affectées",
+          "description": "Chaque euro réservé a un nom : mutuelle, taxe circulation, entretien chaudière. Rien ne fuit sans que tu le saches."
+        },
+        "reserve": {
+          "title": "Réserve libre",
+          "description": "Ce qui reste vraiment à toi, après les engagements. Le vrai chiffre — pas l'illusion du solde brut."
+        },
+        "whatIf": {
+          "title": "Simulateur what-if",
+          "description": "Renégocier l'électricité ? Changer de fournisseur ? Ankora te montre l'impact sur 12 mois avant que tu décides."
+        }
+      }
     },
-    "transfer": {
-      "invalid": "Importe inválido.",
-      "negative": "Debe ser ≥ 0.",
-      "tooHigh": "Importe demasiado elevado."
+    "feature": {
+      "eyebrow": "Cashflow waterfall",
+      "h3Line1": "Du salaire au net disponible.",
+      "h3Line2": "En un seul coup d'œil.",
+      "description": "Plus de mystère sur où va ton argent. Chaque étape est visible : revenus, dépenses courantes, argent disponible. Tu vois immédiatement si un poste dérape.",
+      "ctaPrimary": "Voir un exemple",
+      "ctaSecondary": "Comment ça marche ?"
+    },
+    "whatif": {
+      "title": "Et si tu changeais une seule chose ?",
+      "subtitle": "Bouge le curseur. Vois l'impact sur ta réserve libre, sur six mois. C'est ce que fait Ankora à chaque décision financière.",
+      "badge": "Démo · pas de compte requis",
+      "scenarios": {
+        "gsm": {
+          "label": "Renégocier mon GSM",
+          "hint": "Forfait actuel : 42 €/mois · marché : 18–28 €/mois"
+        },
+        "elec": {
+          "label": "Changer de fournisseur d'électricité",
+          "hint": "Conso actuelle : 168 €/mois · 3 offres moins chères dans ta zone"
+        },
+        "stream": {
+          "label": "Couper deux streamings",
+          "hint": "5 abonnements actifs · usage réel : 2 sur 30 jours"
+        }
+      },
+      "controls": {
+        "scenario": "Scénario",
+        "savings": "Économie mensuelle",
+        "slider_aria": "Économie mensuelle pour {label}"
+      },
+      "annual": {
+        "eyebrow": "Sur 12 mois",
+        "fleche": "Ankora pourrait flécher {amount} €/mois vers ton épargne longue."
+      },
+      "chart": {
+        "title": "Réserve libre · projection",
+        "subtitle": "6 mois à partir d'aujourd'hui",
+        "legend": {
+          "baseline": "Sans changement",
+          "scenario": "Avec ton choix"
+        },
+        "aria": "Graphique projection sur 6 mois de la réserve libre, avec et sans le changement choisi",
+        "months": {
+          "may": "mai",
+          "jun": "juin",
+          "jul": "juil",
+          "aug": "août",
+          "sep": "sept",
+          "oct": "oct"
+        },
+        "thresholds": {
+          "danger": "⚠️ Découvert estimé",
+          "fragile": "Zone fragile",
+          "comfortable": "Zone confortable"
+        }
+      },
+      "caveat": "Démo basée sur des hypothèses moyennes. Ankora ne fournit pas de conseil en placement. Aucun import bancaire — tu saisis tes charges manuellement."
+    },
+    "pricing": {
+      "eyebrow": "Transparent dès le départ",
+      "h2": "Gratuit pendant la Phase 1.",
+      "phaseBadge": "Phase 1 · construction",
+      "price": "0 €",
+      "period": "pour l'instant, et sans date limite",
+      "body": "On construit d'abord le cockpit. Pas de carte demandée, pas de limite de temps, pas de fonctionnalité bridée. Export RGPD à tout moment.",
+      "features": {
+        "cockpit": "Cockpit complet, provisions et réserve libre",
+        "simulator": "Simulateur what-if illimité",
+        "manualEntry": "Saisie manuelle · tes données restent en Belgique",
+        "export": "Export RGPD en un clic"
+      },
+      "ctaPrimary": "Ouvrir mon cockpit",
+      "roadmap": {
+        "title": "Tu rejoins Ankora pendant sa Phase 1 ?",
+        "body": "Ton compte garde un accès complet au cockpit core à vie, gratuitement. Une offre Pro avec features avancées (comptes illimités, exports consolidés, support prioritaire) arrivera post-v1.0 — tu auras le choix d'upgrader ou de rester sur ton plan actuel.",
+        "link": "Lire la roadmap →"
+      }
+    },
+    "footerCta": {
+      "h2Lead": "Commence par ce qui est",
+      "h2Highlight": "déjà à toi.",
+      "description": "30 jours d'essai, pas de carte, export RGPD à tout moment. On fait simple parce que c'est déjà assez compliqué comme ça.",
+      "ctaPrimary": "Ouvrir mon cockpit"
+    },
+    "footer": {
+      "links": {
+        "terms": "Conditions",
+        "privacy": "Confidentialité",
+        "security": "Sécurité",
+        "contact": "Contact"
+      },
+      "copyright": "Ankora · éditeur ancré à Bruxelles · 2026"
+    },
+    "faqHeading": "Preguntas frecuentes",
+    "faq": {
+      "advice": {
+        "q": "¿Ankora es una herramienta de asesoramiento financiero?",
+        "a": "No. Ankora es una herramienta de organización y educación presupuestaria. No proporciona recomendaciones de inversión ni asesoramiento financiero personalizado."
+      },
+      "storage": {
+        "q": "¿Dónde se almacenan mis datos?",
+        "a": "Tus datos están alojados en la Unión Europea (Supabase, región UE) con cifrado en reposo y aislamiento estricto por usuario mediante Row Level Security."
+      },
+      "sharing": {
+        "q": "¿Puedo compartir mis datos?",
+        "a": "Por defecto, tu espacio es 100 % privado. Los bolsillos compartidos opcionales (viaje, proyecto común) llegarán en una próxima versión — tú elegirás explícitamente qué compartes y con quién."
+      }
     }
-    },
-    "expense": {
-    "label": {
-      "required": "Etiqueta requerida.",
-      "tooLong": "Máximo 120 caracteres."
-    },
-    "amount": {
-      "invalid": "Importe inválido.",
-      "negative": "Debe ser ≥ 0.",
-      "tooHigh": "Importe demasiado elevado."
-    },
-    "date": {
-      "format": "Formato esperado: YYYY-MM-DD."
-    },
-    "category": {
-      "invalid": "Categoría inválida."
+  },
+  "faq": {
+    "metaTitle": "FAQ",
+    "metaDescription": "Preguntas frecuentes sobre Ankora: seguridad, datos, funcionamiento, privacidad.",
+    "title": "Preguntas frecuentes",
+    "subtitle": "Todo lo que necesitas saber sobre Ankora antes de empezar.",
+    "items": {
+      "bankConnection": {
+        "q": "¿Ankora se conecta a mi banco?",
+        "a": "No. Ankora no utiliza la directiva PSD2. Introduces manualmente tus gastos fijos y gastos. Esta elección garantiza que sigues siendo propietario de tus datos y que no se almacena ninguna información bancaria sensible."
+      },
+      "dataLocation": {
+        "q": "¿Dónde se alojan mis datos?",
+        "a": "Todos tus datos se alojan en la Unión Europea (Supabase región UE, Vercel región UE, Upstash UE). No se realiza ninguna transferencia fuera de la UE."
+      },
+      "smoothing": {
+        "q": "¿Cómo funciona la distribución?",
+        "a": "Ankora toma tus gastos fijos trimestrales, semestrales y anuales y los reparte en 12 meses. Así sabes cuánto apartar cada mes para cubrir todas tus futuras facturas sin estrés."
+      },
+      "deletion": {
+        "q": "¿Puedo eliminar mi cuenta?",
+        "a": "Sí, en cualquier momento desde Ajustes → Privacidad. La eliminación se hace efectiva 30 días después de tu solicitud (puedes cancelar durante ese periodo). Todos tus datos financieros se borran, los logs de seguridad se seudonimizan."
+      },
+      "export": {
+        "q": "¿Puedo exportar mis datos?",
+        "a": "Sí. El botón «Descargar mis datos» en Ajustes te proporciona un archivo JSON completo de todo lo que Ankora tiene sobre ti. Conforme al derecho de portabilidad RGPD (art. 20)."
+      },
+      "advice": {
+        "q": "¿Ankora da consejos financieros?",
+        "a": "No. Ankora es una herramienta de educación presupuestaria y organización. No emitimos ningún consejo de inversión (restricción regulatoria FSMA Bélgica). Para cualquier decisión de inversión, consulta a un profesional autorizado."
+      },
+      "ai": {
+        "q": "¿Hay inteligencia artificial?",
+        "a": "En la Fase 1, no. Los cálculos son deterministas y auditables. En la Fase 2, una capa opcional BYOK (Bring Your Own Key) te permitirá conectar tu propia clave Anthropic u OpenRouter para obtener sugerencias — sin coste adicional por parte de Ankora."
+      },
+      "sharing": {
+        "q": "¿Puedo compartir mi espacio con mis hijos o mis amigos?",
+        "a": "En la Fase 1, cada usuario tiene un espacio privado, aislado por defecto. En la Fase 2, añadiremos la posibilidad de crear «bolsillos compartidos» (por invitación, con roles viewer/editor) sin mezclar nunca tus datos personales."
+      }
     }
+  },
+  "legal": {
+    "versionLine": "Versión {version} — última actualización: {date}",
+    "lastUpdatedLine": "Última actualización: {date}",
+    "cgu": {
+      "metaTitle": "Condiciones generales de uso",
+      "metaDescription": "CGU de Ankora — reglas de uso del servicio.",
+      "title": "Condiciones generales de uso",
+      "s1": {
+        "heading": "1. Objeto",
+        "body": "Ankora es una herramienta de organización presupuestaria y educación financiera destinada a particulares. Permite introducir manualmente los gastos fijos y gastos, distribuirlos a lo largo del año y anticipar las necesidades de tesorería."
+      },
+      "s2": {
+        "heading": "2. Lo que Ankora NO es",
+        "item1": "Ankora <b>no es un servicio de asesoramiento de inversión</b> ni de inversiones.",
+        "item2": "Ankora <b>no es un servicio bancario</b> y no custodia ningún fondo.",
+        "item3": "Ankora <b>no es un agregador PSD2</b> — sin conexión a tus cuentas bancarias.",
+        "item4": "Ankora <b>no es un software de contabilidad profesional</b>.",
+        "outro": "La información mostrada son estimaciones basadas en tus datos. No constituyen asesoramiento financiero personalizado. Para cualquier decisión importante, consulta a un profesional autorizado."
+      },
+      "s3": {
+        "heading": "3. Cuenta",
+        "item1": "Debes ser mayor de edad o contar con la autorización de un representante legal.",
+        "item2": "Una sola cuenta por persona física.",
+        "item3": "Contraseña mínima de 12 caracteres, mixta.",
+        "item4": "Eres responsable de la confidencialidad de tus credenciales."
+      },
+      "s4": {
+        "heading": "4. Uso aceptable",
+        "intro": "Te comprometes a no:",
+        "item1": "utilizar el servicio con fines ilegales,",
+        "item2": "intentar eludir las medidas de seguridad,",
+        "item3": "automatizar el acceso sin autorización explícita,",
+        "item4": "compartir tu cuenta con un tercero."
+      },
+      "s5": {
+        "heading": "5. Propiedad intelectual",
+        "body": "Sigues siendo propietario de tus datos. Ankora conserva la propiedad de su código, marca, diseño y documentación."
+      },
+      "s6": {
+        "heading": "6. Responsabilidad",
+        "body": "Ankora se proporciona «tal cual». El editor no puede ser considerado responsable de las decisiones financieras tomadas en base a la información mostrada. No se garantiza una disponibilidad del 100 %."
+      },
+      "s7": {
+        "heading": "7. Resolución",
+        "body": "Puedes eliminar tu cuenta en cualquier momento desde Ajustes → Privacidad. La eliminación es efectiva 30 días tras la solicitud (periodo cancelable)."
+      },
+      "s8": {
+        "heading": "8. Ley aplicable",
+        "body": "Estas CGU están sujetas al derecho belga. Tribunal competente: Bruselas."
+      },
+      "draft": "Nuestras condiciones generales de uso están en proceso de redacción.",
+      "contact": "Para cualquier pregunta, contáctanos: thierryvm@gmail.com",
+      "backHome": "Volver al inicio"
+    },
+    "privacy": {
+      "metaTitle": "Política de privacidad",
+      "metaDescription": "Política de privacidad de Ankora — alojamiento UE, RGPD, derechos de los usuarios.",
+      "title": "Política de privacidad",
+      "s1": {
+        "heading": "1. Responsable del tratamiento",
+        "body": "Ankora, editado por Thierry Van Mele (Bélgica). Contacto: <mail>thierryvm@gmail.com</mail>."
+      },
+      "s2": {
+        "heading": "2. Datos recogidos",
+        "intro": "Ankora recoge únicamente los datos estrictamente necesarios para prestar el servicio:",
+        "item1": "<b>Identidad</b>: dirección de email, nombre para mostrar (opcional).",
+        "item2": "<b>Datos financieros introducidos por ti</b>: gastos fijos, gastos, categorías, ingresos declarados, saldo de ahorro.",
+        "item3": "<b>Datos técnicos</b>: dirección IP, user-agent (solo para logs de seguridad).",
+        "item4": "<b>Consentimientos</b>: marca temporal, versión, alcance (CGU, privacidad, cookies).",
+        "outro": "Ankora no se conecta a ningún banco (sin agregación PSD2). Tú mismo introduces tus gastos fijos y gastos."
+      },
+      "s3": {
+        "heading": "3. Bases legales (RGPD art. 6)",
+        "item1": "<b>Contrato</b>: prestación del servicio (cuenta, datos financieros).",
+        "item2": "<b>Consentimiento</b>: cookies analíticas/marketing, newsletter.",
+        "item3": "<b>Obligación legal</b>: logs de seguridad (conservación 12 meses).",
+        "item4": "<b>Interés legítimo</b>: prevención del fraude, mantenimiento de la seguridad."
+      },
+      "s4": {
+        "heading": "4. Alojamiento y subencargados",
+        "item1": "<b>Supabase</b> (base de datos, auth) — región UE (Fráncfort o París).",
+        "item2": "<b>Vercel</b> (alojamiento frontend) — región UE (Dublín).",
+        "item3": "<b>Upstash</b> (rate limiting) — región UE.",
+        "outro": "Ningún dato se transfiere fuera de la UE/EEE."
+      },
+      "s5": {
+        "heading": "5. Plazo de conservación",
+        "item1": "Cuenta activa: mientras utilices el servicio.",
+        "item2": "Cuenta eliminada: eliminación efectiva 30 días después de tu solicitud (periodo de gracia cancelable).",
+        "item3": "Logs de seguridad: 12 meses máximo, seudonimizados tras la eliminación de la cuenta."
+      },
+      "s6": {
+        "heading": "6. Tus derechos (RGPD art. 15-22)",
+        "item1": "<b>Acceso</b>: consulta tus datos en cualquier momento desde tu espacio.",
+        "item2": "<b>Rectificación</b>: modifica perfil y datos en las páginas dedicadas.",
+        "item3": "<b>Supresión</b>: botón «Eliminar mi cuenta» en Ajustes → Privacidad.",
+        "item4": "<b>Portabilidad</b>: botón «Descargar mis datos» — exportación JSON completa.",
+        "item5": "<b>Oposición / Limitación</b>: rechaza o retira los cookies no esenciales en cualquier momento.",
+        "item6": "<b>Reclamación</b>: ante la <apd>APD belga</apd> (Bélgica)."
+      },
+      "s7": {
+        "heading": "7. Seguridad",
+        "item1": "Cifrado en tránsito (TLS 1.3) y en reposo.",
+        "item2": "Row Level Security Supabase en todas las tablas.",
+        "item3": "Rate limiting, CSP estricta, audit log append-only.",
+        "item4": "Autenticación por contraseña fuerte + MFA disponible."
+      },
+      "s8": {
+        "heading": "8. Cookies",
+        "body": "Consulta la <link>política de cookies</link>."
+      },
+      "s9": {
+        "heading": "9. Modificaciones",
+        "body": "Toda modificación material de esta política se notifica por email y requiere tu consentimiento renovado para seguir utilizando el servicio."
+      },
+      "draft": "Nuestra política de privacidad está en proceso de redacción.",
+      "contact": "Para cualquier pregunta, contáctanos: thierryvm@gmail.com",
+      "backHome": "Volver al inicio"
+    },
+    "cookies": {
+      "metaTitle": "Política de cookies",
+      "metaDescription": "Política de cookies de Ankora — granularidad total, todo rechazable salvo los esenciales.",
+      "title": "Política de cookies",
+      "categoriesHeading": "Categorías",
+      "essentialHeading": "Esenciales (siempre activos)",
+      "essentialBody": "Indispensables para el funcionamiento: sesión de autenticación, preferencia de tema, anti-CSRF.",
+      "essentialItem1": "<code>sb-*</code> — sesión Supabase (auth)",
+      "essentialItem2": "<code>ankora-theme</code> — preferencia claro/oscuro",
+      "analyticsHeading": "Analíticos (desactivados por defecto)",
+      "analyticsBody1": "Únicamente si das tu consentimiento. Medida de uso agregada, sin identificador personal.",
+      "analyticsBody2": "Ankora no utiliza Google Analytics. Las métricas de Vercel están agregadas y anonimizadas.",
+      "marketingHeading": "Marketing (desactivados por defecto)",
+      "marketingBody": "Ankora no utiliza actualmente ningún cookie de marketing.",
+      "manageHeading": "Gestionar tus preferencias",
+      "manageBody1": "Puedes modificar tus consentimientos en cualquier momento desde <b>Ajustes → Privacidad</b> o pulsando «Gestionar cookies» en el pie de página.",
+      "manageBody2": "Rechazar los cookies no esenciales no degrada la experiencia: Ankora sigue siendo totalmente funcional.",
+      "lifetimeHeading": "Duración",
+      "lifetimeItem1": "Sesión: fin de la navegación",
+      "lifetimeItem2": "Preferencias: 12 meses",
+      "lifetimeItem3": "Analíticas: 6 meses (si se aceptan)",
+      "draft": "Esta página de política de cookies está en proceso de redacción.",
+      "contact": "Para cualquier pregunta, contáctanos: thierryvm@gmail.com",
+      "backHome": "Volver al inicio"
+    }
+  },
+  "offline": {
+    "metaTitle": "Sin conexión",
+    "metaDescription": "Actualmente estás sin conexión. Reconéctate para acceder a Ankora.",
+    "title": "Estás sin conexión",
+    "message": "Reconéctate para acceder a tu cockpit. Tus datos siguen intactos.",
+    "retry": "Reintentar"
+  },
+  "consent": {
+    "title": "Cookies y privacidad",
+    "body": "Solo usamos los cookies esenciales para conectarte. Los cookies de análisis están desactivados por defecto — puedes activarlos si quieres ayudarnos a mejorar Ankora. Puedes cambiar de opinión en cualquier momento desde <link>la política de cookies</link>.",
+    "essentialOnly": "Solo esenciales",
+    "acceptAnalytics": "Aceptar los análisis"
+  },
+  "footer": {
+    "copyright": "© {year} — Todos los derechos reservados",
+    "cgu": "CGU",
+    "privacy": "Privacidad",
+    "cookies": "Gestionar cookies",
+    "faq": "FAQ",
+    "copyrightNotice": "© {year} Ankora™. Todos los derechos reservados."
+  },
+  "auth": {
+    "login": {
+      "title": "Iniciar sesión",
+      "subtitle": "Recupera tu cockpit Ankora.",
+      "metaTitle": "Conexión",
+      "emailLabel": "Email",
+      "passwordLabel": "Contraseña",
+      "forgotLink": "¿Contraseña olvidada?",
+      "submit": "Iniciar sesión",
+      "submitting": "Conectando…",
+      "noAccount": "¿Aún no tienes cuenta?",
+      "signupLink": "Crear una cuenta",
+      "dividerOr": "o",
+      "dividerOrEmail": "o con tu email",
+      "passwordUpdatedBanner": "Contraseña actualizada. Ya puedes iniciar sesión."
+    },
+    "signup": {
+      "title": "Crear una cuenta",
+      "subtitle": "Lanza tu cockpit financiero en menos de 2 minutos.",
+      "pageTitle": "Crear mi cockpit",
+      "pageDescription": "Unos segundos. Sin tarjeta bancaria.",
+      "emailLabel": "Email",
+      "passwordLabel": "Contraseña",
+      "passwordHint": "Al menos 12 caracteres, 1 mayúscula, 1 minúscula, 1 cifra.",
+      "passwordConfirmLabel": "Confirmar la contraseña",
+      "acceptTosPrefix": "Acepto las",
+      "acceptTosLink": "CGU",
+      "acceptPrivacyPrefix": "Acepto la",
+      "acceptPrivacyLink": "política de privacidad",
+      "submit": "Crear mi cuenta",
+      "submitting": "Creando…",
+      "haveAccount": "¿Ya tienes cuenta?",
+      "loginLink": "Iniciar sesión",
+      "dividerOr": "o",
+      "dividerOrEmail": "o con tu email",
+      "googleCta": "Crear mi cuenta con Google",
+      "googleTerms": "Al continuar con Google, aceptas nuestras <cgu>CGU</cgu> y nuestra <privacy>política de privacidad</privacy>."
+    },
+    "forgot": {
+      "title": "Contraseña olvidada",
+      "subtitle": "Introduce tu email y te enviaremos un enlace seguro.",
+      "emailLabel": "Email",
+      "submit": "Enviar el enlace",
+      "submitting": "Enviando…",
+      "sentMessage": "Si este email existe, acaba de enviarse un enlace de restablecimiento.",
+      "backToLogin": "Volver al inicio de sesión"
+    },
+    "reset": {
+      "title": "Nueva contraseña",
+      "subtitle": "Elige una contraseña sólida para tu cuenta.",
+      "passwordLabel": "Nueva contraseña",
+      "passwordConfirmLabel": "Confirmar",
+      "submit": "Actualizar",
+      "submitting": "Actualizando…"
+    },
+    "google": {
+      "label": "Continuar con Google",
+      "redirecting": "Redirigiendo…"
+    },
+    "checkEmail": {
+      "title": "Comprueba tu bandeja de entrada",
+      "metaTitle": "Comprueba tu email",
+      "body": "Acabamos de enviarte un enlace de confirmación. Púlsalo para activar tu cuenta.",
+      "backToLogin": "Volver al inicio de sesión"
+    }
+  },
+  "onboarding": {
+    "defaultWorkspaceName": "Mi espacio",
+    "previous": "Volver",
+    "next": "Continuar",
+    "finish": "Terminar",
+    "finishing": "Guardando…",
+    "validation": {
+      "workspaceNameRequired": "Dale un nombre a tu espacio.",
+      "incomeInvalid": "Introduce un ingreso válido (≥ 0)."
+    },
+    "step1": {
+      "title": "Nombra tu espacio",
+      "description": "Podrás modificarlo más tarde en los ajustes.",
+      "nameLabel": "Nombre del espacio"
+    },
+    "step2": {
+      "title": "Tu ingreso neto mensual",
+      "description": "Sirve de base para sugerirte las transferencias mensuales.",
+      "incomeLabel": "Ingreso neto mensual (€)"
+    },
+    "step3": {
+      "title": "Tu primer gasto fijo (opcional)",
+      "description": "Añade un alquiler, un seguro, una suscripción…",
+      "labelLabel": "Etiqueta",
+      "labelPlaceholder": "Alquiler, seguro de coche…",
+      "amountLabel": "Importe (€)",
+      "frequencyLabel": "Frecuencia",
+      "dueMonthLabel": "Mes de referencia",
+      "skipLater": "Introduciré mis gastos fijos más tarde"
+    }
+  },
+  "app": {
+    "dashboard": {
+      "metaTitle": "Panel",
+      "headerTitle": "{month} — tu cockpit",
+      "emptyTitle": "Empieza añadiendo tus gastos fijos",
+      "emptyDescription": "Alquiler, seguros, suscripciones — Ankora los distribuye en 12 meses por ti.",
+      "emptyCta": "Añadir un gasto fijo",
+      "kpiProvisionsMonthly": "Reservas / mes",
+      "kpiProvisionsAnnualHint": "Anual: {amount}",
+      "kpiHealth": "Salud de reservas",
+      "kpiHealthTargetHint": "Objetivo: {amount}",
+      "kpiSuggestedTransfer": "Transferencia sugerida",
+      "kpiSuggestedTransferToSavings": "Para apartar",
+      "kpiSuggestedTransferFromSavings": "Para retirar del ahorro",
+      "kpiBillsMonth": "Facturas {month}",
+      "kpiBillsHint": "Salida de efectivo este mes",
+      "healthHealthy": "Sano",
+      "healthWarning": "A vigilar",
+      "healthCritical": "Crítico",
+      "planTitle": "Plan del mes — {month}",
+      "planDescription": "Las transferencias que ejecutar a principios de mes en tus tres cuentas.",
+      "planAdjustAccounts": "Ajustar mis cuentas",
+      "missingSetupTitle": "Configura primero tus cuentas",
+      "missingSetupDescription": "Para calcular tu Transferencia Inteligente, Ankora necesita tu ingreso mensual y el importe fijo que envías a Día a Día.",
+      "missingSetupCta": "Configurar mis cuentas",
+      "transferPrincipalToVieCourante": "Principal → Día a Día",
+      "transferVieCouranteHint": "Sobre compra, gasolina, restaurantes.",
+      "transferPrincipalToEpargne": "Principal → Ahorro",
+      "transferEpargneToPrincipal": "Ahorro → Principal",
+      "transferEpargneHint": "Reserva {provision} − facturas {bills}",
+      "transferPrincipalRemaining": "Restante en Principal",
+      "transferPrincipalRemainingHint": "Tras el salario, las transferencias y las facturas de Principal ({bills}).",
+      "ctaCharges": "Mis gastos fijos",
+      "ctaExpenses": "Mis gastos",
+      "ctaSimulator": "Simular",
+      "expensesTitle": "Gastos — {month}",
+      "expensesCount": "{count, plural, =0 {Sin gastos este mes} one {1 gasto este mes} other {# gastos este mes}}",
+      "expensesEmpty": "No hay gastos registrados este mes.",
+      "expensesViewAll": "Ver todos los gastos →"
+    },
+    "charges": {
+      "title": "Mis gastos fijos",
+      "subtitle": "Cada gasto fijo se distribuye automáticamente en 12 meses.",
+      "addFormTitle": "Añadir un gasto fijo",
+      "emptyState": "Ningún gasto fijo por ahora.",
+      "labelLabel": "Etiqueta",
+      "amountLabel": "Importe (€)",
+      "frequencyLabel": "Frecuencia",
+      "dueMonthLabel": "Mes de referencia",
+      "addButton": "Añadir",
+      "adding": "Añadiendo…",
+      "count": "{count, plural, =0 {ningún gasto fijo} one {1 gasto fijo} other {# gastos fijos}}",
+      "referenceFormat": "{frequency} · ref. {month}",
+      "deleteAria": "Eliminar {label}",
+      "toastCreated": "Gasto fijo añadido",
+      "toastDeleted": "Gasto fijo eliminado"
+    },
+    "accounts": {
+      "metaTitle": "Mis cuentas",
+      "metaDescription": "Sigue los saldos de tus cuentas Principal, Día a Día y Ahorro. Ajusta tu ingreso mensual y tu transferencia a Día a Día.",
+      "title": "Mis cuentas",
+      "subtitle": "Introduce tus saldos reales para que Ankora calcule con precisión tu transferencia inteligente cada mes.",
+      "balancesHeading": "Saldos actuales",
+      "amountLabel": "Importe (€)",
+      "saveButton": "Guardar",
+      "saving": "Guardando…",
+      "income": {
+        "title": "Ingreso neto mensual",
+        "description": "El salario que llega cada mes a tu cuenta Principal. Sirve para calcular lo que te queda tras los gastos fijos y la transferencia a Día a Día.",
+        "placeholder": "Ej. 2500",
+        "toastSaved": "Ingreso mensual actualizado"
+      },
+      "transfer": {
+        "title": "Transferencia mensual a Día a Día",
+        "description": "Suma fija transferida cada mes desde Principal a tu cuenta Día a Día. Es lo que se usará para la compra, la gasolina y los restaurantes.",
+        "placeholder": "Ej. 500",
+        "toastSaved": "Transferencia mensual actualizada"
+      },
+      "balance": {
+        "invalidAmount": "Introduce un importe válido.",
+        "saveLabel": "Actualizar",
+        "srLabel": "Saldo actual de {label}",
+        "toastSaved": "{name} actualizado"
+      },
+      "kind": {
+        "principal": {
+          "description": "Recibe el salario, paga los gastos fijos mensuales."
+        },
+        "vieCourante": {
+          "description": "Presupuesto del día a día (compra, gasolina, restaurantes)."
+        },
+        "epargne": {
+          "description": "Distribuye las facturas trimestrales y anuales."
+        }
+      },
+      "types": {
+        "income_bills": "Salary & Bills",
+        "provisions": "Annual Provisions",
+        "daily_card": "Groceries, Gas & Leisure"
+      },
+      "defaults": {
+        "income_bills": "Main Account",
+        "provisions": "Savings Account",
+        "daily_card": "Daily Card"
+      }
+    },
+    "expenses": {
+      "title": "Mis gastos",
+      "subtitle": "Las salidas fuera de los gastos fijos recurrentes — compra, restaurantes, ocio…",
+      "addFormTitle": "Añadir un gasto",
+      "labelLabel": "Etiqueta",
+      "amountLabel": "Importe (€)",
+      "dateLabel": "Fecha",
+      "addButton": "Añadir",
+      "adding": "Añadiendo…",
+      "emptyState": "Ningún gasto registrado.",
+      "summary": "{count, plural, =0 {Ningún gasto} one {1 gasto · {total}} other {# gastos · {total}}}",
+      "deleteAria": "Eliminar {label}",
+      "toastCreated": "Gasto añadido",
+      "toastDeleted": "Gasto eliminado"
     },
     "settings": {
-    "displayName": {
-      "required": "Nombre requerido.",
-      "tooLong": "Máximo 80 caracteres."
+      "metaTitle": "Ajustes",
+      "metaDescription": "Gestiona tu perfil, la seguridad 2FA y tus datos personales.",
+      "title": "Ajustes",
+      "description": "Perfil, seguridad y datos personales.",
+      "profile": {
+        "title": "Perfil",
+        "description": "Estos datos personalizan tu cockpit.",
+        "emailLabel": "Email",
+        "displayNameLabel": "Nombre para mostrar",
+        "localeLabel": "Idioma",
+        "localeOptions": {
+          "fr-BE": "Français (Belgique)",
+          "fr-FR": "Français (France)",
+          "en-GB": "English"
+        },
+        "submit": "Guardar",
+        "submitting": "Guardando…",
+        "toastSaved": "Perfil actualizado"
+      },
+      "mfa": {
+        "title": "Seguridad — 2FA",
+        "description": "Un código de un solo uso generado por una app de autenticación (Authy, 1Password, Google Authenticator).",
+        "emptyState": "Ningún factor 2FA activo. Actívalo para proteger tu cuenta.",
+        "enrollButton": "Activar la 2FA",
+        "enrolling": "Preparando…",
+        "scanInstruction": "Escanea este QR en tu app de autenticación, y luego introduce el código de 6 cifras.",
+        "qrAlt": "QR para la app de autenticación",
+        "manualEntry": "Entrada manual",
+        "codeLabel": "Código de 6 cifras",
+        "verifyButton": "Verificar y activar",
+        "verifying": "Verificando…",
+        "cancel": "Cancelar",
+        "defaultFactorName": "App TOTP",
+        "activeLabel": "Activo",
+        "disableButton": "Desactivar",
+        "toastEnabled": "MFA activado",
+        "toastDisabled": "MFA desactivado"
+      },
+      "data": {
+        "title": "Mis datos",
+        "description": "Portabilidad RGPD (art. 20) — descarga un JSON completo de todo lo que Ankora tiene sobre ti.",
+        "exportButton": "Descargar mis datos",
+        "exporting": "Generando…",
+        "toastDownloaded": "Exportación descargada"
+      },
+      "danger": {
+        "scheduledTitle": "Eliminación en curso",
+        "scheduledBody": "Tu cuenta se eliminará el <strong>{date}</strong>. Puedes cancelar en cualquier momento hasta entonces.",
+        "viewStatus": "Ver el estado",
+        "title": "Zona peligrosa",
+        "description": "Eliminación definitiva de la cuenta. 30 días de gracia para cancelar — después, todo se borra (logs de auditoría seudonimizados).",
+        "reasonLabel": "Motivo (opcional)",
+        "reasonPlaceholder": "Ayúdanos a mejorar…",
+        "confirmLabel": "Para confirmar, escribe tu dirección de e-mail: <code>{email}</code>",
+        "submit": "Eliminar mi cuenta",
+        "submitting": "Programando…",
+        "toastScheduled": "Eliminación programada — tienes 30 días para cancelar"
+      }
+    },
+    "simulator": {
+      "title": "Simulador",
+      "subtitle": "Mide el impacto de un cambio sin tocar tus datos reales.",
+      "scenario": {
+        "title": "Escenario",
+        "description": "Elige una acción a simular.",
+        "modes": {
+          "cancel": "Cancelar un gasto fijo",
+          "negotiate": "Renegociar",
+          "add": "Añadir un gasto fijo"
+        }
+      },
+      "fields": {
+        "charge": "Gasto fijo",
+        "chargePlaceholder": "Selecciona…",
+        "newAmount": "Nuevo importe (€)",
+        "label": "Etiqueta",
+        "amount": "Importe (€)",
+        "frequency": "Frecuencia",
+        "month": "Mes"
+      },
+      "impact": {
+        "title": "Impacto",
+        "empty": "Completa el escenario para ver el impacto.",
+        "currentMonthly": "Actual / mes",
+        "projectedMonthly": "Proyectado / mes",
+        "annualSavings": "Ahorro anual",
+        "monthlyChange": "{sign}{percent}% / mes"
+      }
+    },
+    "deletionStatus": {
+      "title": "Eliminación de la cuenta",
+      "subtitle": "Estado detallado de tu solicitud y periodo de cancelación.",
+      "metaTitle": "Estado de la eliminación",
+      "metaDescription": "Estado de la solicitud de eliminación de tu cuenta Ankora.",
+      "statusLabel": "Estado:",
+      "requestedOn": "Solicitada el {date}.",
+      "statusPending": "Pendiente",
+      "statusCancelled": "Cancelada",
+      "statusCompleted": "Completada",
+      "scheduledFor": "Eliminación prevista",
+      "daysLeft": "Días restantes",
+      "auditLogs": "Logs de auditoría",
+      "auditLogsValue": "Seudonimizados, nunca eliminados",
+      "daysCount": "{days, plural, =0 {Hoy} one {# día} other {# días}}",
+      "backToSettings": "Volver a los ajustes",
+      "cancelledOn": "Solicitud cancelada el {date}. Tu cuenta se conserva.",
+      "cancelledNoDate": "Solicitud cancelada. Tu cuenta se conserva.",
+      "cancelButton": "Cancelar la eliminación",
+      "cancelling": "Cancelando…",
+      "toastCancelled": "Solicitud cancelada — tu cuenta se conserva"
+    },
+    "cockpit": {
+      "capaciteEpargneReelle": {
+        "title": "Real Savings Capacity",
+        "messagePositive": "This is what you truly have left every month, with no surprises.",
+        "messageNegative": "Warning — your overall lifestyle exceeds your income.",
+        "tooltip": "This subtracts every charge (smoothed over the year) and your daily allowance from your monthly income. That is what is actually left for savings or unexpected expenses."
+      },
+      "santeProvisions": {
+        "title": "Provisions Health",
+        "cibleTheorique": "Ideal theoretical target:",
+        "soldeActuel": "Current balance:",
+        "statutAJour": "On track ✨",
+        "deficit": "Deficit detected:",
+        "rattrapageDescription": "Includes +{amount} € to recover the deficit over 3 months.",
+        "tooltip": "The algorithm computes how much your Savings account should hold today to absorb all upcoming periodic charges smoothly."
+      },
+      "virements": {
+        "title": "Transfer Assistant",
+        "provisionsMensuelles": "Monthly provisions:",
+        "facturesAnnuelles": "Periodic bills this month:",
+        "aVirer": "Transfer to Savings:",
+        "aRecuperer": "Pull from Savings:",
+        "aucun": "No transfer needed this month. Provisions exactly cover the periodic bills.",
+        "descriptionAVirer": "Covers your monthly provisions, minus the bills due this month.",
+        "descriptionDepuis": "This month’s periodic bills exceed your provision. Use your savings!",
+        "detailHeader": "Breakdown of the {amount} € provisions:"
+      },
+      "notifications": {
+        "transferToSavings": "Remember to transfer {amount} € to Savings this month.",
+        "transferFromSavings": "You need to pull {amount} € from Savings to cover this month’s bills.",
+        "chargeOverdue": "{label} is overdue (was due on {day}).",
+        "chargeDueSoon": "{label} due in {days} day(s)."
+      }
+    }
+  },
+  "glossary": {
+    "title": "Glossary",
+    "subtitle": "15 essential terms for understanding your budgeting and personal finances.",
+    "metaTitle": "Glossary — Financial Terms",
+    "metaDescription": "Glossary of 15 essential budgeting terms: smoothed budget, bucket account, emergency fund, and more.",
+    "breadcrumb": {
+      "home": "Home",
+      "glossary": "Glossary"
+    },
+    "section": {
+      "whyItMatters": "Why It Matters",
+      "example": "Concrete Example",
+      "relatedTerms": "Related Terms"
+    }
+  },
+  "errors": {
+    "generic": "Se ha producido un error. Reinténtalo.",
+    "session": {
+      "expired": "Sesión expirada. Vuelve a iniciar sesión.",
+      "rateLimited": "Demasiadas solicitudes. Espera un minuto."
+    },
+    "auth": {
+      "invalidCredentials": "Email o contraseña incorrectos.",
+      "signupFailed": "Registro imposible. Reinténtalo más tarde.",
+      "googleFailed": "Conexión con Google no disponible. Reinténtalo más tarde.",
+      "rateLimited": "Demasiados intentos. Reinténtalo en unos minutos.",
+      "serviceTemporarilyUnavailable": "Servicio temporalmente no disponible. Reinténtalo en unos minutos.",
+      "passwordResetFailed": "No se ha podido actualizar la contraseña.",
+      "linkExpired": "Enlace expirado. Solicita un nuevo enlace.",
+      "mfaEnrollFailed": "No se ha podido iniciar el registro.",
+      "mfaChallengeFailed": "Desafío MFA imposible.",
+      "mfaCodeInvalid": "Código incorrecto. Reinténtalo.",
+      "mfaDisableFailed": "No se ha podido desactivar la 2FA."
+    },
+    "db": {
+      "workspaceNotFound": "Ningún workspace editable.",
+      "updateFailed": "Actualización imposible.",
+      "notEditable": "No tienes permisos de edición en este espacio."
+    },
+    "validation": {
+      "generic": "Datos inválidos.",
+      "auth": {
+        "email": {
+          "invalid": "Dirección de email inválida."
+        },
+        "password": {
+          "required": "Contraseña requerida.",
+          "tooShort": "Al menos 12 caracteres.",
+          "tooLong": "Máximo 128 caracteres.",
+          "lowercase": "Al menos una minúscula.",
+          "uppercase": "Al menos una mayúscula.",
+          "digit": "Al menos una cifra."
+        },
+        "passwordConfirm": {
+          "mismatch": "Las contraseñas no coinciden."
+        },
+        "acceptTos": {
+          "required": "Debes aceptar las CGU."
+        },
+        "acceptPrivacy": {
+          "required": "Debes aceptar la política de privacidad."
+        }
+      },
+      "charge": {
+        "label": {
+          "required": "Etiqueta requerida.",
+          "tooLong": "Máximo 120 caracteres."
+        },
+        "amount": {
+          "invalid": "Importe inválido.",
+          "negative": "El importe debe ser ≥ 0.",
+          "tooHigh": "Importe demasiado elevado."
+        },
+        "frequency": {
+          "invalid": "Frecuencia inválida."
+        },
+        "dueMonth": {
+          "range": "Mes entre 1 y 12."
+        },
+        "paidFrom": {
+          "invalid": "Cuenta de cargo inválida."
+        }
+      },
+      "account": {
+        "kind": {
+          "invalid": "Tipo de cuenta inválido."
+        },
+        "balance": {
+          "invalid": "Saldo inválido.",
+          "outOfRange": "Valor fuera de los límites."
+        },
+        "label": {
+          "required": "Etiqueta requerida.",
+          "tooLong": "Máximo 80 caracteres."
+        }
+      },
+      "workspace": {
+        "name": {
+          "required": "Nombre requerido.",
+          "tooLong": "Máximo 80 caracteres."
+        },
+        "income": {
+          "invalid": "Ingreso inválido.",
+          "negative": "Debe ser ≥ 0.",
+          "tooHigh": "Ingreso demasiado elevado."
+        },
+        "transfer": {
+          "invalid": "Importe inválido.",
+          "negative": "Debe ser ≥ 0.",
+          "tooHigh": "Importe demasiado elevado."
+        }
+      },
+      "expense": {
+        "label": {
+          "required": "Etiqueta requerida.",
+          "tooLong": "Máximo 120 caracteres."
+        },
+        "amount": {
+          "invalid": "Importe inválido.",
+          "negative": "Debe ser ≥ 0.",
+          "tooHigh": "Importe demasiado elevado."
+        },
+        "date": {
+          "format": "Formato esperado: YYYY-MM-DD."
+        },
+        "category": {
+          "invalid": "Categoría inválida."
+        }
+      },
+      "settings": {
+        "displayName": {
+          "required": "Nombre requerido.",
+          "tooLong": "Máximo 80 caracteres."
+        },
+        "locale": {
+          "invalid": "Idioma inválido."
+        },
+        "factorId": {
+          "invalid": "Identificador inválido."
+        },
+        "mfaCode": {
+          "invalid": "Código de 6 cifras."
+        },
+        "deletion": {
+          "confirm": "Esta dirección no coincide con tu cuenta."
+        }
+      },
+      "onboarding": {
+        "workspace": {
+          "required": "Nombre requerido.",
+          "tooLong": "Máximo 80 caracteres."
+        },
+        "income": {
+          "invalid": "Ingreso inválido.",
+          "negative": "Debe ser ≥ 0.",
+          "tooHigh": "Ingreso demasiado elevado."
+        },
+        "firstCharge": {
+          "label": {
+            "required": "Etiqueta requerida.",
+            "tooLong": "Máximo 120 caracteres."
+          },
+          "amount": {
+            "invalid": "Importe inválido.",
+            "negative": "Debe ser ≥ 0.",
+            "tooHigh": "Importe demasiado elevado."
+          },
+          "dueMonth": {
+            "range": "Mes entre 1 y 12."
+          }
+        }
+      }
+    },
+    "charges": {
+      "createFailed": "No se ha podido crear el gasto fijo.",
+      "updateFailed": "No se ha podido actualizar el gasto fijo.",
+      "deleteFailed": "No se ha podido eliminar el gasto fijo."
+    },
+    "accounts": {
+      "balanceUpdateFailed": "No se ha podido actualizar el saldo.",
+      "renameFailed": "No se ha podido renombrar la cuenta.",
+      "incomeUpdateFailed": "No se ha podido actualizar el ingreso.",
+      "transferUpdateFailed": "No se ha podido actualizar la transferencia."
+    },
+    "expenses": {
+      "createFailed": "No se ha podido crear el gasto.",
+      "deleteFailed": "No se ha podido eliminar el gasto."
+    },
+    "settings": {
+      "profileUpdateFailed": "No se ha podido actualizar el perfil.",
+      "deletionRequestFailed": "No se ha podido programar la eliminación.",
+      "deletionCancelFailed": "No se ha podido cancelar la solicitud.",
+      "exportLimited": "Exportación limitada a una vez cada 5 minutos."
+    },
+    "onboarding": {
+      "workspaceNotFound": "Workspace no encontrado. Contacta con el soporte.",
+      "workspaceUpdateFailed": "No se ha podido actualizar el workspace.",
+      "chargeFailed": "Workspace creado pero gasto fijo no registrado."
     },
     "locale": {
       "invalid": "Idioma inválido."
-    },
-    "factorId": {
-      "invalid": "Identificador inválido."
-    },
-    "mfaCode": {
-      "invalid": "Código de 6 cifras."
-    },
-    "deletion": {
-      "confirm": "Esta dirección no coincide con tu cuenta."
     }
-    },
-    "onboarding": {
-    "workspace": {
-      "required": "Nombre requerido.",
-      "tooLong": "Máximo 80 caracteres."
-    },
-    "income": {
-      "invalid": "Ingreso inválido.",
-      "negative": "Debe ser ≥ 0.",
-      "tooHigh": "Ingreso demasiado elevado."
-    },
-    "firstCharge": {
-      "label": {
-      "required": "Etiqueta requerida.",
-      "tooLong": "Máximo 120 caracteres."
-      },
-      "amount": {
-      "invalid": "Importe inválido.",
-      "negative": "Debe ser ≥ 0.",
-      "tooHigh": "Importe demasiado elevado."
-      },
-      "dueMonth": {
-      "range": "Mes entre 1 y 12."
-      }
-    }
-    }
-  },
-  "charges": {
-    "createFailed": "No se ha podido crear el gasto fijo.",
-    "updateFailed": "No se ha podido actualizar el gasto fijo.",
-    "deleteFailed": "No se ha podido eliminar el gasto fijo."
-  },
-  "accounts": {
-    "balanceUpdateFailed": "No se ha podido actualizar el saldo.",
-    "renameFailed": "No se ha podido renombrar la cuenta.",
-    "incomeUpdateFailed": "No se ha podido actualizar el ingreso.",
-    "transferUpdateFailed": "No se ha podido actualizar la transferencia."
-  },
-  "expenses": {
-    "createFailed": "No se ha podido crear el gasto.",
-    "deleteFailed": "No se ha podido eliminar el gasto."
-  },
-  "settings": {
-    "profileUpdateFailed": "No se ha podido actualizar el perfil.",
-    "deletionRequestFailed": "No se ha podido programar la eliminación.",
-    "deletionCancelFailed": "No se ha podido cancelar la solicitud.",
-    "exportLimited": "Exportación limitada a una vez cada 5 minutos."
-  },
-  "onboarding": {
-    "workspaceNotFound": "Workspace no encontrado. Contacta con el soporte.",
-    "workspaceUpdateFailed": "No se ha podido actualizar el workspace.",
-    "chargeFailed": "Workspace creado pero gasto fijo no registrado."
-  },
-  "locale": {
-    "invalid": "Idioma inválido."
-  }
   },
   "opengraphImage": {
-  "trustHosting": "🇧🇪 Bélgica · Alojado en UE",
-  "trustNoBank": "Sin agregación bancaria",
-  "trustFree": "0 € Fase 1"
+    "trustHosting": "🇧🇪 Bélgica · Alojado en UE",
+    "trustNoBank": "Sin agregación bancaria",
+    "trustFree": "0 € Fase 1"
   }
 }

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -1,1024 +1,1068 @@
 {
   "common": {
-  "appName": "Ankora",
-  "tagline": "Ton ancrage financier",
-  "description": "Ankora t'aide à lisser tes charges, anticiper chaque facture et garder le contrôle de ton budget. Cockpit clair et sécurisé, sans conseils en placement.",
-  "homeAria": "Accueil Ankora",
-  "a11y": {
-    "skipToMain": "Aller au contenu principal"
-  },
-  "nav": {
-    "mainLabel": "Navigation principale",
-    "appLabel": "Navigation application",
-    "mobileLabel": "Navigation mobile",
-    "footerLabel": "Pied de page",
-    "menu": "Menu",
-    "close": "Fermer",
-    "lightMode": "Mode clair",
-    "darkMode": "Mode sombre",
-    "features": "Fonctionnalités",
-    "faq": "FAQ",
-    "login": "Se connecter",
-    "signup": "Créer un compte",
-    "myCockpit": "Mon cockpit",
-    "dashboard": "Tableau de bord",
-    "accounts": "Comptes",
-    "charges": "Charges",
-    "settings": "Paramètres"
-  },
-  "actions": {
-    "retry": "Réessayer",
-    "back": "Retour"
-  },
-  "months": {
-    "1": "janvier",
-    "2": "février",
-    "3": "mars",
-    "4": "avril",
-    "5": "mai",
-    "6": "juin",
-    "7": "juillet",
-    "8": "août",
-    "9": "septembre",
-    "10": "octobre",
-    "11": "novembre",
-    "12": "décembre"
-  },
-  "monthsShort": {
-    "1": "janv.",
-    "2": "févr.",
-    "3": "mars",
-    "4": "avr.",
-    "5": "mai",
-    "6": "juin",
-    "7": "juil.",
-    "8": "août",
-    "9": "sept.",
-    "10": "oct.",
-    "11": "nov.",
-    "12": "déc."
-  },
-  "frequency": {
-    "monthly": "Mensuel",
-    "quarterly": "Trimestriel",
-    "semiannual": "Semestriel",
-    "annual": "Annuel"
-  }
-  },
-  "ui": {
-  "scrollToTop": "Remonter en haut de la page",
-  "localeSwitcher": {
-    "label": "Langue",
-    "aria": "Changer de langue",
-    "options": {
-    "fr-BE": "Français (BE)",
-    "nl-BE": "Nederlands (BE)",
-    "en": "English",
-    "es-ES": "Español",
-    "de-DE": "Deutsch"
-    }
-  },
-  "action": {
-    "submit": "Valider",
-    "submitting": "Validation…",
-    "save": "Enregistrer",
-    "saving": "Enregistrement…",
-    "cancel": "Annuler",
-    "cancelling": "Annulation…",
-    "delete": "Supprimer",
-    "deleting": "Suppression…",
-    "create": "Créer",
-    "creating": "Création…",
-    "update": "Mettre à jour",
-    "updating": "Mise à jour…",
-    "send": "Envoyer",
-    "sending": "Envoi…",
-    "verify": "Vérifier",
-    "verifying": "Vérification…",
-    "generate": "Générer",
-    "generating": "Génération…",
-    "download": "Télécharger",
-    "downloading": "Téléchargement…",
-    "preparing": "Préparation…",
-    "confirm": "Confirmer",
-    "close": "Fermer"
-  }
-  },
-  "landing": {
-  "mktnav": {
-    "links": {
-    "product": "Produit",
-    "simulator": "Simulateur",
-    "pricing": "Tarifs",
-    "security": "Sécurité",
-    "journal": "Journal"
+    "appName": "Ankora",
+    "tagline": "Ton ancrage financier",
+    "description": "Ankora t'aide à lisser tes charges, anticiper chaque facture et garder le contrôle de ton budget. Cockpit clair et sécurisé, sans conseils en placement.",
+    "homeAria": "Accueil Ankora",
+    "a11y": {
+      "skipToMain": "Aller au contenu principal"
     },
-    "ctaLogin": "Se connecter",
-    "ctaSignup": "Essayer gratuitement"
-  },
-  "hero": {
-    "badge": "Nouveau · Simulateur what-if",
-    "h1Lead": "Ton ancrage",
-    "h1Highlight": "financier.",
-    "description": "Ankora sépare tes provisions affectées de ta réserve libre, projette six mois devant, et te laisse simuler l'impact de chaque décision — en clair, sans jargon.",
-    "ctaPrimary": "Ouvrir mon cockpit",
-    "ctaSecondary": "Voir le simulateur",
-    "trust": {
-    "encrypted": "Données chiffrées en Belgique",
-    "noSale": "Aucune vente de données",
-    "languages": "FR · NL · EN"
+    "nav": {
+      "mainLabel": "Navigation principale",
+      "appLabel": "Navigation application",
+      "mobileLabel": "Navigation mobile",
+      "footerLabel": "Pied de page",
+      "menu": "Menu",
+      "close": "Fermer",
+      "lightMode": "Mode clair",
+      "darkMode": "Mode sombre",
+      "features": "Fonctionnalités",
+      "faq": "FAQ",
+      "login": "Se connecter",
+      "signup": "Créer un compte",
+      "myCockpit": "Mon cockpit",
+      "dashboard": "Tableau de bord",
+      "accounts": "Comptes",
+      "charges": "Charges",
+      "settings": "Paramètres"
     },
-    "mockup": {
-    "eyebrow": "Aperçu cockpit",
-    "browserUrl": "Ankora · cockpit",
-    "kpis": {
-      "netRemaining": {
-      "label": "Net restant",
-      "sub": "avril · après provisions"
-      },
-      "provisions": {
-      "label": "Provisions",
-      "sub": "67 % des 2 480 € planifiés"
-      },
-      "reserve": {
-      "label": "Réserve",
-      "sub": "+120 € vs. mars"
-      }
-    }
+    "actions": {
+      "retry": "Réessayer",
+      "back": "Retour"
     },
-    "waterfall": {
-    "income": "Revenus",
-    "incomeAmount": "+2 466 €",
-    "expenses": "Dépenses courantes",
-    "expensesAmount": "−1 959 €",
-    "provisionsCaption": "dont {amount} € lissés vers provisions affectées",
-    "available": "Argent disponible",
-    "availableAmount": "+507 €",
-    "ariaLabel": "Cascade illustrative : 2 466 € de revenus, 1 959 € de dépenses courantes (dont 59 € lissés en provisions), 507 € disponibles."
-    }
-  },
-  "principles": {
-    "eyebrow": "Trois principes",
-    "h2": "Une façon honnête de parler d'argent.",
-    "description": "Ankora n'essaye pas de te vendre un placement ou une carte. On sépare, on projette, on simule. C'est tout. Toi seul décides.",
-    "items": {
-    "provisions": {
-      "title": "Provisions affectées",
-      "description": "Chaque euro réservé a un nom : mutuelle, taxe circulation, entretien chaudière. Rien ne fuit sans que tu le saches."
-    },
-    "reserve": {
-      "title": "Réserve libre",
-      "description": "Ce qui reste vraiment à toi, après les engagements. Le vrai chiffre — pas l'illusion du solde brut."
-    },
-    "whatIf": {
-      "title": "Simulateur what-if",
-      "description": "Renégocier l'électricité ? Changer de fournisseur ? Ankora te montre l'impact sur 12 mois avant que tu décides."
-    }
-    }
-  },
-  "feature": {
-    "eyebrow": "Cashflow waterfall",
-    "h3Line1": "Du salaire au net disponible.",
-    "h3Line2": "En un seul coup d'œil.",
-    "description": "Plus de mystère sur où va ton argent. Chaque étape est visible : revenus, dépenses courantes, argent disponible. Tu vois immédiatement si un poste dérape.",
-    "ctaPrimary": "Voir un exemple",
-    "ctaSecondary": "Comment ça marche ?"
-  },
-  "whatif": {
-    "title": "Et si tu changeais une seule chose ?",
-    "subtitle": "Bouge le curseur. Vois l'impact sur ta réserve libre, sur six mois. C'est ce que fait Ankora à chaque décision financière.",
-    "badge": "Démo · pas de compte requis",
-    "scenarios": {
-    "gsm": {
-      "label": "Renégocier mon GSM",
-      "hint": "Forfait actuel : 42 €/mois · marché : 18–28 €/mois"
-    },
-    "elec": {
-      "label": "Changer de fournisseur d'électricité",
-      "hint": "Conso actuelle : 168 €/mois · 3 offres moins chères dans ta zone"
-    },
-    "stream": {
-      "label": "Couper deux streamings",
-      "hint": "5 abonnements actifs · usage réel : 2 sur 30 jours"
-    }
-    },
-    "controls": {
-    "scenario": "Scénario",
-    "savings": "Économie mensuelle",
-    "slider_aria": "Économie mensuelle pour {label}"
-    },
-    "annual": {
-    "eyebrow": "Sur 12 mois",
-    "fleche": "Ankora pourrait flécher {amount} €/mois vers ton épargne longue."
-    },
-    "chart": {
-    "title": "Réserve libre · projection",
-    "subtitle": "6 mois à partir d'aujourd'hui",
-    "legend": {
-      "baseline": "Sans changement",
-      "scenario": "Avec ton choix"
-    },
-    "aria": "Graphique projection sur 6 mois de la réserve libre, avec et sans le changement choisi",
     "months": {
-      "may": "mai",
-      "jun": "juin",
-      "jul": "juil",
-      "aug": "août",
-      "sep": "sept",
-      "oct": "oct"
+      "1": "janvier",
+      "2": "février",
+      "3": "mars",
+      "4": "avril",
+      "5": "mai",
+      "6": "juin",
+      "7": "juillet",
+      "8": "août",
+      "9": "septembre",
+      "10": "octobre",
+      "11": "novembre",
+      "12": "décembre"
     },
-    "thresholds": {
-      "danger": "⚠️ Découvert estimé",
-      "fragile": "Zone fragile",
-      "comfortable": "Zone confortable"
-    }
-    },
-    "caveat": "Démo basée sur des hypothèses moyennes. Ankora ne fournit pas de conseil en placement. Aucun import bancaire — tu saisis tes charges manuellement."
-  },
-  "pricing": {
-    "eyebrow": "Transparent dès le départ",
-    "h2": "Gratuit pendant la Phase 1.",
-    "phaseBadge": "Phase 1 · construction",
-    "price": "0 €",
-    "period": "pour l'instant, et sans date limite",
-    "body": "On construit d'abord le cockpit. Pas de carte demandée, pas de limite de temps, pas de fonctionnalité bridée. Export RGPD à tout moment.",
-    "features": {
-    "cockpit": "Cockpit complet, provisions et réserve libre",
-    "simulator": "Simulateur what-if illimité",
-    "manualEntry": "Saisie manuelle · tes données restent en Belgique",
-    "export": "Export RGPD en un clic"
-    },
-    "ctaPrimary": "Ouvrir mon cockpit",
-    "roadmap": {
-    "title": "Tu rejoins Ankora pendant sa Phase 1 ?",
-    "body": "Ton compte garde un accès complet au cockpit core à vie, gratuitement. Une offre Pro avec features avancées (comptes illimités, exports consolidés, support prioritaire) arrivera post-v1.0 — tu auras le choix d'upgrader ou de rester sur ton plan actuel.",
-    "link": "Lire la roadmap →"
-    }
-  },
-  "footerCta": {
-    "h2Lead": "Commence par ce qui est",
-    "h2Highlight": "déjà à toi.",
-    "description": "30 jours d'essai, pas de carte, export RGPD à tout moment. On fait simple parce que c'est déjà assez compliqué comme ça.",
-    "ctaPrimary": "Ouvrir mon cockpit"
-  },
-  "footer": {
-    "links": {
-    "terms": "Conditions",
-    "privacy": "Confidentialité",
-    "security": "Sécurité",
-    "contact": "Contact"
-    },
-    "copyright": "Ankora · éditeur ancré à Bruxelles · 2026"
-  },
-  "faqHeading": "Questions fréquentes",
-  "faq": {
-    "advice": {
-    "q": "Ankora est-il un outil de conseil financier ?",
-    "a": "Non. Ankora est un outil d'organisation et d'éducation budgétaire. Il ne fournit pas de recommandations de placement ni de conseil financier personnalisé."
-    },
-    "storage": {
-    "q": "Où sont stockées mes données ?",
-    "a": "Tes données sont hébergées en Union européenne (Supabase, région UE) avec chiffrement au repos et isolation stricte par utilisateur via Row Level Security."
-    },
-    "sharing": {
-    "q": "Est-ce que je peux partager mes données ?",
-    "a": "Par défaut, ton espace est 100 % privé. Des pots partagés optionnels (voyage, projet commun) arriveront dans une prochaine version — tu choisiras explicitement ce que tu partages, et avec qui."
-    }
-  }
-  },
-  "faq": {
-  "metaTitle": "FAQ",
-  "metaDescription": "Questions fréquentes sur Ankora : sécurité, données, fonctionnement, confidentialité.",
-  "title": "Questions fréquentes",
-  "subtitle": "Tout ce qu'il faut savoir sur Ankora avant de se lancer.",
-  "items": {
-    "bankConnection": {
-    "q": "Est-ce qu'Ankora se connecte à ma banque ?",
-    "a": "Non. Ankora n'utilise pas la directive PSD2. Tu saisis manuellement tes charges et dépenses. Ce choix garantit que tu restes propriétaire de tes données et qu'aucune information bancaire sensible n'est stockée."
-    },
-    "dataLocation": {
-    "q": "Où sont hébergées mes données ?",
-    "a": "Toutes tes données sont hébergées dans l'Union européenne (Supabase région UE, Vercel région UE, Upstash UE). Aucun transfert hors UE n'est effectué."
-    },
-    "smoothing": {
-    "q": "Comment fonctionne le lissage ?",
-    "a": "Ankora prend tes charges trimestrielles, semestrielles et annuelles et les répartit sur 12 mois. Tu sais ainsi combien mettre de côté chaque mois pour couvrir toutes tes futures factures sans stress."
-    },
-    "deletion": {
-    "q": "Puis-je supprimer mon compte ?",
-    "a": "Oui, à tout moment depuis Paramètres → Confidentialité. La suppression prend effet 30 jours après ta demande (tu peux annuler pendant cette période). Toutes tes données financières sont effacées, les logs de sécurité sont pseudonymisés."
-    },
-    "export": {
-    "q": "Puis-je exporter mes données ?",
-    "a": "Oui. Le bouton « Télécharger mes données » dans Paramètres te fournit un fichier JSON complet de tout ce qu'Ankora détient sur toi. Conforme au droit de portabilité RGPD (art. 20)."
-    },
-    "advice": {
-    "q": "Est-ce qu'Ankora donne des conseils financiers ?",
-    "a": "Non. Ankora est un outil d'éducation budgétaire et d'organisation. Nous n'émettons aucun conseil en placement (contrainte réglementaire FSMA Belgique). Pour toute décision d'investissement, consulte un professionnel agréé."
-    },
-    "ai": {
-    "q": "Y a-t-il de l'intelligence artificielle ?",
-    "a": "En Phase 1, non. Les calculs sont déterministes et auditables. En Phase 2, une couche optionnelle BYOK (Bring Your Own Key) te permettra de connecter ta propre clé Anthropic ou OpenRouter pour des suggestions — aucun surcoût côté Ankora."
-    },
-    "sharing": {
-    "q": "Puis-je partager mon espace avec mes enfants ou mes amis ?",
-    "a": "En Phase 1, chaque utilisateur a un espace privé, isolé par défaut. En Phase 2, nous ajouterons la possibilité de créer des « pots partagés » (par invitation, avec rôles viewer/editor) sans jamais mélanger tes données personnelles."
-    }
-  }
-  },
-  "legal": {
-  "versionLine": "Version {version} — dernière mise à jour : {date}",
-  "lastUpdatedLine": "Dernière mise à jour : {date}",
-  "cgu": {
-    "metaTitle": "Conditions générales d'utilisation",
-    "metaDescription": "CGU de Ankora — règles d'utilisation du service.",
-    "title": "Conditions générales d'utilisation",
-    "s1": {
-    "heading": "1. Objet",
-    "body": "Ankora est un outil d'organisation budgétaire et d'éducation financière destiné aux particuliers. Il permet de saisir manuellement ses charges et dépenses, de les lisser sur l'année, et d'anticiper les besoins de trésorerie."
-    },
-    "s2": {
-    "heading": "2. Ce que Ankora n'est PAS",
-    "item1": "Ankora n'est <b>pas un service de conseil en placement</b> ni en investissement.",
-    "item2": "Ankora n'est <b>pas un service bancaire</b> et ne détient aucun fonds.",
-    "item3": "Ankora n'est <b>pas un agrégateur PSD2</b> — aucune connexion à tes comptes bancaires.",
-    "item4": "Ankora n'est <b>pas un logiciel de comptabilité professionnelle</b>.",
-    "outro": "Les informations affichées sont des estimations basées sur tes saisies. Elles ne constituent pas un conseil financier personnalisé. Pour toute décision importante, consulte un professionnel agréé."
-    },
-    "s3": {
-    "heading": "3. Compte",
-    "item1": "Tu dois être majeur ou avoir l'autorisation d'un représentant légal.",
-    "item2": "Un seul compte par personne physique.",
-    "item3": "Mot de passe minimum 12 caractères, mixte.",
-    "item4": "Tu es responsable de la confidentialité de tes identifiants."
-    },
-    "s4": {
-    "heading": "4. Usage acceptable",
-    "intro": "Tu t'engages à ne pas :",
-    "item1": "utiliser le service à des fins illégales,",
-    "item2": "tenter de contourner les mesures de sécurité,",
-    "item3": "automatiser l'accès sans autorisation explicite,",
-    "item4": "partager ton compte avec un tiers."
-    },
-    "s5": {
-    "heading": "5. Propriété intellectuelle",
-    "body": "Tu restes propriétaire de tes données. Ankora conserve la propriété de son code, marque, design et documentation."
-    },
-    "s6": {
-    "heading": "6. Responsabilité",
-    "body": "Ankora est fourni « tel quel ». L'éditeur ne saurait être tenu responsable des décisions financières prises sur base des informations affichées. Aucune garantie de disponibilité à 100%."
-    },
-    "s7": {
-    "heading": "7. Résiliation",
-    "body": "Tu peux supprimer ton compte à tout moment depuis Paramètres → Confidentialité. La suppression est effective 30 jours après la demande (période annulable)."
-    },
-    "s8": {
-    "heading": "8. Droit applicable",
-    "body": "Ces CGU sont soumises au droit belge. Tribunal compétent : Bruxelles."
-    },
-    "draft": "Nos conditions générales d'utilisation sont en cours de rédaction.",
-    "contact": "Pour toute question, contacte-nous : thierryvm@gmail.com",
-    "backHome": "Retour à l'accueil"
-  },
-  "privacy": {
-    "metaTitle": "Politique de confidentialité",
-    "metaDescription": "Politique de confidentialité de Ankora — hébergement UE, RGPD, droits des utilisateurs.",
-    "title": "Politique de confidentialité",
-    "s1": {
-    "heading": "1. Responsable de traitement",
-    "body": "Ankora, édité par Thierry Van Mele (Belgique). Contact : <mail>thierryvm@gmail.com</mail>."
-    },
-    "s2": {
-    "heading": "2. Données collectées",
-    "intro": "Ankora collecte uniquement les données strictement nécessaires à la fourniture du service :",
-    "item1": "<b>Identité</b> : adresse email, nom d'affichage (optionnel).",
-    "item2": "<b>Données financières saisies par toi</b> : charges, dépenses, catégories, revenus déclarés, solde d'épargne.",
-    "item3": "<b>Données techniques</b> : adresse IP, user-agent (pour les logs de sécurité uniquement).",
-    "item4": "<b>Consentements</b> : horodatage, version, portée (CGU, confidentialité, cookies).",
-    "outro": "Ankora ne se connecte à aucune banque (pas d'agrégation PSD2). Tu saisis toi-même tes charges et dépenses."
-    },
-    "s3": {
-    "heading": "3. Bases légales (RGPD art. 6)",
-    "item1": "<b>Contrat</b> : fourniture du service (compte, données financières).",
-    "item2": "<b>Consentement</b> : cookies analytics/marketing, newsletter.",
-    "item3": "<b>Obligation légale</b> : logs de sécurité (conservation 12 mois).",
-    "item4": "<b>Intérêt légitime</b> : prévention fraude, maintien de la sécurité."
-    },
-    "s4": {
-    "heading": "4. Hébergement et sous-traitants",
-    "item1": "<b>Supabase</b> (base de données, auth) — région UE (Francfort ou Paris).",
-    "item2": "<b>Vercel</b> (hébergement frontend) — région UE (Dublin).",
-    "item3": "<b>Upstash</b> (rate limiting) — région UE.",
-    "outro": "Aucune donnée n'est transférée hors UE/EEE."
-    },
-    "s5": {
-    "heading": "5. Durée de conservation",
-    "item1": "Compte actif : tant que tu utilises le service.",
-    "item2": "Compte supprimé : suppression effective 30 jours après ta demande (grace period annulable).",
-    "item3": "Logs de sécurité : 12 mois maximum, pseudonymisés après suppression du compte."
-    },
-    "s6": {
-    "heading": "6. Tes droits (RGPD art. 15-22)",
-    "item1": "<b>Accès</b> : consulte tes données à tout moment dans ton espace.",
-    "item2": "<b>Rectification</b> : modifie profil et données dans les pages dédiées.",
-    "item3": "<b>Effacement</b> : bouton « Supprimer mon compte » dans Paramètres → Confidentialité.",
-    "item4": "<b>Portabilité</b> : bouton « Télécharger mes données » — export JSON complet.",
-    "item5": "<b>Opposition / Restriction</b> : refuse ou retire les cookies non essentiels à tout moment.",
-    "item6": "<b>Plainte</b> : auprès de l'<apd>Autorité de protection des données</apd> (Belgique)."
-    },
-    "s7": {
-    "heading": "7. Sécurité",
-    "item1": "Chiffrement en transit (TLS 1.3) et au repos.",
-    "item2": "Row Level Security Supabase sur toutes les tables.",
-    "item3": "Rate limiting, CSP stricte, audit log append-only.",
-    "item4": "Authentification par mot de passe fort + MFA disponible."
-    },
-    "s8": {
-    "heading": "8. Cookies",
-    "body": "Voir la <link>politique cookies</link>."
-    },
-    "s9": {
-    "heading": "9. Modifications",
-    "body": "Toute modification matérielle de cette politique est notifiée par email et nécessite ton consentement renouvelé pour continuer à utiliser le service."
-    },
-    "draft": "Notre politique de confidentialité est en cours de rédaction.",
-    "contact": "Pour toute question, contacte-nous : thierryvm@gmail.com",
-    "backHome": "Retour à l'accueil"
-  },
-  "cookies": {
-    "metaTitle": "Politique cookies",
-    "metaDescription": "Politique cookies de Ankora — granularité totale, tout refusable sauf essentiels.",
-    "title": "Politique cookies",
-    "categoriesHeading": "Catégories",
-    "essentialHeading": "Essentiels (toujours actifs)",
-    "essentialBody": "Indispensables au fonctionnement : session d'authentification, préférence de thème, anti-CSRF.",
-    "essentialItem1": "<code>sb-*</code> — session Supabase (auth)",
-    "essentialItem2": "<code>ankora-theme</code> — préférence claire/sombre",
-    "analyticsHeading": "Analytics (désactivés par défaut)",
-    "analyticsBody1": "Uniquement si tu donnes ton consentement. Mesure d'usage agrégée, sans identifiant personnel.",
-    "analyticsBody2": "Ankora n'utilise pas Google Analytics. Les métriques Vercel sont agrégées et anonymisées.",
-    "marketingHeading": "Marketing (désactivés par défaut)",
-    "marketingBody": "Ankora n'utilise actuellement aucun cookie marketing.",
-    "manageHeading": "Gérer tes préférences",
-    "manageBody1": "Tu peux modifier tes consentements à tout moment dans <b>Paramètres → Confidentialité</b> ou en cliquant sur « Gérer les cookies » dans le pied de page.",
-    "manageBody2": "Refuser les cookies non essentiels ne dégrade pas l'expérience : Ankora reste entièrement fonctionnel.",
-    "lifetimeHeading": "Durée de vie",
-    "lifetimeItem1": "Session : fin de navigation",
-    "lifetimeItem2": "Préférences : 12 mois",
-    "lifetimeItem3": "Analytics : 6 mois (si acceptés)",
-    "draft": "Cette page de politique cookies est en cours de rédaction.",
-    "contact": "Pour toute question, contacte-nous : thierryvm@gmail.com",
-    "backHome": "Retour à l'accueil"
-  }
-  },
-  "offline": {
-  "metaTitle": "Hors-ligne",
-  "metaDescription": "Tu es actuellement hors-ligne. Reconnecte-toi pour accéder à Ankora.",
-  "title": "Tu es hors-ligne",
-  "message": "Reconnecte-toi pour accéder à ton cockpit. Tes données restent intactes.",
-  "retry": "Réessayer"
-  },
-  "consent": {
-  "title": "Cookies et vie privée",
-  "body": "On utilise uniquement les cookies essentiels pour te connecter. Les cookies d'analyse sont désactivés par défaut — tu peux les activer si tu veux nous aider à améliorer Ankora. Tu peux changer d'avis à tout moment via <link>la politique cookies</link>.",
-  "essentialOnly": "Essentiels uniquement",
-  "acceptAnalytics": "Accepter les analyses"
-  },
-  "footer": {
-  "copyright": "© {year} — Tous droits réservés",
-  "cgu": "CGU",
-  "privacy": "Confidentialité",
-  "cookies": "Gérer les cookies",
-  "faq": "FAQ",
-  "copyrightNotice": "© {year} Ankora™. Tous droits réservés."
-  },
-  "auth": {
-  "login": {
-    "title": "Se connecter",
-    "subtitle": "Retrouve ton cockpit Ankora.",
-    "metaTitle": "Connexion",
-    "emailLabel": "Email",
-    "passwordLabel": "Mot de passe",
-    "forgotLink": "Mot de passe oublié ?",
-    "submit": "Se connecter",
-    "submitting": "Connexion…",
-    "noAccount": "Pas encore de compte ?",
-    "signupLink": "Créer un compte",
-    "dividerOr": "ou",
-    "dividerOrEmail": "ou avec ton email",
-    "passwordUpdatedBanner": "Mot de passe mis à jour. Tu peux te connecter."
-  },
-  "signup": {
-    "title": "Créer un compte",
-    "subtitle": "Lance ton cockpit financier en moins de 2 minutes.",
-    "pageTitle": "Créer mon cockpit",
-    "pageDescription": "Quelques secondes. Aucune carte bancaire.",
-    "emailLabel": "Email",
-    "passwordLabel": "Mot de passe",
-    "passwordHint": "Au moins 12 caractères, 1 majuscule, 1 minuscule, 1 chiffre.",
-    "passwordConfirmLabel": "Confirmer le mot de passe",
-    "acceptTosPrefix": "J'accepte les",
-    "acceptTosLink": "CGU",
-    "acceptPrivacyPrefix": "J'accepte la",
-    "acceptPrivacyLink": "politique de confidentialité",
-    "submit": "Créer mon compte",
-    "submitting": "Création…",
-    "haveAccount": "Déjà un compte ?",
-    "loginLink": "Se connecter",
-    "dividerOr": "ou",
-    "dividerOrEmail": "ou avec ton email",
-    "googleCta": "Créer mon compte avec Google",
-    "googleTerms": "En continuant avec Google, tu acceptes nos <cgu>CGU</cgu> et notre <privacy>politique de confidentialité</privacy>."
-  },
-  "forgot": {
-    "title": "Mot de passe oublié",
-    "subtitle": "Entre ton email, on t'envoie un lien sécurisé.",
-    "emailLabel": "Email",
-    "submit": "Envoyer le lien",
-    "submitting": "Envoi…",
-    "sentMessage": "Si cet email existe, un lien de réinitialisation vient d'être envoyé.",
-    "backToLogin": "Retour à la connexion"
-  },
-  "reset": {
-    "title": "Nouveau mot de passe",
-    "subtitle": "Choisis un mot de passe solide pour ton compte.",
-    "passwordLabel": "Nouveau mot de passe",
-    "passwordConfirmLabel": "Confirmer",
-    "submit": "Mettre à jour",
-    "submitting": "Mise à jour…"
-  },
-  "google": {
-    "label": "Continuer avec Google",
-    "redirecting": "Redirection…"
-  },
-  "checkEmail": {
-    "title": "Vérifie ta boîte mail",
-    "metaTitle": "Vérifie ton email",
-    "body": "On vient de t'envoyer un lien de confirmation. Clique dessus pour activer ton compte.",
-    "backToLogin": "Retour à la connexion"
-  }
-  },
-  "onboarding": {
-  "defaultWorkspaceName": "Mon espace",
-  "previous": "Retour",
-  "next": "Continuer",
-  "finish": "Terminer",
-  "finishing": "Enregistrement…",
-  "validation": {
-    "workspaceNameRequired": "Donne un nom à ton espace.",
-    "incomeInvalid": "Renseigne un revenu valide (≥ 0)."
-  },
-  "step1": {
-    "title": "Nomme ton espace",
-    "description": "Tu pourras le modifier plus tard dans les paramètres.",
-    "nameLabel": "Nom de l'espace"
-  },
-  "step2": {
-    "title": "Ton revenu mensuel net",
-    "description": "Sert de base pour te suggérer les virements mensuels.",
-    "incomeLabel": "Revenu mensuel net (€)"
-  },
-  "step3": {
-    "title": "Ta première charge (optionnel)",
-    "description": "Ajoute un loyer, une assurance, un abonnement…",
-    "labelLabel": "Libellé",
-    "labelPlaceholder": "Loyer, assurance auto…",
-    "amountLabel": "Montant (€)",
-    "frequencyLabel": "Fréquence",
-    "dueMonthLabel": "Mois de référence",
-    "skipLater": "Je renseignerai mes charges plus tard"
-  }
-  },
-  "app": {
-  "dashboard": {
-    "metaTitle": "Tableau de bord",
-    "headerTitle": "{month} — ton cockpit",
-    "emptyTitle": "Commence par ajouter tes charges",
-    "emptyDescription": "Loyer, assurances, abonnements — Ankora les lisse sur 12 mois pour toi.",
-    "emptyCta": "Ajouter une charge",
-    "kpiProvisionsMonthly": "Provisions / mois",
-    "kpiProvisionsAnnualHint": "Annuel : {amount}",
-    "kpiHealth": "Santé provisions",
-    "kpiHealthTargetHint": "Cible : {amount}",
-    "kpiSuggestedTransfer": "Virement suggéré",
-    "kpiSuggestedTransferToSavings": "À mettre de côté",
-    "kpiSuggestedTransferFromSavings": "À retirer de l'épargne",
-    "kpiBillsMonth": "Factures {month}",
-    "kpiBillsHint": "Sortie de cash ce mois",
-    "healthHealthy": "Sain",
-    "healthWarning": "À surveiller",
-    "healthCritical": "Critique",
-    "planTitle": "Plan du mois — {month}",
-    "planDescription": "Les virements à exécuter en début de mois sur tes trois comptes.",
-    "planAdjustAccounts": "Ajuster mes comptes",
-    "missingSetupTitle": "Renseigne d'abord tes comptes",
-    "missingSetupDescription": "Pour calculer ton Virement Intelligent, Ankora a besoin de ton revenu mensuel et du montant fixe que tu envoies sur Vie Courante.",
-    "missingSetupCta": "Configurer mes comptes",
-    "transferPrincipalToVieCourante": "Principal → Vie Courante",
-    "transferVieCouranteHint": "Enveloppe courses, essence, restos.",
-    "transferPrincipalToEpargne": "Principal → Épargne",
-    "transferEpargneToPrincipal": "Épargne → Principal",
-    "transferEpargneHint": "Provision {provision} − factures {bills}",
-    "transferPrincipalRemaining": "Restant Principal",
-    "transferPrincipalRemainingHint": "Après salaire, virements et factures Principal ({bills}).",
-    "ctaCharges": "Mes charges",
-    "ctaExpenses": "Mes dépenses",
-    "ctaSimulator": "Simuler",
-    "expensesTitle": "Dépenses — {month}",
-    "expensesCount": "{count, plural, =0 {Aucune dépense ce mois} one {1 dépense ce mois} other {# dépenses ce mois}}",
-    "expensesEmpty": "Aucune dépense enregistrée pour ce mois.",
-    "expensesViewAll": "Voir toutes les dépenses →"
-  },
-  "charges": {
-    "title": "Mes charges",
-    "subtitle": "Chaque charge est lissée automatiquement sur 12 mois.",
-    "addFormTitle": "Ajouter une charge",
-    "emptyState": "Aucune charge pour l'instant.",
-    "labelLabel": "Libellé",
-    "amountLabel": "Montant (€)",
-    "frequencyLabel": "Fréquence",
-    "dueMonthLabel": "Mois de référence",
-    "addButton": "Ajouter",
-    "adding": "Ajout…",
-    "count": "{count, plural, =0 {aucune charge} one {1 charge} other {# charges}}",
-    "referenceFormat": "{frequency} · ref. {month}",
-    "deleteAria": "Supprimer {label}",
-    "toastCreated": "Charge ajoutée",
-    "toastDeleted": "Charge supprimée"
-  },
-  "accounts": {
-    "metaTitle": "Mes comptes",
-    "metaDescription": "Suis les soldes de tes comptes Principal, Vie Courante et Épargne. Règle ton revenu mensuel et ton virement vers Vie Courante.",
-    "title": "Mes comptes",
-    "subtitle": "Saisis tes soldes réels pour qu'Ankora calcule précisément ton virement intelligent chaque mois.",
-    "balancesHeading": "Soldes actuels",
-    "amountLabel": "Montant (€)",
-    "saveButton": "Enregistrer",
-    "saving": "Enregistrement…",
-    "income": {
-    "title": "Revenu mensuel net",
-    "description": "Le salaire qui arrive chaque mois sur ton compte Principal. Sert à calculer ce qu'il te reste après les charges et le virement vers Vie Courante.",
-    "placeholder": "Ex. 2500",
-    "toastSaved": "Revenu mensuel mis à jour"
-    },
-    "transfer": {
-    "title": "Virement mensuel vers Vie Courante",
-    "description": "Somme fixe transférée chaque mois du Principal vers ton compte Vie Courante. C'est ce qui servira aux courses, à l'essence et aux restos.",
-    "placeholder": "Ex. 500",
-    "toastSaved": "Virement mensuel mis à jour"
-    },
-    "balance": {
-    "invalidAmount": "Entre un montant valide.",
-    "saveLabel": "Mettre à jour",
-    "srLabel": "Solde actuel de {label}",
-    "toastSaved": "{name} mis à jour"
-    },
-    "kind": {
-    "principal": {
-      "description": "Reçoit le salaire, paye les charges fixes mensuelles."
-    },
-    "vieCourante": {
-      "description": "Budget du quotidien (courses, essence, restos)."
-    },
-    "epargne": {
-      "description": "Lisse les factures trimestrielles et annuelles."
-    }
-    }
-  },
-  "expenses": {
-    "title": "Mes dépenses",
-    "subtitle": "Les sorties hors charges récurrentes — courses, resto, loisirs…",
-    "addFormTitle": "Ajouter une dépense",
-    "labelLabel": "Libellé",
-    "amountLabel": "Montant (€)",
-    "dateLabel": "Date",
-    "addButton": "Ajouter",
-    "adding": "Ajout…",
-    "emptyState": "Aucune dépense enregistrée.",
-    "summary": "{count, plural, =0 {Aucune dépense} one {1 dépense · {total}} other {# dépenses · {total}}}",
-    "deleteAria": "Supprimer {label}",
-    "toastCreated": "Dépense ajoutée",
-    "toastDeleted": "Dépense supprimée"
-  },
-  "settings": {
-    "metaTitle": "Paramètres",
-    "metaDescription": "Gère ton profil, la sécurité 2FA et tes données personnelles.",
-    "title": "Paramètres",
-    "description": "Profil, sécurité et données personnelles.",
-    "profile": {
-    "title": "Profil",
-    "description": "Ces informations personnalisent ton cockpit.",
-    "emailLabel": "Email",
-    "displayNameLabel": "Nom d'affichage",
-    "localeLabel": "Langue",
-    "localeOptions": {
-      "fr-BE": "Français (Belgique)",
-      "fr-FR": "Français (France)",
-      "en-GB": "English"
-    },
-    "submit": "Enregistrer",
-    "submitting": "Enregistrement…",
-    "toastSaved": "Profil mis à jour"
-    },
-    "mfa": {
-    "title": "Sécurité — 2FA",
-    "description": "Un code à usage unique généré par une app d'authentification (Authy, 1Password, Google Authenticator).",
-    "emptyState": "Aucun facteur 2FA actif. Active-le pour protéger ton compte.",
-    "enrollButton": "Activer la 2FA",
-    "enrolling": "Préparation…",
-    "scanInstruction": "Scanne ce QR code dans ton app d'authentification, puis saisis le code à 6 chiffres.",
-    "qrAlt": "QR code pour l'app d'authentification",
-    "manualEntry": "Saisie manuelle",
-    "codeLabel": "Code à 6 chiffres",
-    "verifyButton": "Vérifier et activer",
-    "verifying": "Vérification…",
-    "cancel": "Annuler",
-    "defaultFactorName": "App TOTP",
-    "activeLabel": "Actif",
-    "disableButton": "Désactiver",
-    "toastEnabled": "MFA activé",
-    "toastDisabled": "MFA désactivé"
-    },
-    "data": {
-    "title": "Mes données",
-    "description": "Portabilité RGPD (art. 20) — télécharge un JSON complet de tout ce qu'Ankora détient sur toi.",
-    "exportButton": "Télécharger mes données",
-    "exporting": "Génération…",
-    "toastDownloaded": "Export téléchargé"
-    },
-    "danger": {
-    "scheduledTitle": "Suppression en cours",
-    "scheduledBody": "Ton compte sera supprimé le <strong>{date}</strong>. Tu peux annuler à tout moment jusque-là.",
-    "viewStatus": "Voir le statut",
-    "title": "Zone dangereuse",
-    "description": "Suppression définitive du compte. Grâce de 30 jours pour annuler — après, tout est effacé (logs audit pseudonymisés).",
-    "reasonLabel": "Raison (optionnel)",
-    "reasonPlaceholder": "Aide-nous à nous améliorer…",
-    "confirmLabel": "Pour confirmer, tape ton adresse e-mail : <code>{email}</code>",
-    "submit": "Supprimer mon compte",
-    "submitting": "Programmation…",
-    "toastScheduled": "Suppression programmée — tu as 30 jours pour annuler"
-    }
-  },
-  "simulator": {
-    "title": "Simulateur",
-    "subtitle": "Mesure l'impact d'un changement sans toucher à tes données réelles.",
-    "scenario": {
-    "title": "Scénario",
-    "description": "Choisis une action à simuler.",
-    "modes": {
-      "cancel": "Annuler une charge",
-      "negotiate": "Renégocier",
-      "add": "Ajouter une charge"
-    }
-    },
-    "fields": {
-    "charge": "Charge",
-    "chargePlaceholder": "Sélectionne…",
-    "newAmount": "Nouveau montant (€)",
-    "label": "Libellé",
-    "amount": "Montant (€)",
-    "frequency": "Fréquence",
-    "month": "Mois"
-    },
-    "impact": {
-    "title": "Impact",
-    "empty": "Complète le scénario pour voir l'impact.",
-    "currentMonthly": "Actuel / mois",
-    "projectedMonthly": "Projeté / mois",
-    "annualSavings": "Économie annuelle",
-    "monthlyChange": "{sign}{percent}% / mois"
-    }
-  },
-  "deletionStatus": {
-    "title": "Suppression du compte",
-    "subtitle": "État détaillé de ta demande et période d'annulation.",
-    "metaTitle": "Statut de suppression",
-    "metaDescription": "État de la demande de suppression de ton compte Ankora.",
-    "statusLabel": "Statut :",
-    "requestedOn": "Demandée le {date}.",
-    "statusPending": "En attente",
-    "statusCancelled": "Annulée",
-    "statusCompleted": "Complétée",
-    "scheduledFor": "Suppression prévue",
-    "daysLeft": "Jours restants",
-    "auditLogs": "Logs audit",
-    "auditLogsValue": "Pseudonymisés, jamais supprimés",
-    "daysCount": "{days, plural, =0 {Aujourd'hui} one {# jour} other {# jours}}",
-    "backToSettings": "Retour aux paramètres",
-    "cancelledOn": "Demande annulée le {date}. Ton compte est conservé.",
-    "cancelledNoDate": "Demande annulée. Ton compte est conservé.",
-    "cancelButton": "Annuler la suppression",
-    "cancelling": "Annulation…",
-    "toastCancelled": "Demande annulée — ton compte est conservé"
-  }
-  },
-  "glossary": {
-  "title": "Glossaire",
-  "subtitle": "15 termes essentiels pour comprendre ta gestion budgétaire et tes finances personnelles.",
-  "metaTitle": "Glossaire — Termes financiers",
-  "metaDescription": "Glossaire des 15 termes essentiels de la gestion budgétaire : budget de lissage, compte bucket, épargne de précaution, et plus.",
-  "breadcrumb": {
-    "home": "Accueil",
-    "glossary": "Glossaire"
-  },
-  "section": {
-    "whyItMatters": "Pourquoi c'est important",
-    "example": "Exemple concret",
-    "relatedTerms": "Termes liés"
-  }
-  },
-  "errors": {
-  "generic": "Une erreur est survenue. Réessaie.",
-  "session": {
-    "expired": "Session expirée. Reconnecte-toi.",
-    "rateLimited": "Trop de requêtes. Attends une minute."
-  },
-  "auth": {
-    "invalidCredentials": "Email ou mot de passe incorrect.",
-    "signupFailed": "Inscription impossible. Réessaie plus tard.",
-    "googleFailed": "Connexion Google indisponible. Réessaie plus tard.",
-    "rateLimited": "Trop de tentatives. Réessaie dans quelques minutes.",
-    "serviceTemporarilyUnavailable": "Service temporairement indisponible. Réessaie dans quelques minutes.",
-    "passwordResetFailed": "Impossible de mettre à jour le mot de passe.",
-    "linkExpired": "Lien expiré. Demande un nouveau lien.",
-    "mfaEnrollFailed": "Impossible de démarrer l'enrôlement.",
-    "mfaChallengeFailed": "Challenge MFA impossible.",
-    "mfaCodeInvalid": "Code incorrect. Réessaie.",
-    "mfaDisableFailed": "Impossible de désactiver la 2FA."
-  },
-  "db": {
-    "workspaceNotFound": "Aucun workspace éditable.",
-    "updateFailed": "Mise à jour impossible.",
-    "notEditable": "Tu n'as pas les droits d'édition sur cet espace."
-  },
-  "validation": {
-    "generic": "Données invalides.",
-    "auth": {
-    "email": {
-      "invalid": "Adresse email invalide."
-    },
-    "password": {
-      "required": "Mot de passe requis.",
-      "tooShort": "Au moins 12 caractères.",
-      "tooLong": "Maximum 128 caractères.",
-      "lowercase": "Au moins une minuscule.",
-      "uppercase": "Au moins une majuscule.",
-      "digit": "Au moins un chiffre."
-    },
-    "passwordConfirm": {
-      "mismatch": "Les mots de passe ne correspondent pas."
-    },
-    "acceptTos": {
-      "required": "Tu dois accepter les CGU."
-    },
-    "acceptPrivacy": {
-      "required": "Tu dois accepter la politique de confidentialité."
-    }
-    },
-    "charge": {
-    "label": {
-      "required": "Libellé requis.",
-      "tooLong": "Maximum 120 caractères."
-    },
-    "amount": {
-      "invalid": "Montant invalide.",
-      "negative": "Le montant doit être ≥ 0.",
-      "tooHigh": "Montant trop élevé."
+    "monthsShort": {
+      "1": "janv.",
+      "2": "févr.",
+      "3": "mars",
+      "4": "avr.",
+      "5": "mai",
+      "6": "juin",
+      "7": "juil.",
+      "8": "août",
+      "9": "sept.",
+      "10": "oct.",
+      "11": "nov.",
+      "12": "déc."
     },
     "frequency": {
-      "invalid": "Fréquence invalide."
-    },
-    "dueMonth": {
-      "range": "Mois entre 1 et 12."
-    },
-    "paidFrom": {
-      "invalid": "Compte débiteur invalide."
+      "monthly": "Mensuel",
+      "quarterly": "Trimestriel",
+      "semiannual": "Semestriel",
+      "annual": "Annuel"
     }
+  },
+  "ui": {
+    "scrollToTop": "Remonter en haut de la page",
+    "localeSwitcher": {
+      "label": "Langue",
+      "aria": "Changer de langue",
+      "options": {
+        "fr-BE": "Français (BE)",
+        "nl-BE": "Nederlands (BE)",
+        "en": "English",
+        "es-ES": "Español",
+        "de-DE": "Deutsch"
+      }
     },
-    "account": {
-    "kind": {
-      "invalid": "Type de compte invalide."
-    },
-    "balance": {
-      "invalid": "Solde invalide.",
-      "outOfRange": "Valeur hors limites."
-    },
-    "label": {
-      "required": "Libellé requis.",
-      "tooLong": "Maximum 80 caractères."
+    "action": {
+      "submit": "Valider",
+      "submitting": "Validation…",
+      "save": "Enregistrer",
+      "saving": "Enregistrement…",
+      "cancel": "Annuler",
+      "cancelling": "Annulation…",
+      "delete": "Supprimer",
+      "deleting": "Suppression…",
+      "create": "Créer",
+      "creating": "Création…",
+      "update": "Mettre à jour",
+      "updating": "Mise à jour…",
+      "send": "Envoyer",
+      "sending": "Envoi…",
+      "verify": "Vérifier",
+      "verifying": "Vérification…",
+      "generate": "Générer",
+      "generating": "Génération…",
+      "download": "Télécharger",
+      "downloading": "Téléchargement…",
+      "preparing": "Préparation…",
+      "confirm": "Confirmer",
+      "close": "Fermer"
     }
+  },
+  "landing": {
+    "mktnav": {
+      "links": {
+        "product": "Produit",
+        "simulator": "Simulateur",
+        "pricing": "Tarifs",
+        "security": "Sécurité",
+        "journal": "Journal"
+      },
+      "ctaLogin": "Se connecter",
+      "ctaSignup": "Essayer gratuitement"
     },
-    "workspace": {
-    "name": {
-      "required": "Nom requis.",
-      "tooLong": "Maximum 80 caractères."
+    "hero": {
+      "badge": "Nouveau · Simulateur what-if",
+      "h1Lead": "Ton ancrage",
+      "h1Highlight": "financier.",
+      "description": "Ankora sépare tes provisions affectées de ta réserve libre, projette six mois devant, et te laisse simuler l'impact de chaque décision — en clair, sans jargon.",
+      "ctaPrimary": "Ouvrir mon cockpit",
+      "ctaSecondary": "Voir le simulateur",
+      "trust": {
+        "encrypted": "Données chiffrées en Belgique",
+        "noSale": "Aucune vente de données",
+        "languages": "FR · NL · EN"
+      },
+      "mockup": {
+        "eyebrow": "Aperçu cockpit",
+        "browserUrl": "Ankora · cockpit",
+        "kpis": {
+          "netRemaining": {
+            "label": "Net restant",
+            "sub": "avril · après provisions"
+          },
+          "provisions": {
+            "label": "Provisions",
+            "sub": "67 % des 2 480 € planifiés"
+          },
+          "reserve": {
+            "label": "Réserve",
+            "sub": "+120 € vs. mars"
+          }
+        }
+      },
+      "waterfall": {
+        "income": "Revenus",
+        "incomeAmount": "+2 466 €",
+        "expenses": "Dépenses courantes",
+        "expensesAmount": "−1 959 €",
+        "provisionsCaption": "dont {amount} € lissés vers provisions affectées",
+        "available": "Argent disponible",
+        "availableAmount": "+507 €",
+        "ariaLabel": "Cascade illustrative : 2 466 € de revenus, 1 959 € de dépenses courantes (dont 59 € lissés en provisions), 507 € disponibles."
+      }
     },
-    "income": {
-      "invalid": "Revenu invalide.",
-      "negative": "Doit être ≥ 0.",
-      "tooHigh": "Revenu trop élevé."
+    "principles": {
+      "eyebrow": "Trois principes",
+      "h2": "Une façon honnête de parler d'argent.",
+      "description": "Ankora n'essaye pas de te vendre un placement ou une carte. On sépare, on projette, on simule. C'est tout. Toi seul décides.",
+      "items": {
+        "provisions": {
+          "title": "Provisions affectées",
+          "description": "Chaque euro réservé a un nom : mutuelle, taxe circulation, entretien chaudière. Rien ne fuit sans que tu le saches."
+        },
+        "reserve": {
+          "title": "Réserve libre",
+          "description": "Ce qui reste vraiment à toi, après les engagements. Le vrai chiffre — pas l'illusion du solde brut."
+        },
+        "whatIf": {
+          "title": "Simulateur what-if",
+          "description": "Renégocier l'électricité ? Changer de fournisseur ? Ankora te montre l'impact sur 12 mois avant que tu décides."
+        }
+      }
     },
-    "transfer": {
-      "invalid": "Montant invalide.",
-      "negative": "Doit être ≥ 0.",
-      "tooHigh": "Montant trop élevé."
+    "feature": {
+      "eyebrow": "Cashflow waterfall",
+      "h3Line1": "Du salaire au net disponible.",
+      "h3Line2": "En un seul coup d'œil.",
+      "description": "Plus de mystère sur où va ton argent. Chaque étape est visible : revenus, dépenses courantes, argent disponible. Tu vois immédiatement si un poste dérape.",
+      "ctaPrimary": "Voir un exemple",
+      "ctaSecondary": "Comment ça marche ?"
+    },
+    "whatif": {
+      "title": "Et si tu changeais une seule chose ?",
+      "subtitle": "Bouge le curseur. Vois l'impact sur ta réserve libre, sur six mois. C'est ce que fait Ankora à chaque décision financière.",
+      "badge": "Démo · pas de compte requis",
+      "scenarios": {
+        "gsm": {
+          "label": "Renégocier mon GSM",
+          "hint": "Forfait actuel : 42 €/mois · marché : 18–28 €/mois"
+        },
+        "elec": {
+          "label": "Changer de fournisseur d'électricité",
+          "hint": "Conso actuelle : 168 €/mois · 3 offres moins chères dans ta zone"
+        },
+        "stream": {
+          "label": "Couper deux streamings",
+          "hint": "5 abonnements actifs · usage réel : 2 sur 30 jours"
+        }
+      },
+      "controls": {
+        "scenario": "Scénario",
+        "savings": "Économie mensuelle",
+        "slider_aria": "Économie mensuelle pour {label}"
+      },
+      "annual": {
+        "eyebrow": "Sur 12 mois",
+        "fleche": "Ankora pourrait flécher {amount} €/mois vers ton épargne longue."
+      },
+      "chart": {
+        "title": "Réserve libre · projection",
+        "subtitle": "6 mois à partir d'aujourd'hui",
+        "legend": {
+          "baseline": "Sans changement",
+          "scenario": "Avec ton choix"
+        },
+        "aria": "Graphique projection sur 6 mois de la réserve libre, avec et sans le changement choisi",
+        "months": {
+          "may": "mai",
+          "jun": "juin",
+          "jul": "juil",
+          "aug": "août",
+          "sep": "sept",
+          "oct": "oct"
+        },
+        "thresholds": {
+          "danger": "⚠️ Découvert estimé",
+          "fragile": "Zone fragile",
+          "comfortable": "Zone confortable"
+        }
+      },
+      "caveat": "Démo basée sur des hypothèses moyennes. Ankora ne fournit pas de conseil en placement. Aucun import bancaire — tu saisis tes charges manuellement."
+    },
+    "pricing": {
+      "eyebrow": "Transparent dès le départ",
+      "h2": "Gratuit pendant la Phase 1.",
+      "phaseBadge": "Phase 1 · construction",
+      "price": "0 €",
+      "period": "pour l'instant, et sans date limite",
+      "body": "On construit d'abord le cockpit. Pas de carte demandée, pas de limite de temps, pas de fonctionnalité bridée. Export RGPD à tout moment.",
+      "features": {
+        "cockpit": "Cockpit complet, provisions et réserve libre",
+        "simulator": "Simulateur what-if illimité",
+        "manualEntry": "Saisie manuelle · tes données restent en Belgique",
+        "export": "Export RGPD en un clic"
+      },
+      "ctaPrimary": "Ouvrir mon cockpit",
+      "roadmap": {
+        "title": "Tu rejoins Ankora pendant sa Phase 1 ?",
+        "body": "Ton compte garde un accès complet au cockpit core à vie, gratuitement. Une offre Pro avec features avancées (comptes illimités, exports consolidés, support prioritaire) arrivera post-v1.0 — tu auras le choix d'upgrader ou de rester sur ton plan actuel.",
+        "link": "Lire la roadmap →"
+      }
+    },
+    "footerCta": {
+      "h2Lead": "Commence par ce qui est",
+      "h2Highlight": "déjà à toi.",
+      "description": "30 jours d'essai, pas de carte, export RGPD à tout moment. On fait simple parce que c'est déjà assez compliqué comme ça.",
+      "ctaPrimary": "Ouvrir mon cockpit"
+    },
+    "footer": {
+      "links": {
+        "terms": "Conditions",
+        "privacy": "Confidentialité",
+        "security": "Sécurité",
+        "contact": "Contact"
+      },
+      "copyright": "Ankora · éditeur ancré à Bruxelles · 2026"
+    },
+    "faqHeading": "Questions fréquentes",
+    "faq": {
+      "advice": {
+        "q": "Ankora est-il un outil de conseil financier ?",
+        "a": "Non. Ankora est un outil d'organisation et d'éducation budgétaire. Il ne fournit pas de recommandations de placement ni de conseil financier personnalisé."
+      },
+      "storage": {
+        "q": "Où sont stockées mes données ?",
+        "a": "Tes données sont hébergées en Union européenne (Supabase, région UE) avec chiffrement au repos et isolation stricte par utilisateur via Row Level Security."
+      },
+      "sharing": {
+        "q": "Est-ce que je peux partager mes données ?",
+        "a": "Par défaut, ton espace est 100 % privé. Des pots partagés optionnels (voyage, projet commun) arriveront dans une prochaine version — tu choisiras explicitement ce que tu partages, et avec qui."
+      }
     }
-    },
-    "expense": {
-    "label": {
-      "required": "Libellé requis.",
-      "tooLong": "Maximum 120 caractères."
-    },
-    "amount": {
-      "invalid": "Montant invalide.",
-      "negative": "Doit être ≥ 0.",
-      "tooHigh": "Montant trop élevé."
-    },
-    "date": {
-      "format": "Format attendu : YYYY-MM-DD."
-    },
-    "category": {
-      "invalid": "Catégorie invalide."
+  },
+  "faq": {
+    "metaTitle": "FAQ",
+    "metaDescription": "Questions fréquentes sur Ankora : sécurité, données, fonctionnement, confidentialité.",
+    "title": "Questions fréquentes",
+    "subtitle": "Tout ce qu'il faut savoir sur Ankora avant de se lancer.",
+    "items": {
+      "bankConnection": {
+        "q": "Est-ce qu'Ankora se connecte à ma banque ?",
+        "a": "Non. Ankora n'utilise pas la directive PSD2. Tu saisis manuellement tes charges et dépenses. Ce choix garantit que tu restes propriétaire de tes données et qu'aucune information bancaire sensible n'est stockée."
+      },
+      "dataLocation": {
+        "q": "Où sont hébergées mes données ?",
+        "a": "Toutes tes données sont hébergées dans l'Union européenne (Supabase région UE, Vercel région UE, Upstash UE). Aucun transfert hors UE n'est effectué."
+      },
+      "smoothing": {
+        "q": "Comment fonctionne le lissage ?",
+        "a": "Ankora prend tes charges trimestrielles, semestrielles et annuelles et les répartit sur 12 mois. Tu sais ainsi combien mettre de côté chaque mois pour couvrir toutes tes futures factures sans stress."
+      },
+      "deletion": {
+        "q": "Puis-je supprimer mon compte ?",
+        "a": "Oui, à tout moment depuis Paramètres → Confidentialité. La suppression prend effet 30 jours après ta demande (tu peux annuler pendant cette période). Toutes tes données financières sont effacées, les logs de sécurité sont pseudonymisés."
+      },
+      "export": {
+        "q": "Puis-je exporter mes données ?",
+        "a": "Oui. Le bouton « Télécharger mes données » dans Paramètres te fournit un fichier JSON complet de tout ce qu'Ankora détient sur toi. Conforme au droit de portabilité RGPD (art. 20)."
+      },
+      "advice": {
+        "q": "Est-ce qu'Ankora donne des conseils financiers ?",
+        "a": "Non. Ankora est un outil d'éducation budgétaire et d'organisation. Nous n'émettons aucun conseil en placement (contrainte réglementaire FSMA Belgique). Pour toute décision d'investissement, consulte un professionnel agréé."
+      },
+      "ai": {
+        "q": "Y a-t-il de l'intelligence artificielle ?",
+        "a": "En Phase 1, non. Les calculs sont déterministes et auditables. En Phase 2, une couche optionnelle BYOK (Bring Your Own Key) te permettra de connecter ta propre clé Anthropic ou OpenRouter pour des suggestions — aucun surcoût côté Ankora."
+      },
+      "sharing": {
+        "q": "Puis-je partager mon espace avec mes enfants ou mes amis ?",
+        "a": "En Phase 1, chaque utilisateur a un espace privé, isolé par défaut. En Phase 2, nous ajouterons la possibilité de créer des « pots partagés » (par invitation, avec rôles viewer/editor) sans jamais mélanger tes données personnelles."
+      }
     }
+  },
+  "legal": {
+    "versionLine": "Version {version} — dernière mise à jour : {date}",
+    "lastUpdatedLine": "Dernière mise à jour : {date}",
+    "cgu": {
+      "metaTitle": "Conditions générales d'utilisation",
+      "metaDescription": "CGU de Ankora — règles d'utilisation du service.",
+      "title": "Conditions générales d'utilisation",
+      "s1": {
+        "heading": "1. Objet",
+        "body": "Ankora est un outil d'organisation budgétaire et d'éducation financière destiné aux particuliers. Il permet de saisir manuellement ses charges et dépenses, de les lisser sur l'année, et d'anticiper les besoins de trésorerie."
+      },
+      "s2": {
+        "heading": "2. Ce que Ankora n'est PAS",
+        "item1": "Ankora n'est <b>pas un service de conseil en placement</b> ni en investissement.",
+        "item2": "Ankora n'est <b>pas un service bancaire</b> et ne détient aucun fonds.",
+        "item3": "Ankora n'est <b>pas un agrégateur PSD2</b> — aucune connexion à tes comptes bancaires.",
+        "item4": "Ankora n'est <b>pas un logiciel de comptabilité professionnelle</b>.",
+        "outro": "Les informations affichées sont des estimations basées sur tes saisies. Elles ne constituent pas un conseil financier personnalisé. Pour toute décision importante, consulte un professionnel agréé."
+      },
+      "s3": {
+        "heading": "3. Compte",
+        "item1": "Tu dois être majeur ou avoir l'autorisation d'un représentant légal.",
+        "item2": "Un seul compte par personne physique.",
+        "item3": "Mot de passe minimum 12 caractères, mixte.",
+        "item4": "Tu es responsable de la confidentialité de tes identifiants."
+      },
+      "s4": {
+        "heading": "4. Usage acceptable",
+        "intro": "Tu t'engages à ne pas :",
+        "item1": "utiliser le service à des fins illégales,",
+        "item2": "tenter de contourner les mesures de sécurité,",
+        "item3": "automatiser l'accès sans autorisation explicite,",
+        "item4": "partager ton compte avec un tiers."
+      },
+      "s5": {
+        "heading": "5. Propriété intellectuelle",
+        "body": "Tu restes propriétaire de tes données. Ankora conserve la propriété de son code, marque, design et documentation."
+      },
+      "s6": {
+        "heading": "6. Responsabilité",
+        "body": "Ankora est fourni « tel quel ». L'éditeur ne saurait être tenu responsable des décisions financières prises sur base des informations affichées. Aucune garantie de disponibilité à 100%."
+      },
+      "s7": {
+        "heading": "7. Résiliation",
+        "body": "Tu peux supprimer ton compte à tout moment depuis Paramètres → Confidentialité. La suppression est effective 30 jours après la demande (période annulable)."
+      },
+      "s8": {
+        "heading": "8. Droit applicable",
+        "body": "Ces CGU sont soumises au droit belge. Tribunal compétent : Bruxelles."
+      },
+      "draft": "Nos conditions générales d'utilisation sont en cours de rédaction.",
+      "contact": "Pour toute question, contacte-nous : thierryvm@gmail.com",
+      "backHome": "Retour à l'accueil"
+    },
+    "privacy": {
+      "metaTitle": "Politique de confidentialité",
+      "metaDescription": "Politique de confidentialité de Ankora — hébergement UE, RGPD, droits des utilisateurs.",
+      "title": "Politique de confidentialité",
+      "s1": {
+        "heading": "1. Responsable de traitement",
+        "body": "Ankora, édité par Thierry Van Mele (Belgique). Contact : <mail>thierryvm@gmail.com</mail>."
+      },
+      "s2": {
+        "heading": "2. Données collectées",
+        "intro": "Ankora collecte uniquement les données strictement nécessaires à la fourniture du service :",
+        "item1": "<b>Identité</b> : adresse email, nom d'affichage (optionnel).",
+        "item2": "<b>Données financières saisies par toi</b> : charges, dépenses, catégories, revenus déclarés, solde d'épargne.",
+        "item3": "<b>Données techniques</b> : adresse IP, user-agent (pour les logs de sécurité uniquement).",
+        "item4": "<b>Consentements</b> : horodatage, version, portée (CGU, confidentialité, cookies).",
+        "outro": "Ankora ne se connecte à aucune banque (pas d'agrégation PSD2). Tu saisis toi-même tes charges et dépenses."
+      },
+      "s3": {
+        "heading": "3. Bases légales (RGPD art. 6)",
+        "item1": "<b>Contrat</b> : fourniture du service (compte, données financières).",
+        "item2": "<b>Consentement</b> : cookies analytics/marketing, newsletter.",
+        "item3": "<b>Obligation légale</b> : logs de sécurité (conservation 12 mois).",
+        "item4": "<b>Intérêt légitime</b> : prévention fraude, maintien de la sécurité."
+      },
+      "s4": {
+        "heading": "4. Hébergement et sous-traitants",
+        "item1": "<b>Supabase</b> (base de données, auth) — région UE (Francfort ou Paris).",
+        "item2": "<b>Vercel</b> (hébergement frontend) — région UE (Dublin).",
+        "item3": "<b>Upstash</b> (rate limiting) — région UE.",
+        "outro": "Aucune donnée n'est transférée hors UE/EEE."
+      },
+      "s5": {
+        "heading": "5. Durée de conservation",
+        "item1": "Compte actif : tant que tu utilises le service.",
+        "item2": "Compte supprimé : suppression effective 30 jours après ta demande (grace period annulable).",
+        "item3": "Logs de sécurité : 12 mois maximum, pseudonymisés après suppression du compte."
+      },
+      "s6": {
+        "heading": "6. Tes droits (RGPD art. 15-22)",
+        "item1": "<b>Accès</b> : consulte tes données à tout moment dans ton espace.",
+        "item2": "<b>Rectification</b> : modifie profil et données dans les pages dédiées.",
+        "item3": "<b>Effacement</b> : bouton « Supprimer mon compte » dans Paramètres → Confidentialité.",
+        "item4": "<b>Portabilité</b> : bouton « Télécharger mes données » — export JSON complet.",
+        "item5": "<b>Opposition / Restriction</b> : refuse ou retire les cookies non essentiels à tout moment.",
+        "item6": "<b>Plainte</b> : auprès de l'<apd>Autorité de protection des données</apd> (Belgique)."
+      },
+      "s7": {
+        "heading": "7. Sécurité",
+        "item1": "Chiffrement en transit (TLS 1.3) et au repos.",
+        "item2": "Row Level Security Supabase sur toutes les tables.",
+        "item3": "Rate limiting, CSP stricte, audit log append-only.",
+        "item4": "Authentification par mot de passe fort + MFA disponible."
+      },
+      "s8": {
+        "heading": "8. Cookies",
+        "body": "Voir la <link>politique cookies</link>."
+      },
+      "s9": {
+        "heading": "9. Modifications",
+        "body": "Toute modification matérielle de cette politique est notifiée par email et nécessite ton consentement renouvelé pour continuer à utiliser le service."
+      },
+      "draft": "Notre politique de confidentialité est en cours de rédaction.",
+      "contact": "Pour toute question, contacte-nous : thierryvm@gmail.com",
+      "backHome": "Retour à l'accueil"
+    },
+    "cookies": {
+      "metaTitle": "Politique cookies",
+      "metaDescription": "Politique cookies de Ankora — granularité totale, tout refusable sauf essentiels.",
+      "title": "Politique cookies",
+      "categoriesHeading": "Catégories",
+      "essentialHeading": "Essentiels (toujours actifs)",
+      "essentialBody": "Indispensables au fonctionnement : session d'authentification, préférence de thème, anti-CSRF.",
+      "essentialItem1": "<code>sb-*</code> — session Supabase (auth)",
+      "essentialItem2": "<code>ankora-theme</code> — préférence claire/sombre",
+      "analyticsHeading": "Analytics (désactivés par défaut)",
+      "analyticsBody1": "Uniquement si tu donnes ton consentement. Mesure d'usage agrégée, sans identifiant personnel.",
+      "analyticsBody2": "Ankora n'utilise pas Google Analytics. Les métriques Vercel sont agrégées et anonymisées.",
+      "marketingHeading": "Marketing (désactivés par défaut)",
+      "marketingBody": "Ankora n'utilise actuellement aucun cookie marketing.",
+      "manageHeading": "Gérer tes préférences",
+      "manageBody1": "Tu peux modifier tes consentements à tout moment dans <b>Paramètres → Confidentialité</b> ou en cliquant sur « Gérer les cookies » dans le pied de page.",
+      "manageBody2": "Refuser les cookies non essentiels ne dégrade pas l'expérience : Ankora reste entièrement fonctionnel.",
+      "lifetimeHeading": "Durée de vie",
+      "lifetimeItem1": "Session : fin de navigation",
+      "lifetimeItem2": "Préférences : 12 mois",
+      "lifetimeItem3": "Analytics : 6 mois (si acceptés)",
+      "draft": "Cette page de politique cookies est en cours de rédaction.",
+      "contact": "Pour toute question, contacte-nous : thierryvm@gmail.com",
+      "backHome": "Retour à l'accueil"
+    }
+  },
+  "offline": {
+    "metaTitle": "Hors-ligne",
+    "metaDescription": "Tu es actuellement hors-ligne. Reconnecte-toi pour accéder à Ankora.",
+    "title": "Tu es hors-ligne",
+    "message": "Reconnecte-toi pour accéder à ton cockpit. Tes données restent intactes.",
+    "retry": "Réessayer"
+  },
+  "consent": {
+    "title": "Cookies et vie privée",
+    "body": "On utilise uniquement les cookies essentiels pour te connecter. Les cookies d'analyse sont désactivés par défaut — tu peux les activer si tu veux nous aider à améliorer Ankora. Tu peux changer d'avis à tout moment via <link>la politique cookies</link>.",
+    "essentialOnly": "Essentiels uniquement",
+    "acceptAnalytics": "Accepter les analyses"
+  },
+  "footer": {
+    "copyright": "© {year} — Tous droits réservés",
+    "cgu": "CGU",
+    "privacy": "Confidentialité",
+    "cookies": "Gérer les cookies",
+    "faq": "FAQ",
+    "copyrightNotice": "© {year} Ankora™. Tous droits réservés."
+  },
+  "auth": {
+    "login": {
+      "title": "Se connecter",
+      "subtitle": "Retrouve ton cockpit Ankora.",
+      "metaTitle": "Connexion",
+      "emailLabel": "Email",
+      "passwordLabel": "Mot de passe",
+      "forgotLink": "Mot de passe oublié ?",
+      "submit": "Se connecter",
+      "submitting": "Connexion…",
+      "noAccount": "Pas encore de compte ?",
+      "signupLink": "Créer un compte",
+      "dividerOr": "ou",
+      "dividerOrEmail": "ou avec ton email",
+      "passwordUpdatedBanner": "Mot de passe mis à jour. Tu peux te connecter."
+    },
+    "signup": {
+      "title": "Créer un compte",
+      "subtitle": "Lance ton cockpit financier en moins de 2 minutes.",
+      "pageTitle": "Créer mon cockpit",
+      "pageDescription": "Quelques secondes. Aucune carte bancaire.",
+      "emailLabel": "Email",
+      "passwordLabel": "Mot de passe",
+      "passwordHint": "Au moins 12 caractères, 1 majuscule, 1 minuscule, 1 chiffre.",
+      "passwordConfirmLabel": "Confirmer le mot de passe",
+      "acceptTosPrefix": "J'accepte les",
+      "acceptTosLink": "CGU",
+      "acceptPrivacyPrefix": "J'accepte la",
+      "acceptPrivacyLink": "politique de confidentialité",
+      "submit": "Créer mon compte",
+      "submitting": "Création…",
+      "haveAccount": "Déjà un compte ?",
+      "loginLink": "Se connecter",
+      "dividerOr": "ou",
+      "dividerOrEmail": "ou avec ton email",
+      "googleCta": "Créer mon compte avec Google",
+      "googleTerms": "En continuant avec Google, tu acceptes nos <cgu>CGU</cgu> et notre <privacy>politique de confidentialité</privacy>."
+    },
+    "forgot": {
+      "title": "Mot de passe oublié",
+      "subtitle": "Entre ton email, on t'envoie un lien sécurisé.",
+      "emailLabel": "Email",
+      "submit": "Envoyer le lien",
+      "submitting": "Envoi…",
+      "sentMessage": "Si cet email existe, un lien de réinitialisation vient d'être envoyé.",
+      "backToLogin": "Retour à la connexion"
+    },
+    "reset": {
+      "title": "Nouveau mot de passe",
+      "subtitle": "Choisis un mot de passe solide pour ton compte.",
+      "passwordLabel": "Nouveau mot de passe",
+      "passwordConfirmLabel": "Confirmer",
+      "submit": "Mettre à jour",
+      "submitting": "Mise à jour…"
+    },
+    "google": {
+      "label": "Continuer avec Google",
+      "redirecting": "Redirection…"
+    },
+    "checkEmail": {
+      "title": "Vérifie ta boîte mail",
+      "metaTitle": "Vérifie ton email",
+      "body": "On vient de t'envoyer un lien de confirmation. Clique dessus pour activer ton compte.",
+      "backToLogin": "Retour à la connexion"
+    }
+  },
+  "onboarding": {
+    "defaultWorkspaceName": "Mon espace",
+    "previous": "Retour",
+    "next": "Continuer",
+    "finish": "Terminer",
+    "finishing": "Enregistrement…",
+    "validation": {
+      "workspaceNameRequired": "Donne un nom à ton espace.",
+      "incomeInvalid": "Renseigne un revenu valide (≥ 0)."
+    },
+    "step1": {
+      "title": "Nomme ton espace",
+      "description": "Tu pourras le modifier plus tard dans les paramètres.",
+      "nameLabel": "Nom de l'espace"
+    },
+    "step2": {
+      "title": "Ton revenu mensuel net",
+      "description": "Sert de base pour te suggérer les virements mensuels.",
+      "incomeLabel": "Revenu mensuel net (€)"
+    },
+    "step3": {
+      "title": "Ta première charge (optionnel)",
+      "description": "Ajoute un loyer, une assurance, un abonnement…",
+      "labelLabel": "Libellé",
+      "labelPlaceholder": "Loyer, assurance auto…",
+      "amountLabel": "Montant (€)",
+      "frequencyLabel": "Fréquence",
+      "dueMonthLabel": "Mois de référence",
+      "skipLater": "Je renseignerai mes charges plus tard"
+    }
+  },
+  "app": {
+    "dashboard": {
+      "metaTitle": "Tableau de bord",
+      "headerTitle": "{month} — ton cockpit",
+      "emptyTitle": "Commence par ajouter tes charges",
+      "emptyDescription": "Loyer, assurances, abonnements — Ankora les lisse sur 12 mois pour toi.",
+      "emptyCta": "Ajouter une charge",
+      "kpiProvisionsMonthly": "Provisions / mois",
+      "kpiProvisionsAnnualHint": "Annuel : {amount}",
+      "kpiHealth": "Santé provisions",
+      "kpiHealthTargetHint": "Cible : {amount}",
+      "kpiSuggestedTransfer": "Virement suggéré",
+      "kpiSuggestedTransferToSavings": "À mettre de côté",
+      "kpiSuggestedTransferFromSavings": "À retirer de l'épargne",
+      "kpiBillsMonth": "Factures {month}",
+      "kpiBillsHint": "Sortie de cash ce mois",
+      "healthHealthy": "Sain",
+      "healthWarning": "À surveiller",
+      "healthCritical": "Critique",
+      "planTitle": "Plan du mois — {month}",
+      "planDescription": "Les virements à exécuter en début de mois sur tes trois comptes.",
+      "planAdjustAccounts": "Ajuster mes comptes",
+      "missingSetupTitle": "Renseigne d'abord tes comptes",
+      "missingSetupDescription": "Pour calculer ton Virement Intelligent, Ankora a besoin de ton revenu mensuel et du montant fixe que tu envoies sur Vie Courante.",
+      "missingSetupCta": "Configurer mes comptes",
+      "transferPrincipalToVieCourante": "Principal → Vie Courante",
+      "transferVieCouranteHint": "Enveloppe courses, essence, restos.",
+      "transferPrincipalToEpargne": "Principal → Épargne",
+      "transferEpargneToPrincipal": "Épargne → Principal",
+      "transferEpargneHint": "Provision {provision} − factures {bills}",
+      "transferPrincipalRemaining": "Restant Principal",
+      "transferPrincipalRemainingHint": "Après salaire, virements et factures Principal ({bills}).",
+      "ctaCharges": "Mes charges",
+      "ctaExpenses": "Mes dépenses",
+      "ctaSimulator": "Simuler",
+      "expensesTitle": "Dépenses — {month}",
+      "expensesCount": "{count, plural, =0 {Aucune dépense ce mois} one {1 dépense ce mois} other {# dépenses ce mois}}",
+      "expensesEmpty": "Aucune dépense enregistrée pour ce mois.",
+      "expensesViewAll": "Voir toutes les dépenses →"
+    },
+    "charges": {
+      "title": "Mes charges",
+      "subtitle": "Chaque charge est lissée automatiquement sur 12 mois.",
+      "addFormTitle": "Ajouter une charge",
+      "emptyState": "Aucune charge pour l'instant.",
+      "labelLabel": "Libellé",
+      "amountLabel": "Montant (€)",
+      "frequencyLabel": "Fréquence",
+      "dueMonthLabel": "Mois de référence",
+      "addButton": "Ajouter",
+      "adding": "Ajout…",
+      "count": "{count, plural, =0 {aucune charge} one {1 charge} other {# charges}}",
+      "referenceFormat": "{frequency} · ref. {month}",
+      "deleteAria": "Supprimer {label}",
+      "toastCreated": "Charge ajoutée",
+      "toastDeleted": "Charge supprimée"
+    },
+    "accounts": {
+      "metaTitle": "Mes comptes",
+      "metaDescription": "Suis les soldes de tes comptes Principal, Vie Courante et Épargne. Règle ton revenu mensuel et ton virement vers Vie Courante.",
+      "title": "Mes comptes",
+      "subtitle": "Saisis tes soldes réels pour qu'Ankora calcule précisément ton virement intelligent chaque mois.",
+      "balancesHeading": "Soldes actuels",
+      "amountLabel": "Montant (€)",
+      "saveButton": "Enregistrer",
+      "saving": "Enregistrement…",
+      "income": {
+        "title": "Revenu mensuel net",
+        "description": "Le salaire qui arrive chaque mois sur ton compte Principal. Sert à calculer ce qu'il te reste après les charges et le virement vers Vie Courante.",
+        "placeholder": "Ex. 2500",
+        "toastSaved": "Revenu mensuel mis à jour"
+      },
+      "transfer": {
+        "title": "Virement mensuel vers Vie Courante",
+        "description": "Somme fixe transférée chaque mois du Principal vers ton compte Vie Courante. C'est ce qui servira aux courses, à l'essence et aux restos.",
+        "placeholder": "Ex. 500",
+        "toastSaved": "Virement mensuel mis à jour"
+      },
+      "balance": {
+        "invalidAmount": "Entre un montant valide.",
+        "saveLabel": "Mettre à jour",
+        "srLabel": "Solde actuel de {label}",
+        "toastSaved": "{name} mis à jour"
+      },
+      "kind": {
+        "principal": {
+          "description": "Reçoit le salaire, paye les charges fixes mensuelles."
+        },
+        "vieCourante": {
+          "description": "Budget du quotidien (courses, essence, restos)."
+        },
+        "epargne": {
+          "description": "Lisse les factures trimestrielles et annuelles."
+        }
+      },
+      "types": {
+        "income_bills": "Salaires & Factures",
+        "provisions": "Provisions Annuelles",
+        "daily_card": "Courses, Essence, Loisirs"
+      },
+      "defaults": {
+        "income_bills": "Compte Principal",
+        "provisions": "Compte Épargne",
+        "daily_card": "Carte Quotidien"
+      }
+    },
+    "expenses": {
+      "title": "Mes dépenses",
+      "subtitle": "Les sorties hors charges récurrentes — courses, resto, loisirs…",
+      "addFormTitle": "Ajouter une dépense",
+      "labelLabel": "Libellé",
+      "amountLabel": "Montant (€)",
+      "dateLabel": "Date",
+      "addButton": "Ajouter",
+      "adding": "Ajout…",
+      "emptyState": "Aucune dépense enregistrée.",
+      "summary": "{count, plural, =0 {Aucune dépense} one {1 dépense · {total}} other {# dépenses · {total}}}",
+      "deleteAria": "Supprimer {label}",
+      "toastCreated": "Dépense ajoutée",
+      "toastDeleted": "Dépense supprimée"
     },
     "settings": {
-    "displayName": {
-      "required": "Nom requis.",
-      "tooLong": "Maximum 80 caractères."
+      "metaTitle": "Paramètres",
+      "metaDescription": "Gère ton profil, la sécurité 2FA et tes données personnelles.",
+      "title": "Paramètres",
+      "description": "Profil, sécurité et données personnelles.",
+      "profile": {
+        "title": "Profil",
+        "description": "Ces informations personnalisent ton cockpit.",
+        "emailLabel": "Email",
+        "displayNameLabel": "Nom d'affichage",
+        "localeLabel": "Langue",
+        "localeOptions": {
+          "fr-BE": "Français (Belgique)",
+          "fr-FR": "Français (France)",
+          "en-GB": "English"
+        },
+        "submit": "Enregistrer",
+        "submitting": "Enregistrement…",
+        "toastSaved": "Profil mis à jour"
+      },
+      "mfa": {
+        "title": "Sécurité — 2FA",
+        "description": "Un code à usage unique généré par une app d'authentification (Authy, 1Password, Google Authenticator).",
+        "emptyState": "Aucun facteur 2FA actif. Active-le pour protéger ton compte.",
+        "enrollButton": "Activer la 2FA",
+        "enrolling": "Préparation…",
+        "scanInstruction": "Scanne ce QR code dans ton app d'authentification, puis saisis le code à 6 chiffres.",
+        "qrAlt": "QR code pour l'app d'authentification",
+        "manualEntry": "Saisie manuelle",
+        "codeLabel": "Code à 6 chiffres",
+        "verifyButton": "Vérifier et activer",
+        "verifying": "Vérification…",
+        "cancel": "Annuler",
+        "defaultFactorName": "App TOTP",
+        "activeLabel": "Actif",
+        "disableButton": "Désactiver",
+        "toastEnabled": "MFA activé",
+        "toastDisabled": "MFA désactivé"
+      },
+      "data": {
+        "title": "Mes données",
+        "description": "Portabilité RGPD (art. 20) — télécharge un JSON complet de tout ce qu'Ankora détient sur toi.",
+        "exportButton": "Télécharger mes données",
+        "exporting": "Génération…",
+        "toastDownloaded": "Export téléchargé"
+      },
+      "danger": {
+        "scheduledTitle": "Suppression en cours",
+        "scheduledBody": "Ton compte sera supprimé le <strong>{date}</strong>. Tu peux annuler à tout moment jusque-là.",
+        "viewStatus": "Voir le statut",
+        "title": "Zone dangereuse",
+        "description": "Suppression définitive du compte. Grâce de 30 jours pour annuler — après, tout est effacé (logs audit pseudonymisés).",
+        "reasonLabel": "Raison (optionnel)",
+        "reasonPlaceholder": "Aide-nous à nous améliorer…",
+        "confirmLabel": "Pour confirmer, tape ton adresse e-mail : <code>{email}</code>",
+        "submit": "Supprimer mon compte",
+        "submitting": "Programmation…",
+        "toastScheduled": "Suppression programmée — tu as 30 jours pour annuler"
+      }
+    },
+    "simulator": {
+      "title": "Simulateur",
+      "subtitle": "Mesure l'impact d'un changement sans toucher à tes données réelles.",
+      "scenario": {
+        "title": "Scénario",
+        "description": "Choisis une action à simuler.",
+        "modes": {
+          "cancel": "Annuler une charge",
+          "negotiate": "Renégocier",
+          "add": "Ajouter une charge"
+        }
+      },
+      "fields": {
+        "charge": "Charge",
+        "chargePlaceholder": "Sélectionne…",
+        "newAmount": "Nouveau montant (€)",
+        "label": "Libellé",
+        "amount": "Montant (€)",
+        "frequency": "Fréquence",
+        "month": "Mois"
+      },
+      "impact": {
+        "title": "Impact",
+        "empty": "Complète le scénario pour voir l'impact.",
+        "currentMonthly": "Actuel / mois",
+        "projectedMonthly": "Projeté / mois",
+        "annualSavings": "Économie annuelle",
+        "monthlyChange": "{sign}{percent}% / mois"
+      }
+    },
+    "deletionStatus": {
+      "title": "Suppression du compte",
+      "subtitle": "État détaillé de ta demande et période d'annulation.",
+      "metaTitle": "Statut de suppression",
+      "metaDescription": "État de la demande de suppression de ton compte Ankora.",
+      "statusLabel": "Statut :",
+      "requestedOn": "Demandée le {date}.",
+      "statusPending": "En attente",
+      "statusCancelled": "Annulée",
+      "statusCompleted": "Complétée",
+      "scheduledFor": "Suppression prévue",
+      "daysLeft": "Jours restants",
+      "auditLogs": "Logs audit",
+      "auditLogsValue": "Pseudonymisés, jamais supprimés",
+      "daysCount": "{days, plural, =0 {Aujourd'hui} one {# jour} other {# jours}}",
+      "backToSettings": "Retour aux paramètres",
+      "cancelledOn": "Demande annulée le {date}. Ton compte est conservé.",
+      "cancelledNoDate": "Demande annulée. Ton compte est conservé.",
+      "cancelButton": "Annuler la suppression",
+      "cancelling": "Annulation…",
+      "toastCancelled": "Demande annulée — ton compte est conservé"
+    },
+    "cockpit": {
+      "capaciteEpargneReelle": {
+        "title": "Capacité d'Épargne Réelle",
+        "messagePositive": "C'est ton vrai reste à vivre chaque mois, sans surprise.",
+        "messageNegative": "Attention, ton train de vie global dépasse tes revenus.",
+        "tooltip": "Cette valeur soustrait toutes tes charges (lissées sur l'année) et ton plafond Quotidien à tes revenus mensuels. C'est ce qu'il te reste réellement chaque mois pour épargner ou pour les imprévus."
+      },
+      "santeProvisions": {
+        "title": "Santé des Provisions",
+        "cibleTheorique": "Cible théorique idéale :",
+        "soldeActuel": "Solde actuel :",
+        "statutAJour": "À jour ✨",
+        "deficit": "Déficit détecté :",
+        "rattrapageDescription": "Inclut +{amount} € pour rattraper le déficit sur 3 mois.",
+        "tooltip": "L'algorithme calcule ce que ton compte Épargne devrait contenir aujourd'hui pour absorber sereinement toutes tes charges périodiques à venir."
+      },
+      "virements": {
+        "title": "Assistant Virements",
+        "provisionsMensuelles": "Provisions mensuelles :",
+        "facturesAnnuelles": "Factures annuelles ce mois-ci :",
+        "aVirer": "À virer vers l'Épargne :",
+        "aRecuperer": "À récupérer de l'Épargne :",
+        "aucun": "Aucun virement nécessaire ce mois-ci. Les provisions couvrent exactement les factures périodiques.",
+        "descriptionAVirer": "Couvre tes provisions mensuelles, déduction faite des factures de ce mois.",
+        "descriptionDepuis": "Les factures annuelles de ce mois dépassent ta provision. Utilise ton épargne !",
+        "detailHeader": "Détail des {amount} € de provisions :"
+      },
+      "notifications": {
+        "transferToSavings": "N'oublie pas de virer {amount} € vers l'Épargne ce mois-ci.",
+        "transferFromSavings": "Tu dois récupérer {amount} € de l'Épargne pour les factures de ce mois.",
+        "chargeOverdue": "{label} en retard (prévue le {day}).",
+        "chargeDueSoon": "{label} due dans {days} jour(s)."
+      }
+    }
+  },
+  "glossary": {
+    "title": "Glossaire",
+    "subtitle": "15 termes essentiels pour comprendre ta gestion budgétaire et tes finances personnelles.",
+    "metaTitle": "Glossaire — Termes financiers",
+    "metaDescription": "Glossaire des 15 termes essentiels de la gestion budgétaire : budget de lissage, compte bucket, épargne de précaution, et plus.",
+    "breadcrumb": {
+      "home": "Accueil",
+      "glossary": "Glossaire"
+    },
+    "section": {
+      "whyItMatters": "Pourquoi c'est important",
+      "example": "Exemple concret",
+      "relatedTerms": "Termes liés"
+    }
+  },
+  "errors": {
+    "generic": "Une erreur est survenue. Réessaie.",
+    "session": {
+      "expired": "Session expirée. Reconnecte-toi.",
+      "rateLimited": "Trop de requêtes. Attends une minute."
+    },
+    "auth": {
+      "invalidCredentials": "Email ou mot de passe incorrect.",
+      "signupFailed": "Inscription impossible. Réessaie plus tard.",
+      "googleFailed": "Connexion Google indisponible. Réessaie plus tard.",
+      "rateLimited": "Trop de tentatives. Réessaie dans quelques minutes.",
+      "serviceTemporarilyUnavailable": "Service temporairement indisponible. Réessaie dans quelques minutes.",
+      "passwordResetFailed": "Impossible de mettre à jour le mot de passe.",
+      "linkExpired": "Lien expiré. Demande un nouveau lien.",
+      "mfaEnrollFailed": "Impossible de démarrer l'enrôlement.",
+      "mfaChallengeFailed": "Challenge MFA impossible.",
+      "mfaCodeInvalid": "Code incorrect. Réessaie.",
+      "mfaDisableFailed": "Impossible de désactiver la 2FA."
+    },
+    "db": {
+      "workspaceNotFound": "Aucun workspace éditable.",
+      "updateFailed": "Mise à jour impossible.",
+      "notEditable": "Tu n'as pas les droits d'édition sur cet espace."
+    },
+    "validation": {
+      "generic": "Données invalides.",
+      "auth": {
+        "email": {
+          "invalid": "Adresse email invalide."
+        },
+        "password": {
+          "required": "Mot de passe requis.",
+          "tooShort": "Au moins 12 caractères.",
+          "tooLong": "Maximum 128 caractères.",
+          "lowercase": "Au moins une minuscule.",
+          "uppercase": "Au moins une majuscule.",
+          "digit": "Au moins un chiffre."
+        },
+        "passwordConfirm": {
+          "mismatch": "Les mots de passe ne correspondent pas."
+        },
+        "acceptTos": {
+          "required": "Tu dois accepter les CGU."
+        },
+        "acceptPrivacy": {
+          "required": "Tu dois accepter la politique de confidentialité."
+        }
+      },
+      "charge": {
+        "label": {
+          "required": "Libellé requis.",
+          "tooLong": "Maximum 120 caractères."
+        },
+        "amount": {
+          "invalid": "Montant invalide.",
+          "negative": "Le montant doit être ≥ 0.",
+          "tooHigh": "Montant trop élevé."
+        },
+        "frequency": {
+          "invalid": "Fréquence invalide."
+        },
+        "dueMonth": {
+          "range": "Mois entre 1 et 12."
+        },
+        "paidFrom": {
+          "invalid": "Compte débiteur invalide."
+        }
+      },
+      "account": {
+        "kind": {
+          "invalid": "Type de compte invalide."
+        },
+        "balance": {
+          "invalid": "Solde invalide.",
+          "outOfRange": "Valeur hors limites."
+        },
+        "label": {
+          "required": "Libellé requis.",
+          "tooLong": "Maximum 80 caractères."
+        }
+      },
+      "workspace": {
+        "name": {
+          "required": "Nom requis.",
+          "tooLong": "Maximum 80 caractères."
+        },
+        "income": {
+          "invalid": "Revenu invalide.",
+          "negative": "Doit être ≥ 0.",
+          "tooHigh": "Revenu trop élevé."
+        },
+        "transfer": {
+          "invalid": "Montant invalide.",
+          "negative": "Doit être ≥ 0.",
+          "tooHigh": "Montant trop élevé."
+        }
+      },
+      "expense": {
+        "label": {
+          "required": "Libellé requis.",
+          "tooLong": "Maximum 120 caractères."
+        },
+        "amount": {
+          "invalid": "Montant invalide.",
+          "negative": "Doit être ≥ 0.",
+          "tooHigh": "Montant trop élevé."
+        },
+        "date": {
+          "format": "Format attendu : YYYY-MM-DD."
+        },
+        "category": {
+          "invalid": "Catégorie invalide."
+        }
+      },
+      "settings": {
+        "displayName": {
+          "required": "Nom requis.",
+          "tooLong": "Maximum 80 caractères."
+        },
+        "locale": {
+          "invalid": "Langue invalide."
+        },
+        "factorId": {
+          "invalid": "Identifiant invalide."
+        },
+        "mfaCode": {
+          "invalid": "Code à 6 chiffres."
+        },
+        "deletion": {
+          "confirm": "Cette adresse ne correspond pas à ton compte."
+        }
+      },
+      "onboarding": {
+        "workspace": {
+          "required": "Nom requis.",
+          "tooLong": "Maximum 80 caractères."
+        },
+        "income": {
+          "invalid": "Revenu invalide.",
+          "negative": "Doit être ≥ 0.",
+          "tooHigh": "Revenu trop élevé."
+        },
+        "firstCharge": {
+          "label": {
+            "required": "Libellé requis.",
+            "tooLong": "Maximum 120 caractères."
+          },
+          "amount": {
+            "invalid": "Montant invalide.",
+            "negative": "Doit être ≥ 0.",
+            "tooHigh": "Montant trop élevé."
+          },
+          "dueMonth": {
+            "range": "Mois entre 1 et 12."
+          }
+        }
+      }
+    },
+    "charges": {
+      "createFailed": "Impossible de créer la charge.",
+      "updateFailed": "Impossible de mettre à jour la charge.",
+      "deleteFailed": "Impossible de supprimer la charge."
+    },
+    "accounts": {
+      "balanceUpdateFailed": "Impossible de mettre à jour le solde.",
+      "renameFailed": "Impossible de renommer le compte.",
+      "incomeUpdateFailed": "Impossible de mettre à jour le revenu.",
+      "transferUpdateFailed": "Impossible de mettre à jour le virement."
+    },
+    "expenses": {
+      "createFailed": "Impossible de créer la dépense.",
+      "deleteFailed": "Impossible de supprimer la dépense."
+    },
+    "settings": {
+      "profileUpdateFailed": "Impossible de mettre à jour le profil.",
+      "deletionRequestFailed": "Impossible de programmer la suppression.",
+      "deletionCancelFailed": "Impossible d'annuler la demande.",
+      "exportLimited": "Export limité à une fois toutes les 5 minutes."
+    },
+    "onboarding": {
+      "workspaceNotFound": "Workspace introuvable. Contacte le support.",
+      "workspaceUpdateFailed": "Impossible de mettre à jour le workspace.",
+      "chargeFailed": "Workspace créé mais charge non enregistrée."
     },
     "locale": {
       "invalid": "Langue invalide."
-    },
-    "factorId": {
-      "invalid": "Identifiant invalide."
-    },
-    "mfaCode": {
-      "invalid": "Code à 6 chiffres."
-    },
-    "deletion": {
-      "confirm": "Cette adresse ne correspond pas à ton compte."
     }
-    },
-    "onboarding": {
-    "workspace": {
-      "required": "Nom requis.",
-      "tooLong": "Maximum 80 caractères."
-    },
-    "income": {
-      "invalid": "Revenu invalide.",
-      "negative": "Doit être ≥ 0.",
-      "tooHigh": "Revenu trop élevé."
-    },
-    "firstCharge": {
-      "label": {
-      "required": "Libellé requis.",
-      "tooLong": "Maximum 120 caractères."
-      },
-      "amount": {
-      "invalid": "Montant invalide.",
-      "negative": "Doit être ≥ 0.",
-      "tooHigh": "Montant trop élevé."
-      },
-      "dueMonth": {
-      "range": "Mois entre 1 et 12."
-      }
-    }
-    }
-  },
-  "charges": {
-    "createFailed": "Impossible de créer la charge.",
-    "updateFailed": "Impossible de mettre à jour la charge.",
-    "deleteFailed": "Impossible de supprimer la charge."
-  },
-  "accounts": {
-    "balanceUpdateFailed": "Impossible de mettre à jour le solde.",
-    "renameFailed": "Impossible de renommer le compte.",
-    "incomeUpdateFailed": "Impossible de mettre à jour le revenu.",
-    "transferUpdateFailed": "Impossible de mettre à jour le virement."
-  },
-  "expenses": {
-    "createFailed": "Impossible de créer la dépense.",
-    "deleteFailed": "Impossible de supprimer la dépense."
-  },
-  "settings": {
-    "profileUpdateFailed": "Impossible de mettre à jour le profil.",
-    "deletionRequestFailed": "Impossible de programmer la suppression.",
-    "deletionCancelFailed": "Impossible d'annuler la demande.",
-    "exportLimited": "Export limité à une fois toutes les 5 minutes."
-  },
-  "onboarding": {
-    "workspaceNotFound": "Workspace introuvable. Contacte le support.",
-    "workspaceUpdateFailed": "Impossible de mettre à jour le workspace.",
-    "chargeFailed": "Workspace créé mais charge non enregistrée."
-  },
-  "locale": {
-    "invalid": "Langue invalide."
-  }
   },
   "opengraphImage": {
-  "trustHosting": "🇧🇪 Belgique · Hébergé UE",
-  "trustNoBank": "Sans agrégation bancaire",
-  "trustFree": "0 € Phase 1"
+    "trustHosting": "🇧🇪 Belgique · Hébergé UE",
+    "trustNoBank": "Sans agrégation bancaire",
+    "trustFree": "0 € Phase 1"
   }
 }

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -1,1024 +1,1068 @@
 {
   "common": {
-  "appName": "Ankora",
-  "tagline": "Je financieel houvast",
-  "description": "Ankora helpt je je vaste kosten te spreiden, elke factuur te anticiperen en de controle over je budget te houden. Een heldere en beveiligde cockpit, zonder beleggingsadvies.",
-  "homeAria": "Ankora startpagina",
-  "a11y": {
-    "skipToMain": "Ga naar de hoofdinhoud"
-  },
-  "nav": {
-    "mainLabel": "Hoofdnavigatie",
-    "appLabel": "Applicatienavigatie",
-    "mobileLabel": "Mobiele navigatie",
-    "footerLabel": "Voettekst",
-    "menu": "Menu",
-    "close": "Sluiten",
-    "lightMode": "Lichte modus",
-    "darkMode": "Donkere modus",
-    "features": "Functies",
-    "faq": "FAQ",
-    "login": "Inloggen",
-    "signup": "Account aanmaken",
-    "myCockpit": "Mijn cockpit",
-    "dashboard": "Dashboard",
-    "accounts": "Rekeningen",
-    "charges": "Vaste kosten",
-    "settings": "Instellingen"
-  },
-  "actions": {
-    "retry": "Opnieuw proberen",
-    "back": "Terug"
-  },
-  "months": {
-    "1": "januari",
-    "2": "februari",
-    "3": "maart",
-    "4": "april",
-    "5": "mei",
-    "6": "juni",
-    "7": "juli",
-    "8": "augustus",
-    "9": "september",
-    "10": "oktober",
-    "11": "november",
-    "12": "december"
-  },
-  "monthsShort": {
-    "1": "jan.",
-    "2": "feb.",
-    "3": "mrt.",
-    "4": "apr.",
-    "5": "mei",
-    "6": "jun.",
-    "7": "jul.",
-    "8": "aug.",
-    "9": "sep.",
-    "10": "okt.",
-    "11": "nov.",
-    "12": "dec."
-  },
-  "frequency": {
-    "monthly": "Maandelijks",
-    "quarterly": "Driemaandelijks",
-    "semiannual": "Halfjaarlijks",
-    "annual": "Jaarlijks"
-  }
-  },
-  "ui": {
-  "scrollToTop": "Terug naar boven",
-  "localeSwitcher": {
-    "label": "Taal",
-    "aria": "Taal wijzigen",
-    "options": {
-    "fr-BE": "Français (BE)",
-    "nl-BE": "Nederlands (BE)",
-    "en": "English",
-    "es-ES": "Español",
-    "de-DE": "Deutsch"
-    }
-  },
-  "action": {
-    "submit": "Bevestigen",
-    "submitting": "Bevestigen…",
-    "save": "Opslaan",
-    "saving": "Opslaan…",
-    "cancel": "Annuleren",
-    "cancelling": "Annuleren…",
-    "delete": "Verwijderen",
-    "deleting": "Verwijderen…",
-    "create": "Aanmaken",
-    "creating": "Aanmaken…",
-    "update": "Bijwerken",
-    "updating": "Bijwerken…",
-    "send": "Versturen",
-    "sending": "Versturen…",
-    "verify": "Verifiëren",
-    "verifying": "Verifiëren…",
-    "generate": "Genereren",
-    "generating": "Genereren…",
-    "download": "Downloaden",
-    "downloading": "Downloaden…",
-    "preparing": "Voorbereiden…",
-    "confirm": "Bevestigen",
-    "close": "Sluiten"
-  }
-  },
-  "landing": {
-  "mktnav": {
-    "links": {
-    "product": "Produit",
-    "simulator": "Simulateur",
-    "pricing": "Tarifs",
-    "security": "Sécurité",
-    "journal": "Journal"
+    "appName": "Ankora",
+    "tagline": "Je financieel houvast",
+    "description": "Ankora helpt je je vaste kosten te spreiden, elke factuur te anticiperen en de controle over je budget te houden. Een heldere en beveiligde cockpit, zonder beleggingsadvies.",
+    "homeAria": "Ankora startpagina",
+    "a11y": {
+      "skipToMain": "Ga naar de hoofdinhoud"
     },
-    "ctaLogin": "Se connecter",
-    "ctaSignup": "Essayer gratuitement"
-  },
-  "hero": {
-    "badge": "Nouveau · Simulateur what-if",
-    "h1Lead": "Ton ancrage",
-    "h1Highlight": "financier.",
-    "description": "Ankora sépare tes provisions affectées de ta réserve libre, projette six mois devant, et te laisse simuler l'impact de chaque décision — en clair, sans jargon.",
-    "ctaPrimary": "Ouvrir mon cockpit",
-    "ctaSecondary": "Voir le simulateur",
-    "trust": {
-    "encrypted": "Données chiffrées en Belgique",
-    "noSale": "Aucune vente de données",
-    "languages": "FR · NL · EN"
+    "nav": {
+      "mainLabel": "Hoofdnavigatie",
+      "appLabel": "Applicatienavigatie",
+      "mobileLabel": "Mobiele navigatie",
+      "footerLabel": "Voettekst",
+      "menu": "Menu",
+      "close": "Sluiten",
+      "lightMode": "Lichte modus",
+      "darkMode": "Donkere modus",
+      "features": "Functies",
+      "faq": "FAQ",
+      "login": "Inloggen",
+      "signup": "Account aanmaken",
+      "myCockpit": "Mijn cockpit",
+      "dashboard": "Dashboard",
+      "accounts": "Rekeningen",
+      "charges": "Vaste kosten",
+      "settings": "Instellingen"
     },
-    "mockup": {
-    "eyebrow": "Aperçu cockpit",
-    "browserUrl": "Ankora · cockpit",
-    "kpis": {
-      "netRemaining": {
-      "label": "Net restant",
-      "sub": "avril · après provisions"
-      },
-      "provisions": {
-      "label": "Provisions",
-      "sub": "67 % des 2 480 € planifiés"
-      },
-      "reserve": {
-      "label": "Réserve",
-      "sub": "+120 € vs. mars"
-      }
-    }
+    "actions": {
+      "retry": "Opnieuw proberen",
+      "back": "Terug"
     },
-    "waterfall": {
-    "income": "Revenus",
-    "incomeAmount": "+2 466 €",
-    "expenses": "Dépenses courantes",
-    "expensesAmount": "−1 959 €",
-    "provisionsCaption": "dont {amount} € lissés vers provisions affectées",
-    "available": "Argent disponible",
-    "availableAmount": "+507 €",
-    "ariaLabel": "Cascade illustrative : 2 466 € de revenus, 1 959 € de dépenses courantes (dont 59 € lissés en provisions), 507 € disponibles."
-    }
-  },
-  "principles": {
-    "eyebrow": "Trois principes",
-    "h2": "Une façon honnête de parler d'argent.",
-    "description": "Ankora n'essaye pas de te vendre un placement ou une carte. On sépare, on projette, on simule. C'est tout. Toi seul décides.",
-    "items": {
-    "provisions": {
-      "title": "Provisions affectées",
-      "description": "Chaque euro réservé a un nom : mutuelle, taxe circulation, entretien chaudière. Rien ne fuit sans que tu le saches."
-    },
-    "reserve": {
-      "title": "Réserve libre",
-      "description": "Ce qui reste vraiment à toi, après les engagements. Le vrai chiffre — pas l'illusion du solde brut."
-    },
-    "whatIf": {
-      "title": "Simulateur what-if",
-      "description": "Renégocier l'électricité ? Changer de fournisseur ? Ankora te montre l'impact sur 12 mois avant que tu décides."
-    }
-    }
-  },
-  "feature": {
-    "eyebrow": "Cashflow waterfall",
-    "h3Line1": "Du salaire au net disponible.",
-    "h3Line2": "En un seul coup d'œil.",
-    "description": "Plus de mystère sur où va ton argent. Chaque étape est visible : revenus, dépenses courantes, argent disponible. Tu vois immédiatement si un poste dérape.",
-    "ctaPrimary": "Voir un exemple",
-    "ctaSecondary": "Comment ça marche ?"
-  },
-  "whatif": {
-    "title": "Et si tu changeais une seule chose ?",
-    "subtitle": "Bouge le curseur. Vois l'impact sur ta réserve libre, sur six mois. C'est ce que fait Ankora à chaque décision financière.",
-    "badge": "Démo · pas de compte requis",
-    "scenarios": {
-    "gsm": {
-      "label": "Renégocier mon GSM",
-      "hint": "Forfait actuel : 42 €/mois · marché : 18–28 €/mois"
-    },
-    "elec": {
-      "label": "Changer de fournisseur d'électricité",
-      "hint": "Conso actuelle : 168 €/mois · 3 offres moins chères dans ta zone"
-    },
-    "stream": {
-      "label": "Couper deux streamings",
-      "hint": "5 abonnements actifs · usage réel : 2 sur 30 jours"
-    }
-    },
-    "controls": {
-    "scenario": "Scénario",
-    "savings": "Économie mensuelle",
-    "slider_aria": "Économie mensuelle pour {label}"
-    },
-    "annual": {
-    "eyebrow": "Sur 12 mois",
-    "fleche": "Ankora pourrait flécher {amount} €/mois vers ton épargne longue."
-    },
-    "chart": {
-    "title": "Réserve libre · projection",
-    "subtitle": "6 mois à partir d'aujourd'hui",
-    "legend": {
-      "baseline": "Sans changement",
-      "scenario": "Avec ton choix"
-    },
-    "aria": "Graphique projection sur 6 mois de la réserve libre, avec et sans le changement choisi",
     "months": {
-      "may": "mai",
-      "jun": "juin",
-      "jul": "juil",
-      "aug": "août",
-      "sep": "sept",
-      "oct": "oct"
+      "1": "januari",
+      "2": "februari",
+      "3": "maart",
+      "4": "april",
+      "5": "mei",
+      "6": "juni",
+      "7": "juli",
+      "8": "augustus",
+      "9": "september",
+      "10": "oktober",
+      "11": "november",
+      "12": "december"
     },
-    "thresholds": {
-      "danger": "⚠️ Découvert estimé",
-      "fragile": "Zone fragile",
-      "comfortable": "Zone confortable"
-    }
-    },
-    "caveat": "Démo basée sur des hypothèses moyennes. Ankora ne fournit pas de conseil en placement. Aucun import bancaire — tu saisis tes charges manuellement."
-  },
-  "pricing": {
-    "eyebrow": "Transparent dès le départ",
-    "h2": "Gratuit pendant la Phase 1.",
-    "phaseBadge": "Phase 1 · construction",
-    "price": "0 €",
-    "period": "pour l'instant, et sans date limite",
-    "body": "On construit d'abord le cockpit. Pas de carte demandée, pas de limite de temps, pas de fonctionnalité bridée. Export RGPD à tout moment.",
-    "features": {
-    "cockpit": "Cockpit complet, provisions et réserve libre",
-    "simulator": "Simulateur what-if illimité",
-    "manualEntry": "Saisie manuelle · tes données restent en Belgique",
-    "export": "Export RGPD en un clic"
-    },
-    "ctaPrimary": "Ouvrir mon cockpit",
-    "roadmap": {
-    "title": "Tu rejoins Ankora pendant sa Phase 1 ?",
-    "body": "Ton compte garde un accès complet au cockpit core à vie, gratuitement. Une offre Pro avec features avancées (comptes illimités, exports consolidés, support prioritaire) arrivera post-v1.0 — tu auras le choix d'upgrader ou de rester sur ton plan actuel.",
-    "link": "Lire la roadmap →"
-    }
-  },
-  "footerCta": {
-    "h2Lead": "Commence par ce qui est",
-    "h2Highlight": "déjà à toi.",
-    "description": "30 jours d'essai, pas de carte, export RGPD à tout moment. On fait simple parce que c'est déjà assez compliqué comme ça.",
-    "ctaPrimary": "Ouvrir mon cockpit"
-  },
-  "footer": {
-    "links": {
-    "terms": "Conditions",
-    "privacy": "Confidentialité",
-    "security": "Sécurité",
-    "contact": "Contact"
-    },
-    "copyright": "Ankora · éditeur ancré à Bruxelles · 2026"
-  },
-  "faqHeading": "Veelgestelde vragen",
-  "faq": {
-    "advice": {
-    "q": "Is Ankora een tool voor financieel advies?",
-    "a": "Nee. Ankora is een tool voor budgetorganisatie en financiële educatie. Het levert geen beleggingsaanbevelingen of gepersonaliseerd financieel advies."
-    },
-    "storage": {
-    "q": "Waar worden mijn gegevens bewaard?",
-    "a": "Je gegevens worden gehost in de Europese Unie (Supabase, EU-regio) met versleuteling at rest en strikte isolatie per gebruiker via Row Level Security."
-    },
-    "sharing": {
-    "q": "Kan ik mijn gegevens delen?",
-    "a": "Standaard is je ruimte 100% privé. Optionele gedeelde potten (reis, gezamenlijk project) komen in een volgende versie — jij kiest expliciet wat je deelt en met wie."
-    }
-  }
-  },
-  "faq": {
-  "metaTitle": "FAQ",
-  "metaDescription": "Veelgestelde vragen over Ankora: veiligheid, gegevens, werking, privacy.",
-  "title": "Veelgestelde vragen",
-  "subtitle": "Alles wat je moet weten over Ankora voor je van start gaat.",
-  "items": {
-    "bankConnection": {
-    "q": "Maakt Ankora verbinding met mijn bank?",
-    "a": "Nee. Ankora gebruikt geen PSD2-richtlijn. Je geeft je vaste kosten en uitgaven handmatig in. Die keuze zorgt ervoor dat jij eigenaar blijft van je gegevens en dat er geen gevoelige bankinformatie bewaard wordt."
-    },
-    "dataLocation": {
-    "q": "Waar worden mijn gegevens gehost?",
-    "a": "Al je gegevens worden gehost in de Europese Unie (Supabase EU-regio, Vercel EU-regio, Upstash EU). Er worden geen gegevens buiten de EU overgedragen."
-    },
-    "smoothing": {
-    "q": "Hoe werkt de spreiding?",
-    "a": "Ankora neemt je driemaandelijkse, halfjaarlijkse en jaarlijkse vaste kosten en verdeelt ze over 12 maanden. Zo weet je hoeveel je elke maand opzij moet zetten om al je toekomstige facturen zonder stress te dekken."
-    },
-    "deletion": {
-    "q": "Kan ik mijn account verwijderen?",
-    "a": "Ja, op elk moment via Instellingen → Privacy. De verwijdering gaat 30 dagen na je aanvraag in (je kunt ze tijdens die periode annuleren). Al je financiële gegevens worden gewist, de beveiligingslogs worden gepseudonimiseerd."
-    },
-    "export": {
-    "q": "Kan ik mijn gegevens exporteren?",
-    "a": "Ja. De knop « Mijn gegevens downloaden » in Instellingen bezorgt je een volledig JSON-bestand met alles wat Ankora over jou bewaart. Conform het recht op dataportabiliteit AVG (art. 20)."
-    },
-    "advice": {
-    "q": "Geeft Ankora financieel advies?",
-    "a": "Nee. Ankora is een tool voor budgeteducatie en -organisatie. We geven geen enkel beleggingsadvies (reglementaire beperking FSMA België). Voor elke investeringsbeslissing, raadpleeg een erkende professional."
-    },
-    "ai": {
-    "q": "Wordt er artificiële intelligentie gebruikt?",
-    "a": "In Fase 1 niet. De berekeningen zijn deterministisch en controleerbaar. In Fase 2 laat een optionele BYOK-laag (Bring Your Own Key) je toe je eigen Anthropic- of OpenRouter-sleutel te koppelen voor suggesties — geen extra kost langs Ankora."
-    },
-    "sharing": {
-    "q": "Kan ik mijn ruimte delen met mijn kinderen of vrienden?",
-    "a": "In Fase 1 heeft elke gebruiker een privé-ruimte, standaard afgeschermd. In Fase 2 voegen we de mogelijkheid toe om « gedeelde potten » aan te maken (op uitnodiging, met viewer/editor-rollen) zonder ooit je persoonlijke gegevens te vermengen."
-    }
-  }
-  },
-  "legal": {
-  "versionLine": "Versie {version} — laatste update: {date}",
-  "lastUpdatedLine": "Laatste update: {date}",
-  "cgu": {
-    "metaTitle": "Algemene gebruiksvoorwaarden",
-    "metaDescription": "Gebruiksvoorwaarden van Ankora — regels voor het gebruik van de dienst.",
-    "title": "Algemene gebruiksvoorwaarden",
-    "s1": {
-    "heading": "1. Doel",
-    "body": "Ankora is een tool voor budgetorganisatie en financiële educatie bestemd voor particulieren. Hij laat toe om handmatig vaste kosten en uitgaven in te geven, ze over het jaar te spreiden en cashflowbehoeften te anticiperen."
-    },
-    "s2": {
-    "heading": "2. Wat Ankora NIET is",
-    "item1": "Ankora is <b>geen dienst voor beleggingsadvies</b> of investeringsadvies.",
-    "item2": "Ankora is <b>geen bankdienst</b> en houdt geen geld aan.",
-    "item3": "Ankora is <b>geen PSD2-aggregator</b> — geen enkele verbinding met je bankrekeningen.",
-    "item4": "Ankora is <b>geen professionele boekhoudsoftware</b>.",
-    "outro": "De getoonde informatie zijn schattingen op basis van jouw invoer. Ze vormen geen gepersonaliseerd financieel advies. Voor elke belangrijke beslissing, raadpleeg een erkende professional."
-    },
-    "s3": {
-    "heading": "3. Account",
-    "item1": "Je moet meerderjarig zijn of toestemming hebben van een wettelijke vertegenwoordiger.",
-    "item2": "Eén account per natuurlijke persoon.",
-    "item3": "Wachtwoord minimum 12 tekens, gemengd.",
-    "item4": "Je bent verantwoordelijk voor de vertrouwelijkheid van je inloggegevens."
-    },
-    "s4": {
-    "heading": "4. Aanvaardbaar gebruik",
-    "intro": "Je verbindt je ertoe om niet:",
-    "item1": "de dienst te gebruiken voor illegale doeleinden,",
-    "item2": "de beveiligingsmaatregelen te proberen omzeilen,",
-    "item3": "de toegang te automatiseren zonder expliciete toestemming,",
-    "item4": "je account te delen met een derde."
-    },
-    "s5": {
-    "heading": "5. Intellectuele eigendom",
-    "body": "Jij blijft eigenaar van je gegevens. Ankora behoudt de eigendom van zijn code, merk, design en documentatie."
-    },
-    "s6": {
-    "heading": "6. Aansprakelijkheid",
-    "body": "Ankora wordt geleverd « as is ». De uitgever kan niet aansprakelijk gesteld worden voor financiële beslissingen genomen op basis van de getoonde informatie. Geen garantie op 100% beschikbaarheid."
-    },
-    "s7": {
-    "heading": "7. Beëindiging",
-    "body": "Je kunt je account op elk moment verwijderen via Instellingen → Privacy. De verwijdering wordt 30 dagen na de aanvraag effectief (annuleerbare periode)."
-    },
-    "s8": {
-    "heading": "8. Toepasselijk recht",
-    "body": "Deze voorwaarden zijn onderworpen aan het Belgische recht. Bevoegde rechtbank: Brussel."
-    },
-    "draft": "Onze algemene gebruiksvoorwaarden worden momenteel opgesteld.",
-    "contact": "Voor elke vraag, contacteer ons: thierryvm@gmail.com",
-    "backHome": "Terug naar de startpagina"
-  },
-  "privacy": {
-    "metaTitle": "Privacybeleid",
-    "metaDescription": "Privacybeleid van Ankora — EU-hosting, AVG, gebruikersrechten.",
-    "title": "Privacybeleid",
-    "s1": {
-    "heading": "1. Verwerkingsverantwoordelijke",
-    "body": "Ankora, uitgegeven door Thierry Van Mele (België). Contact: <mail>thierryvm@gmail.com</mail>."
-    },
-    "s2": {
-    "heading": "2. Verzamelde gegevens",
-    "intro": "Ankora verzamelt enkel de gegevens die strikt noodzakelijk zijn voor het leveren van de dienst:",
-    "item1": "<b>Identiteit</b>: e-mailadres, weergavenaam (optioneel).",
-    "item2": "<b>Financiële gegevens die jij ingeeft</b>: vaste kosten, uitgaven, categorieën, opgegeven inkomens, spaarsaldo.",
-    "item3": "<b>Technische gegevens</b>: IP-adres, user-agent (enkel voor beveiligingslogs).",
-    "item4": "<b>Toestemmingen</b>: tijdstempel, versie, reikwijdte (gebruiksvoorwaarden, privacy, cookies).",
-    "outro": "Ankora maakt geen verbinding met een bank (geen PSD2-aggregatie). Je geeft zelf je vaste kosten en uitgaven in."
-    },
-    "s3": {
-    "heading": "3. Rechtsgronden (AVG art. 6)",
-    "item1": "<b>Contract</b>: levering van de dienst (account, financiële gegevens).",
-    "item2": "<b>Toestemming</b>: analytics/marketing-cookies, nieuwsbrief.",
-    "item3": "<b>Wettelijke verplichting</b>: beveiligingslogs (bewaring 12 maanden).",
-    "item4": "<b>Gerechtvaardigd belang</b>: fraudepreventie, behoud van veiligheid."
-    },
-    "s4": {
-    "heading": "4. Hosting en onderaannemers",
-    "item1": "<b>Supabase</b> (database, auth) — EU-regio (Frankfurt of Parijs).",
-    "item2": "<b>Vercel</b> (frontend hosting) — EU-regio (Dublin).",
-    "item3": "<b>Upstash</b> (rate limiting) — EU-regio.",
-    "outro": "Geen enkele gegevens worden buiten de EU/EER overgedragen."
-    },
-    "s5": {
-    "heading": "5. Bewaartermijn",
-    "item1": "Actief account: zolang je de dienst gebruikt.",
-    "item2": "Verwijderd account: verwijdering effectief 30 dagen na je aanvraag (annuleerbare grace period).",
-    "item3": "Beveiligingslogs: maximum 12 maanden, gepseudonimiseerd na accountverwijdering."
-    },
-    "s6": {
-    "heading": "6. Je rechten (AVG art. 15-22)",
-    "item1": "<b>Inzage</b>: raadpleeg je gegevens op elk moment in je ruimte.",
-    "item2": "<b>Rectificatie</b>: wijzig profiel en gegevens in de voorziene pagina's.",
-    "item3": "<b>Verwijdering</b>: knop « Mijn account verwijderen » in Instellingen → Privacy.",
-    "item4": "<b>Portabiliteit</b>: knop « Mijn gegevens downloaden » — volledige JSON-export.",
-    "item5": "<b>Bezwaar / Beperking</b>: weiger of trek niet-essentiële cookies op elk moment in.",
-    "item6": "<b>Klacht</b>: bij de <apd>Gegevensbeschermingsautoriteit</apd> (België)."
-    },
-    "s7": {
-    "heading": "7. Veiligheid",
-    "item1": "Versleuteling in transit (TLS 1.3) en at rest.",
-    "item2": "Row Level Security Supabase op alle tabellen.",
-    "item3": "Rate limiting, strikte CSP, append-only audit log.",
-    "item4": "Authenticatie met sterk wachtwoord + MFA beschikbaar."
-    },
-    "s8": {
-    "heading": "8. Cookies",
-    "body": "Zie het <link>cookiebeleid</link>."
-    },
-    "s9": {
-    "heading": "9. Wijzigingen",
-    "body": "Elke materiële wijziging van dit beleid wordt per e-mail gemeld en vereist je vernieuwde toestemming om de dienst te blijven gebruiken."
-    },
-    "draft": "Ons privacybeleid wordt momenteel opgesteld.",
-    "contact": "Voor elke vraag, contacteer ons: thierryvm@gmail.com",
-    "backHome": "Terug naar de startpagina"
-  },
-  "cookies": {
-    "metaTitle": "Cookiebeleid",
-    "metaDescription": "Cookiebeleid van Ankora — volledige granulariteit, alles weigerbaar behalve essentiële.",
-    "title": "Cookiebeleid",
-    "categoriesHeading": "Categorieën",
-    "essentialHeading": "Essentieel (altijd actief)",
-    "essentialBody": "Onmisbaar voor de werking: authenticatiesessie, themavoorkeur, anti-CSRF.",
-    "essentialItem1": "<code>sb-*</code> — Supabase-sessie (auth)",
-    "essentialItem2": "<code>ankora-theme</code> — voorkeur licht/donker",
-    "analyticsHeading": "Analytics (standaard uitgeschakeld)",
-    "analyticsBody1": "Enkel als je toestemming geeft. Geaggregeerde gebruiksmeting, zonder persoonlijke identificator.",
-    "analyticsBody2": "Ankora gebruikt geen Google Analytics. De Vercel-metrics zijn geaggregeerd en anoniem.",
-    "marketingHeading": "Marketing (standaard uitgeschakeld)",
-    "marketingBody": "Ankora gebruikt momenteel geen enkele marketing-cookie.",
-    "manageHeading": "Je voorkeuren beheren",
-    "manageBody1": "Je kunt je toestemmingen op elk moment wijzigen in <b>Instellingen → Privacy</b> of door op « Cookies beheren » te klikken in de voettekst.",
-    "manageBody2": "Niet-essentiële cookies weigeren heeft geen invloed op de ervaring: Ankora blijft volledig functioneel.",
-    "lifetimeHeading": "Levensduur",
-    "lifetimeItem1": "Sessie: einde van de navigatie",
-    "lifetimeItem2": "Voorkeuren: 12 maanden",
-    "lifetimeItem3": "Analytics: 6 maanden (indien aanvaard)",
-    "draft": "Deze pagina met het cookiebeleid wordt momenteel opgesteld.",
-    "contact": "Voor elke vraag, contacteer ons: thierryvm@gmail.com",
-    "backHome": "Terug naar de startpagina"
-  }
-  },
-  "offline": {
-  "metaTitle": "Offline",
-  "metaDescription": "Je bent momenteel offline. Maak opnieuw verbinding om Ankora te gebruiken.",
-  "title": "Je bent offline",
-  "message": "Maak opnieuw verbinding om je cockpit te openen. Je gegevens blijven intact.",
-  "retry": "Opnieuw proberen"
-  },
-  "consent": {
-  "title": "Cookies en privacy",
-  "body": "We gebruiken enkel essentiële cookies om je te laten inloggen. Analytische cookies zijn standaard uitgeschakeld — je kunt ze activeren als je ons wil helpen Ankora te verbeteren. Je kunt op elk moment van gedacht veranderen via <link>het cookiebeleid</link>.",
-  "essentialOnly": "Enkel essentiële",
-  "acceptAnalytics": "Analyses aanvaarden"
-  },
-  "footer": {
-  "copyright": "© {year} — Alle rechten voorbehouden",
-  "cgu": "Voorwaarden",
-  "privacy": "Privacy",
-  "cookies": "Cookies beheren",
-  "faq": "FAQ",
-  "copyrightNotice": "© {year} Ankora™. Alle rechten voorbehouden."
-  },
-  "auth": {
-  "login": {
-    "title": "Inloggen",
-    "subtitle": "Vind je Ankora-cockpit terug.",
-    "metaTitle": "Inloggen",
-    "emailLabel": "E-mail",
-    "passwordLabel": "Wachtwoord",
-    "forgotLink": "Wachtwoord vergeten?",
-    "submit": "Inloggen",
-    "submitting": "Inloggen…",
-    "noAccount": "Nog geen account?",
-    "signupLink": "Account aanmaken",
-    "dividerOr": "of",
-    "dividerOrEmail": "of met je e-mail",
-    "passwordUpdatedBanner": "Wachtwoord bijgewerkt. Je kunt inloggen."
-  },
-  "signup": {
-    "title": "Account aanmaken",
-    "subtitle": "Start je financiële cockpit in minder dan 2 minuten.",
-    "pageTitle": "Mijn cockpit aanmaken",
-    "pageDescription": "Enkele seconden. Geen bankkaart nodig.",
-    "emailLabel": "E-mail",
-    "passwordLabel": "Wachtwoord",
-    "passwordHint": "Minimum 12 tekens, 1 hoofdletter, 1 kleine letter, 1 cijfer.",
-    "passwordConfirmLabel": "Wachtwoord bevestigen",
-    "acceptTosPrefix": "Ik aanvaard de",
-    "acceptTosLink": "gebruiksvoorwaarden",
-    "acceptPrivacyPrefix": "Ik aanvaard het",
-    "acceptPrivacyLink": "privacybeleid",
-    "submit": "Mijn account aanmaken",
-    "submitting": "Aanmaken…",
-    "haveAccount": "Al een account?",
-    "loginLink": "Inloggen",
-    "dividerOr": "of",
-    "dividerOrEmail": "of met je e-mail",
-    "googleCta": "Mijn account aanmaken met Google",
-    "googleTerms": "Door verder te gaan met Google, aanvaard je onze <cgu>gebruiksvoorwaarden</cgu> en ons <privacy>privacybeleid</privacy>."
-  },
-  "forgot": {
-    "title": "Wachtwoord vergeten",
-    "subtitle": "Geef je e-mail in, we sturen je een beveiligde link.",
-    "emailLabel": "E-mail",
-    "submit": "Link versturen",
-    "submitting": "Versturen…",
-    "sentMessage": "Als dit e-mailadres bestaat, werd zonet een resetlink verstuurd.",
-    "backToLogin": "Terug naar inloggen"
-  },
-  "reset": {
-    "title": "Nieuw wachtwoord",
-    "subtitle": "Kies een sterk wachtwoord voor je account.",
-    "passwordLabel": "Nieuw wachtwoord",
-    "passwordConfirmLabel": "Bevestigen",
-    "submit": "Bijwerken",
-    "submitting": "Bijwerken…"
-  },
-  "google": {
-    "label": "Verdergaan met Google",
-    "redirecting": "Doorsturen…"
-  },
-  "checkEmail": {
-    "title": "Controleer je inbox",
-    "metaTitle": "Controleer je e-mail",
-    "body": "We stuurden je net een bevestigingslink. Klik erop om je account te activeren.",
-    "backToLogin": "Terug naar inloggen"
-  }
-  },
-  "onboarding": {
-  "defaultWorkspaceName": "Mijn ruimte",
-  "previous": "Terug",
-  "next": "Doorgaan",
-  "finish": "Afronden",
-  "finishing": "Opslaan…",
-  "validation": {
-    "workspaceNameRequired": "Geef je ruimte een naam.",
-    "incomeInvalid": "Geef een geldig nettoloon in (≥ 0)."
-  },
-  "step1": {
-    "title": "Benoem je ruimte",
-    "description": "Je kunt dit later wijzigen in de instellingen.",
-    "nameLabel": "Naam van de ruimte"
-  },
-  "step2": {
-    "title": "Je maandelijks nettoloon",
-    "description": "Dient als basis om je maandelijkse overschrijvingen voor te stellen.",
-    "incomeLabel": "Maandelijks nettoloon (€)"
-  },
-  "step3": {
-    "title": "Je eerste vaste kost (optioneel)",
-    "description": "Voeg een huur, een verzekering, een abonnement toe…",
-    "labelLabel": "Omschrijving",
-    "labelPlaceholder": "Huur, autoverzekering…",
-    "amountLabel": "Bedrag (€)",
-    "frequencyLabel": "Frequentie",
-    "dueMonthLabel": "Referentiemaand",
-    "skipLater": "Ik geef mijn vaste kosten later in"
-  }
-  },
-  "app": {
-  "dashboard": {
-    "metaTitle": "Dashboard",
-    "headerTitle": "{month} — je cockpit",
-    "emptyTitle": "Begin met het toevoegen van je vaste kosten",
-    "emptyDescription": "Huur, verzekeringen, abonnementen — Ankora spreidt ze voor jou over 12 maanden.",
-    "emptyCta": "Vaste kost toevoegen",
-    "kpiProvisionsMonthly": "Voorzieningen / maand",
-    "kpiProvisionsAnnualHint": "Jaarlijks: {amount}",
-    "kpiHealth": "Gezondheid voorzieningen",
-    "kpiHealthTargetHint": "Doel: {amount}",
-    "kpiSuggestedTransfer": "Voorgestelde overschrijving",
-    "kpiSuggestedTransferToSavings": "Opzij te zetten",
-    "kpiSuggestedTransferFromSavings": "Van spaargeld te halen",
-    "kpiBillsMonth": "Facturen {month}",
-    "kpiBillsHint": "Cash-uitstroom deze maand",
-    "healthHealthy": "Gezond",
-    "healthWarning": "In de gaten houden",
-    "healthCritical": "Kritiek",
-    "planTitle": "Plan van de maand — {month}",
-    "planDescription": "De overschrijvingen die je begin van de maand moet uitvoeren op je drie rekeningen.",
-    "planAdjustAccounts": "Mijn rekeningen aanpassen",
-    "missingSetupTitle": "Geef eerst je rekeningen in",
-    "missingSetupDescription": "Om je Slimme Overschrijving te berekenen, heeft Ankora je maandelijkse nettoloon en het vaste bedrag nodig dat je naar Dagelijks Leven stuurt.",
-    "missingSetupCta": "Mijn rekeningen instellen",
-    "transferPrincipalToVieCourante": "Hoofdrekening → Dagelijks Leven",
-    "transferVieCouranteHint": "Envelop boodschappen, benzine, uit eten.",
-    "transferPrincipalToEpargne": "Hoofdrekening → Spaarrekening",
-    "transferEpargneToPrincipal": "Spaarrekening → Hoofdrekening",
-    "transferEpargneHint": "Voorziening {provision} − facturen {bills}",
-    "transferPrincipalRemaining": "Saldo Hoofdrekening",
-    "transferPrincipalRemainingHint": "Na loon, overschrijvingen en facturen Hoofdrekening ({bills}).",
-    "ctaCharges": "Mijn vaste kosten",
-    "ctaExpenses": "Mijn uitgaven",
-    "ctaSimulator": "Simuleren",
-    "expensesTitle": "Uitgaven — {month}",
-    "expensesCount": "{count, plural, =0 {Geen uitgaven deze maand} one {1 uitgave deze maand} other {# uitgaven deze maand}}",
-    "expensesEmpty": "Geen uitgaven geregistreerd voor deze maand.",
-    "expensesViewAll": "Alle uitgaven bekijken →"
-  },
-  "charges": {
-    "title": "Mijn vaste kosten",
-    "subtitle": "Elke vaste kost wordt automatisch over 12 maanden gespreid.",
-    "addFormTitle": "Vaste kost toevoegen",
-    "emptyState": "Nog geen vaste kosten.",
-    "labelLabel": "Omschrijving",
-    "amountLabel": "Bedrag (€)",
-    "frequencyLabel": "Frequentie",
-    "dueMonthLabel": "Referentiemaand",
-    "addButton": "Toevoegen",
-    "adding": "Toevoegen…",
-    "count": "{count, plural, =0 {geen vaste kosten} one {1 vaste kost} other {# vaste kosten}}",
-    "referenceFormat": "{frequency} · ref. {month}",
-    "deleteAria": "{label} verwijderen",
-    "toastCreated": "Vaste kost toegevoegd",
-    "toastDeleted": "Vaste kost verwijderd"
-  },
-  "accounts": {
-    "metaTitle": "Mijn rekeningen",
-    "metaDescription": "Volg de saldi van je Hoofdrekening, Dagelijks Leven en Spaarrekening. Stel je maandelijks nettoloon en je overschrijving naar Dagelijks Leven in.",
-    "title": "Mijn rekeningen",
-    "subtitle": "Geef je reële saldi in zodat Ankora elke maand je slimme overschrijving precies kan berekenen.",
-    "balancesHeading": "Huidige saldi",
-    "amountLabel": "Bedrag (€)",
-    "saveButton": "Opslaan",
-    "saving": "Opslaan…",
-    "income": {
-    "title": "Maandelijks nettoloon",
-    "description": "Het loon dat elke maand op je Hoofdrekening toekomt. Dient om te berekenen wat je overhoudt na vaste kosten en de overschrijving naar Dagelijks Leven.",
-    "placeholder": "Bv. 2500",
-    "toastSaved": "Maandelijks nettoloon bijgewerkt"
-    },
-    "transfer": {
-    "title": "Maandelijkse overschrijving naar Dagelijks Leven",
-    "description": "Vast bedrag dat elke maand van de Hoofdrekening naar je rekening Dagelijks Leven wordt overgeschreven. Dat dient voor boodschappen, benzine en uit eten.",
-    "placeholder": "Bv. 500",
-    "toastSaved": "Maandelijkse overschrijving bijgewerkt"
-    },
-    "balance": {
-    "invalidAmount": "Geef een geldig bedrag in.",
-    "saveLabel": "Bijwerken",
-    "srLabel": "Huidig saldo van {label}",
-    "toastSaved": "{name} bijgewerkt"
-    },
-    "kind": {
-    "principal": {
-      "description": "Ontvangt het loon, betaalt de maandelijkse vaste kosten."
-    },
-    "vieCourante": {
-      "description": "Dagelijks budget (boodschappen, benzine, uit eten)."
-    },
-    "epargne": {
-      "description": "Spreidt de driemaandelijkse en jaarlijkse facturen."
-    }
-    }
-  },
-  "expenses": {
-    "title": "Mijn uitgaven",
-    "subtitle": "De uitgaven buiten de terugkerende vaste kosten — boodschappen, resto, vrije tijd…",
-    "addFormTitle": "Uitgave toevoegen",
-    "labelLabel": "Omschrijving",
-    "amountLabel": "Bedrag (€)",
-    "dateLabel": "Datum",
-    "addButton": "Toevoegen",
-    "adding": "Toevoegen…",
-    "emptyState": "Nog geen uitgaven geregistreerd.",
-    "summary": "{count, plural, =0 {Geen uitgaven} one {1 uitgave · {total}} other {# uitgaven · {total}}}",
-    "deleteAria": "{label} verwijderen",
-    "toastCreated": "Uitgave toegevoegd",
-    "toastDeleted": "Uitgave verwijderd"
-  },
-  "settings": {
-    "metaTitle": "Instellingen",
-    "metaDescription": "Beheer je profiel, de 2FA-beveiliging en je persoonlijke gegevens.",
-    "title": "Instellingen",
-    "description": "Profiel, beveiliging en persoonlijke gegevens.",
-    "profile": {
-    "title": "Profiel",
-    "description": "Deze informatie personaliseert je cockpit.",
-    "emailLabel": "E-mail",
-    "displayNameLabel": "Weergavenaam",
-    "localeLabel": "Taal",
-    "localeOptions": {
-      "fr-BE": "Français (Belgique)",
-      "fr-FR": "Français (France)",
-      "en-GB": "English"
-    },
-    "submit": "Opslaan",
-    "submitting": "Opslaan…",
-    "toastSaved": "Profiel bijgewerkt"
-    },
-    "mfa": {
-    "title": "Beveiliging — 2FA",
-    "description": "Een eenmalige code gegenereerd door een authenticatie-app (Authy, 1Password, Google Authenticator).",
-    "emptyState": "Geen 2FA-factor actief. Activeer hem om je account te beschermen.",
-    "enrollButton": "2FA activeren",
-    "enrolling": "Voorbereiden…",
-    "scanInstruction": "Scan deze QR-code in je authenticatie-app en geef dan de code van 6 cijfers in.",
-    "qrAlt": "QR-code voor de authenticatie-app",
-    "manualEntry": "Handmatige invoer",
-    "codeLabel": "Code van 6 cijfers",
-    "verifyButton": "Verifiëren en activeren",
-    "verifying": "Verifiëren…",
-    "cancel": "Annuleren",
-    "defaultFactorName": "TOTP-app",
-    "activeLabel": "Actief",
-    "disableButton": "Uitschakelen",
-    "toastEnabled": "MFA geactiveerd",
-    "toastDisabled": "MFA uitgeschakeld"
-    },
-    "data": {
-    "title": "Mijn gegevens",
-    "description": "AVG-dataportabiliteit (art. 20) — download een volledige JSON van alles wat Ankora over jou bewaart.",
-    "exportButton": "Mijn gegevens downloaden",
-    "exporting": "Genereren…",
-    "toastDownloaded": "Export gedownload"
-    },
-    "danger": {
-    "scheduledTitle": "Verwijdering in uitvoering",
-    "scheduledBody": "Je account wordt verwijderd op <strong>{date}</strong>. Je kunt tot dan op elk moment annuleren.",
-    "viewStatus": "Status bekijken",
-    "title": "Gevarenzone",
-    "description": "Definitieve verwijdering van het account. 30 dagen grace period om te annuleren — daarna wordt alles gewist (audit logs gepseudonimiseerd).",
-    "reasonLabel": "Reden (optioneel)",
-    "reasonPlaceholder": "Help ons om te verbeteren…",
-    "confirmLabel": "Typ je e-mailadres om te bevestigen: <code>{email}</code>",
-    "submit": "Mijn account verwijderen",
-    "submitting": "Inplannen…",
-    "toastScheduled": "Verwijdering ingepland — je hebt 30 dagen om te annuleren"
-    }
-  },
-  "simulator": {
-    "title": "Simulator",
-    "subtitle": "Meet de impact van een wijziging zonder aan je echte gegevens te raken.",
-    "scenario": {
-    "title": "Scenario",
-    "description": "Kies een actie om te simuleren.",
-    "modes": {
-      "cancel": "Een vaste kost annuleren",
-      "negotiate": "Heronderhandelen",
-      "add": "Een vaste kost toevoegen"
-    }
-    },
-    "fields": {
-    "charge": "Vaste kost",
-    "chargePlaceholder": "Selecteer…",
-    "newAmount": "Nieuw bedrag (€)",
-    "label": "Omschrijving",
-    "amount": "Bedrag (€)",
-    "frequency": "Frequentie",
-    "month": "Maand"
-    },
-    "impact": {
-    "title": "Impact",
-    "empty": "Vul het scenario aan om de impact te zien.",
-    "currentMonthly": "Huidig / maand",
-    "projectedMonthly": "Verwacht / maand",
-    "annualSavings": "Jaarlijkse besparing",
-    "monthlyChange": "{sign}{percent}% / maand"
-    }
-  },
-  "deletionStatus": {
-    "title": "Accountverwijdering",
-    "subtitle": "Gedetailleerde status van je aanvraag en annulatieperiode.",
-    "metaTitle": "Verwijderingsstatus",
-    "metaDescription": "Status van de verwijderingsaanvraag van je Ankora-account.",
-    "statusLabel": "Status:",
-    "requestedOn": "Aangevraagd op {date}.",
-    "statusPending": "In afwachting",
-    "statusCancelled": "Geannuleerd",
-    "statusCompleted": "Voltooid",
-    "scheduledFor": "Verwijdering gepland",
-    "daysLeft": "Resterende dagen",
-    "auditLogs": "Audit logs",
-    "auditLogsValue": "Gepseudonimiseerd, nooit verwijderd",
-    "daysCount": "{days, plural, =0 {Vandaag} one {# dag} other {# dagen}}",
-    "backToSettings": "Terug naar instellingen",
-    "cancelledOn": "Aanvraag geannuleerd op {date}. Je account blijft behouden.",
-    "cancelledNoDate": "Aanvraag geannuleerd. Je account blijft behouden.",
-    "cancelButton": "Verwijdering annuleren",
-    "cancelling": "Annuleren…",
-    "toastCancelled": "Aanvraag geannuleerd — je account blijft behouden"
-  }
-  },
-  "glossary": {
-  "title": "Woordenboek",
-  "subtitle": "15 essentiële termen voor het begrijpen van je budgetbeheer en persoonlijke financiën.",
-  "metaTitle": "Woordenboek — Financiële termen",
-  "metaDescription": "Woordenboek van 15 essentiële termen voor budgetbeheer: uitvlakkingsbudget, bucket-rekening, noodspaargeld, en meer.",
-  "breadcrumb": {
-    "home": "Startpagina",
-    "glossary": "Woordenboek"
-  },
-  "section": {
-    "whyItMatters": "Waarom dit belangrijk is",
-    "example": "Concreet voorbeeld",
-    "relatedTerms": "Gerelateerde termen"
-  }
-  },
-  "errors": {
-  "generic": "Er is een fout opgetreden. Probeer opnieuw.",
-  "session": {
-    "expired": "Sessie verlopen. Log opnieuw in.",
-    "rateLimited": "Te veel aanvragen. Wacht een minuut."
-  },
-  "auth": {
-    "invalidCredentials": "E-mail of wachtwoord is niet correct.",
-    "signupFailed": "Registratie niet mogelijk. Probeer later opnieuw.",
-    "googleFailed": "Google-login niet beschikbaar. Probeer later opnieuw.",
-    "rateLimited": "Te veel pogingen. Probeer binnen enkele minuten opnieuw.",
-    "serviceTemporarilyUnavailable": "Dienst tijdelijk niet beschikbaar. Probeer binnen enkele minuten opnieuw.",
-    "passwordResetFailed": "Kan het wachtwoord niet bijwerken.",
-    "linkExpired": "Link verlopen. Vraag een nieuwe link aan.",
-    "mfaEnrollFailed": "Kan de inschrijving niet starten.",
-    "mfaChallengeFailed": "MFA-challenge niet mogelijk.",
-    "mfaCodeInvalid": "Code niet correct. Probeer opnieuw.",
-    "mfaDisableFailed": "Kan de 2FA niet uitschakelen."
-  },
-  "db": {
-    "workspaceNotFound": "Geen bewerkbare workspace.",
-    "updateFailed": "Bijwerken niet mogelijk.",
-    "notEditable": "Je hebt geen bewerkingsrechten op deze ruimte."
-  },
-  "validation": {
-    "generic": "Gegevens niet geldig.",
-    "auth": {
-    "email": {
-      "invalid": "E-mailadres niet geldig."
-    },
-    "password": {
-      "required": "Wachtwoord verplicht.",
-      "tooShort": "Minimum 12 tekens.",
-      "tooLong": "Maximum 128 tekens.",
-      "lowercase": "Minstens één kleine letter.",
-      "uppercase": "Minstens één hoofdletter.",
-      "digit": "Minstens één cijfer."
-    },
-    "passwordConfirm": {
-      "mismatch": "De wachtwoorden komen niet overeen."
-    },
-    "acceptTos": {
-      "required": "Je moet de gebruiksvoorwaarden aanvaarden."
-    },
-    "acceptPrivacy": {
-      "required": "Je moet het privacybeleid aanvaarden."
-    }
-    },
-    "charge": {
-    "label": {
-      "required": "Omschrijving verplicht.",
-      "tooLong": "Maximum 120 tekens."
-    },
-    "amount": {
-      "invalid": "Bedrag niet geldig.",
-      "negative": "Het bedrag moet ≥ 0 zijn.",
-      "tooHigh": "Bedrag te hoog."
+    "monthsShort": {
+      "1": "jan.",
+      "2": "feb.",
+      "3": "mrt.",
+      "4": "apr.",
+      "5": "mei",
+      "6": "jun.",
+      "7": "jul.",
+      "8": "aug.",
+      "9": "sep.",
+      "10": "okt.",
+      "11": "nov.",
+      "12": "dec."
     },
     "frequency": {
-      "invalid": "Frequentie niet geldig."
-    },
-    "dueMonth": {
-      "range": "Maand tussen 1 en 12."
-    },
-    "paidFrom": {
-      "invalid": "Debetrekening niet geldig."
+      "monthly": "Maandelijks",
+      "quarterly": "Driemaandelijks",
+      "semiannual": "Halfjaarlijks",
+      "annual": "Jaarlijks"
     }
+  },
+  "ui": {
+    "scrollToTop": "Terug naar boven",
+    "localeSwitcher": {
+      "label": "Taal",
+      "aria": "Taal wijzigen",
+      "options": {
+        "fr-BE": "Français (BE)",
+        "nl-BE": "Nederlands (BE)",
+        "en": "English",
+        "es-ES": "Español",
+        "de-DE": "Deutsch"
+      }
     },
-    "account": {
-    "kind": {
-      "invalid": "Type rekening niet geldig."
-    },
-    "balance": {
-      "invalid": "Saldo niet geldig.",
-      "outOfRange": "Waarde buiten de grenzen."
-    },
-    "label": {
-      "required": "Omschrijving verplicht.",
-      "tooLong": "Maximum 80 tekens."
+    "action": {
+      "submit": "Bevestigen",
+      "submitting": "Bevestigen…",
+      "save": "Opslaan",
+      "saving": "Opslaan…",
+      "cancel": "Annuleren",
+      "cancelling": "Annuleren…",
+      "delete": "Verwijderen",
+      "deleting": "Verwijderen…",
+      "create": "Aanmaken",
+      "creating": "Aanmaken…",
+      "update": "Bijwerken",
+      "updating": "Bijwerken…",
+      "send": "Versturen",
+      "sending": "Versturen…",
+      "verify": "Verifiëren",
+      "verifying": "Verifiëren…",
+      "generate": "Genereren",
+      "generating": "Genereren…",
+      "download": "Downloaden",
+      "downloading": "Downloaden…",
+      "preparing": "Voorbereiden…",
+      "confirm": "Bevestigen",
+      "close": "Sluiten"
     }
+  },
+  "landing": {
+    "mktnav": {
+      "links": {
+        "product": "Produit",
+        "simulator": "Simulateur",
+        "pricing": "Tarifs",
+        "security": "Sécurité",
+        "journal": "Journal"
+      },
+      "ctaLogin": "Se connecter",
+      "ctaSignup": "Essayer gratuitement"
     },
-    "workspace": {
-    "name": {
-      "required": "Naam verplicht.",
-      "tooLong": "Maximum 80 tekens."
+    "hero": {
+      "badge": "Nouveau · Simulateur what-if",
+      "h1Lead": "Ton ancrage",
+      "h1Highlight": "financier.",
+      "description": "Ankora sépare tes provisions affectées de ta réserve libre, projette six mois devant, et te laisse simuler l'impact de chaque décision — en clair, sans jargon.",
+      "ctaPrimary": "Ouvrir mon cockpit",
+      "ctaSecondary": "Voir le simulateur",
+      "trust": {
+        "encrypted": "Données chiffrées en Belgique",
+        "noSale": "Aucune vente de données",
+        "languages": "FR · NL · EN"
+      },
+      "mockup": {
+        "eyebrow": "Aperçu cockpit",
+        "browserUrl": "Ankora · cockpit",
+        "kpis": {
+          "netRemaining": {
+            "label": "Net restant",
+            "sub": "avril · après provisions"
+          },
+          "provisions": {
+            "label": "Provisions",
+            "sub": "67 % des 2 480 € planifiés"
+          },
+          "reserve": {
+            "label": "Réserve",
+            "sub": "+120 € vs. mars"
+          }
+        }
+      },
+      "waterfall": {
+        "income": "Revenus",
+        "incomeAmount": "+2 466 €",
+        "expenses": "Dépenses courantes",
+        "expensesAmount": "−1 959 €",
+        "provisionsCaption": "dont {amount} € lissés vers provisions affectées",
+        "available": "Argent disponible",
+        "availableAmount": "+507 €",
+        "ariaLabel": "Cascade illustrative : 2 466 € de revenus, 1 959 € de dépenses courantes (dont 59 € lissés en provisions), 507 € disponibles."
+      }
     },
-    "income": {
-      "invalid": "Nettoloon niet geldig.",
-      "negative": "Moet ≥ 0 zijn.",
-      "tooHigh": "Nettoloon te hoog."
+    "principles": {
+      "eyebrow": "Trois principes",
+      "h2": "Une façon honnête de parler d'argent.",
+      "description": "Ankora n'essaye pas de te vendre un placement ou une carte. On sépare, on projette, on simule. C'est tout. Toi seul décides.",
+      "items": {
+        "provisions": {
+          "title": "Provisions affectées",
+          "description": "Chaque euro réservé a un nom : mutuelle, taxe circulation, entretien chaudière. Rien ne fuit sans que tu le saches."
+        },
+        "reserve": {
+          "title": "Réserve libre",
+          "description": "Ce qui reste vraiment à toi, après les engagements. Le vrai chiffre — pas l'illusion du solde brut."
+        },
+        "whatIf": {
+          "title": "Simulateur what-if",
+          "description": "Renégocier l'électricité ? Changer de fournisseur ? Ankora te montre l'impact sur 12 mois avant que tu décides."
+        }
+      }
     },
-    "transfer": {
-      "invalid": "Bedrag niet geldig.",
-      "negative": "Moet ≥ 0 zijn.",
-      "tooHigh": "Bedrag te hoog."
+    "feature": {
+      "eyebrow": "Cashflow waterfall",
+      "h3Line1": "Du salaire au net disponible.",
+      "h3Line2": "En un seul coup d'œil.",
+      "description": "Plus de mystère sur où va ton argent. Chaque étape est visible : revenus, dépenses courantes, argent disponible. Tu vois immédiatement si un poste dérape.",
+      "ctaPrimary": "Voir un exemple",
+      "ctaSecondary": "Comment ça marche ?"
+    },
+    "whatif": {
+      "title": "Et si tu changeais une seule chose ?",
+      "subtitle": "Bouge le curseur. Vois l'impact sur ta réserve libre, sur six mois. C'est ce que fait Ankora à chaque décision financière.",
+      "badge": "Démo · pas de compte requis",
+      "scenarios": {
+        "gsm": {
+          "label": "Renégocier mon GSM",
+          "hint": "Forfait actuel : 42 €/mois · marché : 18–28 €/mois"
+        },
+        "elec": {
+          "label": "Changer de fournisseur d'électricité",
+          "hint": "Conso actuelle : 168 €/mois · 3 offres moins chères dans ta zone"
+        },
+        "stream": {
+          "label": "Couper deux streamings",
+          "hint": "5 abonnements actifs · usage réel : 2 sur 30 jours"
+        }
+      },
+      "controls": {
+        "scenario": "Scénario",
+        "savings": "Économie mensuelle",
+        "slider_aria": "Économie mensuelle pour {label}"
+      },
+      "annual": {
+        "eyebrow": "Sur 12 mois",
+        "fleche": "Ankora pourrait flécher {amount} €/mois vers ton épargne longue."
+      },
+      "chart": {
+        "title": "Réserve libre · projection",
+        "subtitle": "6 mois à partir d'aujourd'hui",
+        "legend": {
+          "baseline": "Sans changement",
+          "scenario": "Avec ton choix"
+        },
+        "aria": "Graphique projection sur 6 mois de la réserve libre, avec et sans le changement choisi",
+        "months": {
+          "may": "mai",
+          "jun": "juin",
+          "jul": "juil",
+          "aug": "août",
+          "sep": "sept",
+          "oct": "oct"
+        },
+        "thresholds": {
+          "danger": "⚠️ Découvert estimé",
+          "fragile": "Zone fragile",
+          "comfortable": "Zone confortable"
+        }
+      },
+      "caveat": "Démo basée sur des hypothèses moyennes. Ankora ne fournit pas de conseil en placement. Aucun import bancaire — tu saisis tes charges manuellement."
+    },
+    "pricing": {
+      "eyebrow": "Transparent dès le départ",
+      "h2": "Gratuit pendant la Phase 1.",
+      "phaseBadge": "Phase 1 · construction",
+      "price": "0 €",
+      "period": "pour l'instant, et sans date limite",
+      "body": "On construit d'abord le cockpit. Pas de carte demandée, pas de limite de temps, pas de fonctionnalité bridée. Export RGPD à tout moment.",
+      "features": {
+        "cockpit": "Cockpit complet, provisions et réserve libre",
+        "simulator": "Simulateur what-if illimité",
+        "manualEntry": "Saisie manuelle · tes données restent en Belgique",
+        "export": "Export RGPD en un clic"
+      },
+      "ctaPrimary": "Ouvrir mon cockpit",
+      "roadmap": {
+        "title": "Tu rejoins Ankora pendant sa Phase 1 ?",
+        "body": "Ton compte garde un accès complet au cockpit core à vie, gratuitement. Une offre Pro avec features avancées (comptes illimités, exports consolidés, support prioritaire) arrivera post-v1.0 — tu auras le choix d'upgrader ou de rester sur ton plan actuel.",
+        "link": "Lire la roadmap →"
+      }
+    },
+    "footerCta": {
+      "h2Lead": "Commence par ce qui est",
+      "h2Highlight": "déjà à toi.",
+      "description": "30 jours d'essai, pas de carte, export RGPD à tout moment. On fait simple parce que c'est déjà assez compliqué comme ça.",
+      "ctaPrimary": "Ouvrir mon cockpit"
+    },
+    "footer": {
+      "links": {
+        "terms": "Conditions",
+        "privacy": "Confidentialité",
+        "security": "Sécurité",
+        "contact": "Contact"
+      },
+      "copyright": "Ankora · éditeur ancré à Bruxelles · 2026"
+    },
+    "faqHeading": "Veelgestelde vragen",
+    "faq": {
+      "advice": {
+        "q": "Is Ankora een tool voor financieel advies?",
+        "a": "Nee. Ankora is een tool voor budgetorganisatie en financiële educatie. Het levert geen beleggingsaanbevelingen of gepersonaliseerd financieel advies."
+      },
+      "storage": {
+        "q": "Waar worden mijn gegevens bewaard?",
+        "a": "Je gegevens worden gehost in de Europese Unie (Supabase, EU-regio) met versleuteling at rest en strikte isolatie per gebruiker via Row Level Security."
+      },
+      "sharing": {
+        "q": "Kan ik mijn gegevens delen?",
+        "a": "Standaard is je ruimte 100% privé. Optionele gedeelde potten (reis, gezamenlijk project) komen in een volgende versie — jij kiest expliciet wat je deelt en met wie."
+      }
     }
-    },
-    "expense": {
-    "label": {
-      "required": "Omschrijving verplicht.",
-      "tooLong": "Maximum 120 tekens."
-    },
-    "amount": {
-      "invalid": "Bedrag niet geldig.",
-      "negative": "Moet ≥ 0 zijn.",
-      "tooHigh": "Bedrag te hoog."
-    },
-    "date": {
-      "format": "Verwacht formaat: YYYY-MM-DD."
-    },
-    "category": {
-      "invalid": "Categorie niet geldig."
+  },
+  "faq": {
+    "metaTitle": "FAQ",
+    "metaDescription": "Veelgestelde vragen over Ankora: veiligheid, gegevens, werking, privacy.",
+    "title": "Veelgestelde vragen",
+    "subtitle": "Alles wat je moet weten over Ankora voor je van start gaat.",
+    "items": {
+      "bankConnection": {
+        "q": "Maakt Ankora verbinding met mijn bank?",
+        "a": "Nee. Ankora gebruikt geen PSD2-richtlijn. Je geeft je vaste kosten en uitgaven handmatig in. Die keuze zorgt ervoor dat jij eigenaar blijft van je gegevens en dat er geen gevoelige bankinformatie bewaard wordt."
+      },
+      "dataLocation": {
+        "q": "Waar worden mijn gegevens gehost?",
+        "a": "Al je gegevens worden gehost in de Europese Unie (Supabase EU-regio, Vercel EU-regio, Upstash EU). Er worden geen gegevens buiten de EU overgedragen."
+      },
+      "smoothing": {
+        "q": "Hoe werkt de spreiding?",
+        "a": "Ankora neemt je driemaandelijkse, halfjaarlijkse en jaarlijkse vaste kosten en verdeelt ze over 12 maanden. Zo weet je hoeveel je elke maand opzij moet zetten om al je toekomstige facturen zonder stress te dekken."
+      },
+      "deletion": {
+        "q": "Kan ik mijn account verwijderen?",
+        "a": "Ja, op elk moment via Instellingen → Privacy. De verwijdering gaat 30 dagen na je aanvraag in (je kunt ze tijdens die periode annuleren). Al je financiële gegevens worden gewist, de beveiligingslogs worden gepseudonimiseerd."
+      },
+      "export": {
+        "q": "Kan ik mijn gegevens exporteren?",
+        "a": "Ja. De knop « Mijn gegevens downloaden » in Instellingen bezorgt je een volledig JSON-bestand met alles wat Ankora over jou bewaart. Conform het recht op dataportabiliteit AVG (art. 20)."
+      },
+      "advice": {
+        "q": "Geeft Ankora financieel advies?",
+        "a": "Nee. Ankora is een tool voor budgeteducatie en -organisatie. We geven geen enkel beleggingsadvies (reglementaire beperking FSMA België). Voor elke investeringsbeslissing, raadpleeg een erkende professional."
+      },
+      "ai": {
+        "q": "Wordt er artificiële intelligentie gebruikt?",
+        "a": "In Fase 1 niet. De berekeningen zijn deterministisch en controleerbaar. In Fase 2 laat een optionele BYOK-laag (Bring Your Own Key) je toe je eigen Anthropic- of OpenRouter-sleutel te koppelen voor suggesties — geen extra kost langs Ankora."
+      },
+      "sharing": {
+        "q": "Kan ik mijn ruimte delen met mijn kinderen of vrienden?",
+        "a": "In Fase 1 heeft elke gebruiker een privé-ruimte, standaard afgeschermd. In Fase 2 voegen we de mogelijkheid toe om « gedeelde potten » aan te maken (op uitnodiging, met viewer/editor-rollen) zonder ooit je persoonlijke gegevens te vermengen."
+      }
     }
+  },
+  "legal": {
+    "versionLine": "Versie {version} — laatste update: {date}",
+    "lastUpdatedLine": "Laatste update: {date}",
+    "cgu": {
+      "metaTitle": "Algemene gebruiksvoorwaarden",
+      "metaDescription": "Gebruiksvoorwaarden van Ankora — regels voor het gebruik van de dienst.",
+      "title": "Algemene gebruiksvoorwaarden",
+      "s1": {
+        "heading": "1. Doel",
+        "body": "Ankora is een tool voor budgetorganisatie en financiële educatie bestemd voor particulieren. Hij laat toe om handmatig vaste kosten en uitgaven in te geven, ze over het jaar te spreiden en cashflowbehoeften te anticiperen."
+      },
+      "s2": {
+        "heading": "2. Wat Ankora NIET is",
+        "item1": "Ankora is <b>geen dienst voor beleggingsadvies</b> of investeringsadvies.",
+        "item2": "Ankora is <b>geen bankdienst</b> en houdt geen geld aan.",
+        "item3": "Ankora is <b>geen PSD2-aggregator</b> — geen enkele verbinding met je bankrekeningen.",
+        "item4": "Ankora is <b>geen professionele boekhoudsoftware</b>.",
+        "outro": "De getoonde informatie zijn schattingen op basis van jouw invoer. Ze vormen geen gepersonaliseerd financieel advies. Voor elke belangrijke beslissing, raadpleeg een erkende professional."
+      },
+      "s3": {
+        "heading": "3. Account",
+        "item1": "Je moet meerderjarig zijn of toestemming hebben van een wettelijke vertegenwoordiger.",
+        "item2": "Eén account per natuurlijke persoon.",
+        "item3": "Wachtwoord minimum 12 tekens, gemengd.",
+        "item4": "Je bent verantwoordelijk voor de vertrouwelijkheid van je inloggegevens."
+      },
+      "s4": {
+        "heading": "4. Aanvaardbaar gebruik",
+        "intro": "Je verbindt je ertoe om niet:",
+        "item1": "de dienst te gebruiken voor illegale doeleinden,",
+        "item2": "de beveiligingsmaatregelen te proberen omzeilen,",
+        "item3": "de toegang te automatiseren zonder expliciete toestemming,",
+        "item4": "je account te delen met een derde."
+      },
+      "s5": {
+        "heading": "5. Intellectuele eigendom",
+        "body": "Jij blijft eigenaar van je gegevens. Ankora behoudt de eigendom van zijn code, merk, design en documentatie."
+      },
+      "s6": {
+        "heading": "6. Aansprakelijkheid",
+        "body": "Ankora wordt geleverd « as is ». De uitgever kan niet aansprakelijk gesteld worden voor financiële beslissingen genomen op basis van de getoonde informatie. Geen garantie op 100% beschikbaarheid."
+      },
+      "s7": {
+        "heading": "7. Beëindiging",
+        "body": "Je kunt je account op elk moment verwijderen via Instellingen → Privacy. De verwijdering wordt 30 dagen na de aanvraag effectief (annuleerbare periode)."
+      },
+      "s8": {
+        "heading": "8. Toepasselijk recht",
+        "body": "Deze voorwaarden zijn onderworpen aan het Belgische recht. Bevoegde rechtbank: Brussel."
+      },
+      "draft": "Onze algemene gebruiksvoorwaarden worden momenteel opgesteld.",
+      "contact": "Voor elke vraag, contacteer ons: thierryvm@gmail.com",
+      "backHome": "Terug naar de startpagina"
+    },
+    "privacy": {
+      "metaTitle": "Privacybeleid",
+      "metaDescription": "Privacybeleid van Ankora — EU-hosting, AVG, gebruikersrechten.",
+      "title": "Privacybeleid",
+      "s1": {
+        "heading": "1. Verwerkingsverantwoordelijke",
+        "body": "Ankora, uitgegeven door Thierry Van Mele (België). Contact: <mail>thierryvm@gmail.com</mail>."
+      },
+      "s2": {
+        "heading": "2. Verzamelde gegevens",
+        "intro": "Ankora verzamelt enkel de gegevens die strikt noodzakelijk zijn voor het leveren van de dienst:",
+        "item1": "<b>Identiteit</b>: e-mailadres, weergavenaam (optioneel).",
+        "item2": "<b>Financiële gegevens die jij ingeeft</b>: vaste kosten, uitgaven, categorieën, opgegeven inkomens, spaarsaldo.",
+        "item3": "<b>Technische gegevens</b>: IP-adres, user-agent (enkel voor beveiligingslogs).",
+        "item4": "<b>Toestemmingen</b>: tijdstempel, versie, reikwijdte (gebruiksvoorwaarden, privacy, cookies).",
+        "outro": "Ankora maakt geen verbinding met een bank (geen PSD2-aggregatie). Je geeft zelf je vaste kosten en uitgaven in."
+      },
+      "s3": {
+        "heading": "3. Rechtsgronden (AVG art. 6)",
+        "item1": "<b>Contract</b>: levering van de dienst (account, financiële gegevens).",
+        "item2": "<b>Toestemming</b>: analytics/marketing-cookies, nieuwsbrief.",
+        "item3": "<b>Wettelijke verplichting</b>: beveiligingslogs (bewaring 12 maanden).",
+        "item4": "<b>Gerechtvaardigd belang</b>: fraudepreventie, behoud van veiligheid."
+      },
+      "s4": {
+        "heading": "4. Hosting en onderaannemers",
+        "item1": "<b>Supabase</b> (database, auth) — EU-regio (Frankfurt of Parijs).",
+        "item2": "<b>Vercel</b> (frontend hosting) — EU-regio (Dublin).",
+        "item3": "<b>Upstash</b> (rate limiting) — EU-regio.",
+        "outro": "Geen enkele gegevens worden buiten de EU/EER overgedragen."
+      },
+      "s5": {
+        "heading": "5. Bewaartermijn",
+        "item1": "Actief account: zolang je de dienst gebruikt.",
+        "item2": "Verwijderd account: verwijdering effectief 30 dagen na je aanvraag (annuleerbare grace period).",
+        "item3": "Beveiligingslogs: maximum 12 maanden, gepseudonimiseerd na accountverwijdering."
+      },
+      "s6": {
+        "heading": "6. Je rechten (AVG art. 15-22)",
+        "item1": "<b>Inzage</b>: raadpleeg je gegevens op elk moment in je ruimte.",
+        "item2": "<b>Rectificatie</b>: wijzig profiel en gegevens in de voorziene pagina's.",
+        "item3": "<b>Verwijdering</b>: knop « Mijn account verwijderen » in Instellingen → Privacy.",
+        "item4": "<b>Portabiliteit</b>: knop « Mijn gegevens downloaden » — volledige JSON-export.",
+        "item5": "<b>Bezwaar / Beperking</b>: weiger of trek niet-essentiële cookies op elk moment in.",
+        "item6": "<b>Klacht</b>: bij de <apd>Gegevensbeschermingsautoriteit</apd> (België)."
+      },
+      "s7": {
+        "heading": "7. Veiligheid",
+        "item1": "Versleuteling in transit (TLS 1.3) en at rest.",
+        "item2": "Row Level Security Supabase op alle tabellen.",
+        "item3": "Rate limiting, strikte CSP, append-only audit log.",
+        "item4": "Authenticatie met sterk wachtwoord + MFA beschikbaar."
+      },
+      "s8": {
+        "heading": "8. Cookies",
+        "body": "Zie het <link>cookiebeleid</link>."
+      },
+      "s9": {
+        "heading": "9. Wijzigingen",
+        "body": "Elke materiële wijziging van dit beleid wordt per e-mail gemeld en vereist je vernieuwde toestemming om de dienst te blijven gebruiken."
+      },
+      "draft": "Ons privacybeleid wordt momenteel opgesteld.",
+      "contact": "Voor elke vraag, contacteer ons: thierryvm@gmail.com",
+      "backHome": "Terug naar de startpagina"
+    },
+    "cookies": {
+      "metaTitle": "Cookiebeleid",
+      "metaDescription": "Cookiebeleid van Ankora — volledige granulariteit, alles weigerbaar behalve essentiële.",
+      "title": "Cookiebeleid",
+      "categoriesHeading": "Categorieën",
+      "essentialHeading": "Essentieel (altijd actief)",
+      "essentialBody": "Onmisbaar voor de werking: authenticatiesessie, themavoorkeur, anti-CSRF.",
+      "essentialItem1": "<code>sb-*</code> — Supabase-sessie (auth)",
+      "essentialItem2": "<code>ankora-theme</code> — voorkeur licht/donker",
+      "analyticsHeading": "Analytics (standaard uitgeschakeld)",
+      "analyticsBody1": "Enkel als je toestemming geeft. Geaggregeerde gebruiksmeting, zonder persoonlijke identificator.",
+      "analyticsBody2": "Ankora gebruikt geen Google Analytics. De Vercel-metrics zijn geaggregeerd en anoniem.",
+      "marketingHeading": "Marketing (standaard uitgeschakeld)",
+      "marketingBody": "Ankora gebruikt momenteel geen enkele marketing-cookie.",
+      "manageHeading": "Je voorkeuren beheren",
+      "manageBody1": "Je kunt je toestemmingen op elk moment wijzigen in <b>Instellingen → Privacy</b> of door op « Cookies beheren » te klikken in de voettekst.",
+      "manageBody2": "Niet-essentiële cookies weigeren heeft geen invloed op de ervaring: Ankora blijft volledig functioneel.",
+      "lifetimeHeading": "Levensduur",
+      "lifetimeItem1": "Sessie: einde van de navigatie",
+      "lifetimeItem2": "Voorkeuren: 12 maanden",
+      "lifetimeItem3": "Analytics: 6 maanden (indien aanvaard)",
+      "draft": "Deze pagina met het cookiebeleid wordt momenteel opgesteld.",
+      "contact": "Voor elke vraag, contacteer ons: thierryvm@gmail.com",
+      "backHome": "Terug naar de startpagina"
+    }
+  },
+  "offline": {
+    "metaTitle": "Offline",
+    "metaDescription": "Je bent momenteel offline. Maak opnieuw verbinding om Ankora te gebruiken.",
+    "title": "Je bent offline",
+    "message": "Maak opnieuw verbinding om je cockpit te openen. Je gegevens blijven intact.",
+    "retry": "Opnieuw proberen"
+  },
+  "consent": {
+    "title": "Cookies en privacy",
+    "body": "We gebruiken enkel essentiële cookies om je te laten inloggen. Analytische cookies zijn standaard uitgeschakeld — je kunt ze activeren als je ons wil helpen Ankora te verbeteren. Je kunt op elk moment van gedacht veranderen via <link>het cookiebeleid</link>.",
+    "essentialOnly": "Enkel essentiële",
+    "acceptAnalytics": "Analyses aanvaarden"
+  },
+  "footer": {
+    "copyright": "© {year} — Alle rechten voorbehouden",
+    "cgu": "Voorwaarden",
+    "privacy": "Privacy",
+    "cookies": "Cookies beheren",
+    "faq": "FAQ",
+    "copyrightNotice": "© {year} Ankora™. Alle rechten voorbehouden."
+  },
+  "auth": {
+    "login": {
+      "title": "Inloggen",
+      "subtitle": "Vind je Ankora-cockpit terug.",
+      "metaTitle": "Inloggen",
+      "emailLabel": "E-mail",
+      "passwordLabel": "Wachtwoord",
+      "forgotLink": "Wachtwoord vergeten?",
+      "submit": "Inloggen",
+      "submitting": "Inloggen…",
+      "noAccount": "Nog geen account?",
+      "signupLink": "Account aanmaken",
+      "dividerOr": "of",
+      "dividerOrEmail": "of met je e-mail",
+      "passwordUpdatedBanner": "Wachtwoord bijgewerkt. Je kunt inloggen."
+    },
+    "signup": {
+      "title": "Account aanmaken",
+      "subtitle": "Start je financiële cockpit in minder dan 2 minuten.",
+      "pageTitle": "Mijn cockpit aanmaken",
+      "pageDescription": "Enkele seconden. Geen bankkaart nodig.",
+      "emailLabel": "E-mail",
+      "passwordLabel": "Wachtwoord",
+      "passwordHint": "Minimum 12 tekens, 1 hoofdletter, 1 kleine letter, 1 cijfer.",
+      "passwordConfirmLabel": "Wachtwoord bevestigen",
+      "acceptTosPrefix": "Ik aanvaard de",
+      "acceptTosLink": "gebruiksvoorwaarden",
+      "acceptPrivacyPrefix": "Ik aanvaard het",
+      "acceptPrivacyLink": "privacybeleid",
+      "submit": "Mijn account aanmaken",
+      "submitting": "Aanmaken…",
+      "haveAccount": "Al een account?",
+      "loginLink": "Inloggen",
+      "dividerOr": "of",
+      "dividerOrEmail": "of met je e-mail",
+      "googleCta": "Mijn account aanmaken met Google",
+      "googleTerms": "Door verder te gaan met Google, aanvaard je onze <cgu>gebruiksvoorwaarden</cgu> en ons <privacy>privacybeleid</privacy>."
+    },
+    "forgot": {
+      "title": "Wachtwoord vergeten",
+      "subtitle": "Geef je e-mail in, we sturen je een beveiligde link.",
+      "emailLabel": "E-mail",
+      "submit": "Link versturen",
+      "submitting": "Versturen…",
+      "sentMessage": "Als dit e-mailadres bestaat, werd zonet een resetlink verstuurd.",
+      "backToLogin": "Terug naar inloggen"
+    },
+    "reset": {
+      "title": "Nieuw wachtwoord",
+      "subtitle": "Kies een sterk wachtwoord voor je account.",
+      "passwordLabel": "Nieuw wachtwoord",
+      "passwordConfirmLabel": "Bevestigen",
+      "submit": "Bijwerken",
+      "submitting": "Bijwerken…"
+    },
+    "google": {
+      "label": "Verdergaan met Google",
+      "redirecting": "Doorsturen…"
+    },
+    "checkEmail": {
+      "title": "Controleer je inbox",
+      "metaTitle": "Controleer je e-mail",
+      "body": "We stuurden je net een bevestigingslink. Klik erop om je account te activeren.",
+      "backToLogin": "Terug naar inloggen"
+    }
+  },
+  "onboarding": {
+    "defaultWorkspaceName": "Mijn ruimte",
+    "previous": "Terug",
+    "next": "Doorgaan",
+    "finish": "Afronden",
+    "finishing": "Opslaan…",
+    "validation": {
+      "workspaceNameRequired": "Geef je ruimte een naam.",
+      "incomeInvalid": "Geef een geldig nettoloon in (≥ 0)."
+    },
+    "step1": {
+      "title": "Benoem je ruimte",
+      "description": "Je kunt dit later wijzigen in de instellingen.",
+      "nameLabel": "Naam van de ruimte"
+    },
+    "step2": {
+      "title": "Je maandelijks nettoloon",
+      "description": "Dient als basis om je maandelijkse overschrijvingen voor te stellen.",
+      "incomeLabel": "Maandelijks nettoloon (€)"
+    },
+    "step3": {
+      "title": "Je eerste vaste kost (optioneel)",
+      "description": "Voeg een huur, een verzekering, een abonnement toe…",
+      "labelLabel": "Omschrijving",
+      "labelPlaceholder": "Huur, autoverzekering…",
+      "amountLabel": "Bedrag (€)",
+      "frequencyLabel": "Frequentie",
+      "dueMonthLabel": "Referentiemaand",
+      "skipLater": "Ik geef mijn vaste kosten later in"
+    }
+  },
+  "app": {
+    "dashboard": {
+      "metaTitle": "Dashboard",
+      "headerTitle": "{month} — je cockpit",
+      "emptyTitle": "Begin met het toevoegen van je vaste kosten",
+      "emptyDescription": "Huur, verzekeringen, abonnementen — Ankora spreidt ze voor jou over 12 maanden.",
+      "emptyCta": "Vaste kost toevoegen",
+      "kpiProvisionsMonthly": "Voorzieningen / maand",
+      "kpiProvisionsAnnualHint": "Jaarlijks: {amount}",
+      "kpiHealth": "Gezondheid voorzieningen",
+      "kpiHealthTargetHint": "Doel: {amount}",
+      "kpiSuggestedTransfer": "Voorgestelde overschrijving",
+      "kpiSuggestedTransferToSavings": "Opzij te zetten",
+      "kpiSuggestedTransferFromSavings": "Van spaargeld te halen",
+      "kpiBillsMonth": "Facturen {month}",
+      "kpiBillsHint": "Cash-uitstroom deze maand",
+      "healthHealthy": "Gezond",
+      "healthWarning": "In de gaten houden",
+      "healthCritical": "Kritiek",
+      "planTitle": "Plan van de maand — {month}",
+      "planDescription": "De overschrijvingen die je begin van de maand moet uitvoeren op je drie rekeningen.",
+      "planAdjustAccounts": "Mijn rekeningen aanpassen",
+      "missingSetupTitle": "Geef eerst je rekeningen in",
+      "missingSetupDescription": "Om je Slimme Overschrijving te berekenen, heeft Ankora je maandelijkse nettoloon en het vaste bedrag nodig dat je naar Dagelijks Leven stuurt.",
+      "missingSetupCta": "Mijn rekeningen instellen",
+      "transferPrincipalToVieCourante": "Hoofdrekening → Dagelijks Leven",
+      "transferVieCouranteHint": "Envelop boodschappen, benzine, uit eten.",
+      "transferPrincipalToEpargne": "Hoofdrekening → Spaarrekening",
+      "transferEpargneToPrincipal": "Spaarrekening → Hoofdrekening",
+      "transferEpargneHint": "Voorziening {provision} − facturen {bills}",
+      "transferPrincipalRemaining": "Saldo Hoofdrekening",
+      "transferPrincipalRemainingHint": "Na loon, overschrijvingen en facturen Hoofdrekening ({bills}).",
+      "ctaCharges": "Mijn vaste kosten",
+      "ctaExpenses": "Mijn uitgaven",
+      "ctaSimulator": "Simuleren",
+      "expensesTitle": "Uitgaven — {month}",
+      "expensesCount": "{count, plural, =0 {Geen uitgaven deze maand} one {1 uitgave deze maand} other {# uitgaven deze maand}}",
+      "expensesEmpty": "Geen uitgaven geregistreerd voor deze maand.",
+      "expensesViewAll": "Alle uitgaven bekijken →"
+    },
+    "charges": {
+      "title": "Mijn vaste kosten",
+      "subtitle": "Elke vaste kost wordt automatisch over 12 maanden gespreid.",
+      "addFormTitle": "Vaste kost toevoegen",
+      "emptyState": "Nog geen vaste kosten.",
+      "labelLabel": "Omschrijving",
+      "amountLabel": "Bedrag (€)",
+      "frequencyLabel": "Frequentie",
+      "dueMonthLabel": "Referentiemaand",
+      "addButton": "Toevoegen",
+      "adding": "Toevoegen…",
+      "count": "{count, plural, =0 {geen vaste kosten} one {1 vaste kost} other {# vaste kosten}}",
+      "referenceFormat": "{frequency} · ref. {month}",
+      "deleteAria": "{label} verwijderen",
+      "toastCreated": "Vaste kost toegevoegd",
+      "toastDeleted": "Vaste kost verwijderd"
+    },
+    "accounts": {
+      "metaTitle": "Mijn rekeningen",
+      "metaDescription": "Volg de saldi van je Hoofdrekening, Dagelijks Leven en Spaarrekening. Stel je maandelijks nettoloon en je overschrijving naar Dagelijks Leven in.",
+      "title": "Mijn rekeningen",
+      "subtitle": "Geef je reële saldi in zodat Ankora elke maand je slimme overschrijving precies kan berekenen.",
+      "balancesHeading": "Huidige saldi",
+      "amountLabel": "Bedrag (€)",
+      "saveButton": "Opslaan",
+      "saving": "Opslaan…",
+      "income": {
+        "title": "Maandelijks nettoloon",
+        "description": "Het loon dat elke maand op je Hoofdrekening toekomt. Dient om te berekenen wat je overhoudt na vaste kosten en de overschrijving naar Dagelijks Leven.",
+        "placeholder": "Bv. 2500",
+        "toastSaved": "Maandelijks nettoloon bijgewerkt"
+      },
+      "transfer": {
+        "title": "Maandelijkse overschrijving naar Dagelijks Leven",
+        "description": "Vast bedrag dat elke maand van de Hoofdrekening naar je rekening Dagelijks Leven wordt overgeschreven. Dat dient voor boodschappen, benzine en uit eten.",
+        "placeholder": "Bv. 500",
+        "toastSaved": "Maandelijkse overschrijving bijgewerkt"
+      },
+      "balance": {
+        "invalidAmount": "Geef een geldig bedrag in.",
+        "saveLabel": "Bijwerken",
+        "srLabel": "Huidig saldo van {label}",
+        "toastSaved": "{name} bijgewerkt"
+      },
+      "kind": {
+        "principal": {
+          "description": "Ontvangt het loon, betaalt de maandelijkse vaste kosten."
+        },
+        "vieCourante": {
+          "description": "Dagelijks budget (boodschappen, benzine, uit eten)."
+        },
+        "epargne": {
+          "description": "Spreidt de driemaandelijkse en jaarlijkse facturen."
+        }
+      },
+      "types": {
+        "income_bills": "Salary & Bills",
+        "provisions": "Annual Provisions",
+        "daily_card": "Groceries, Gas & Leisure"
+      },
+      "defaults": {
+        "income_bills": "Main Account",
+        "provisions": "Savings Account",
+        "daily_card": "Daily Card"
+      }
+    },
+    "expenses": {
+      "title": "Mijn uitgaven",
+      "subtitle": "De uitgaven buiten de terugkerende vaste kosten — boodschappen, resto, vrije tijd…",
+      "addFormTitle": "Uitgave toevoegen",
+      "labelLabel": "Omschrijving",
+      "amountLabel": "Bedrag (€)",
+      "dateLabel": "Datum",
+      "addButton": "Toevoegen",
+      "adding": "Toevoegen…",
+      "emptyState": "Nog geen uitgaven geregistreerd.",
+      "summary": "{count, plural, =0 {Geen uitgaven} one {1 uitgave · {total}} other {# uitgaven · {total}}}",
+      "deleteAria": "{label} verwijderen",
+      "toastCreated": "Uitgave toegevoegd",
+      "toastDeleted": "Uitgave verwijderd"
     },
     "settings": {
-    "displayName": {
-      "required": "Naam verplicht.",
-      "tooLong": "Maximum 80 tekens."
+      "metaTitle": "Instellingen",
+      "metaDescription": "Beheer je profiel, de 2FA-beveiliging en je persoonlijke gegevens.",
+      "title": "Instellingen",
+      "description": "Profiel, beveiliging en persoonlijke gegevens.",
+      "profile": {
+        "title": "Profiel",
+        "description": "Deze informatie personaliseert je cockpit.",
+        "emailLabel": "E-mail",
+        "displayNameLabel": "Weergavenaam",
+        "localeLabel": "Taal",
+        "localeOptions": {
+          "fr-BE": "Français (Belgique)",
+          "fr-FR": "Français (France)",
+          "en-GB": "English"
+        },
+        "submit": "Opslaan",
+        "submitting": "Opslaan…",
+        "toastSaved": "Profiel bijgewerkt"
+      },
+      "mfa": {
+        "title": "Beveiliging — 2FA",
+        "description": "Een eenmalige code gegenereerd door een authenticatie-app (Authy, 1Password, Google Authenticator).",
+        "emptyState": "Geen 2FA-factor actief. Activeer hem om je account te beschermen.",
+        "enrollButton": "2FA activeren",
+        "enrolling": "Voorbereiden…",
+        "scanInstruction": "Scan deze QR-code in je authenticatie-app en geef dan de code van 6 cijfers in.",
+        "qrAlt": "QR-code voor de authenticatie-app",
+        "manualEntry": "Handmatige invoer",
+        "codeLabel": "Code van 6 cijfers",
+        "verifyButton": "Verifiëren en activeren",
+        "verifying": "Verifiëren…",
+        "cancel": "Annuleren",
+        "defaultFactorName": "TOTP-app",
+        "activeLabel": "Actief",
+        "disableButton": "Uitschakelen",
+        "toastEnabled": "MFA geactiveerd",
+        "toastDisabled": "MFA uitgeschakeld"
+      },
+      "data": {
+        "title": "Mijn gegevens",
+        "description": "AVG-dataportabiliteit (art. 20) — download een volledige JSON van alles wat Ankora over jou bewaart.",
+        "exportButton": "Mijn gegevens downloaden",
+        "exporting": "Genereren…",
+        "toastDownloaded": "Export gedownload"
+      },
+      "danger": {
+        "scheduledTitle": "Verwijdering in uitvoering",
+        "scheduledBody": "Je account wordt verwijderd op <strong>{date}</strong>. Je kunt tot dan op elk moment annuleren.",
+        "viewStatus": "Status bekijken",
+        "title": "Gevarenzone",
+        "description": "Definitieve verwijdering van het account. 30 dagen grace period om te annuleren — daarna wordt alles gewist (audit logs gepseudonimiseerd).",
+        "reasonLabel": "Reden (optioneel)",
+        "reasonPlaceholder": "Help ons om te verbeteren…",
+        "confirmLabel": "Typ je e-mailadres om te bevestigen: <code>{email}</code>",
+        "submit": "Mijn account verwijderen",
+        "submitting": "Inplannen…",
+        "toastScheduled": "Verwijdering ingepland — je hebt 30 dagen om te annuleren"
+      }
+    },
+    "simulator": {
+      "title": "Simulator",
+      "subtitle": "Meet de impact van een wijziging zonder aan je echte gegevens te raken.",
+      "scenario": {
+        "title": "Scenario",
+        "description": "Kies een actie om te simuleren.",
+        "modes": {
+          "cancel": "Een vaste kost annuleren",
+          "negotiate": "Heronderhandelen",
+          "add": "Een vaste kost toevoegen"
+        }
+      },
+      "fields": {
+        "charge": "Vaste kost",
+        "chargePlaceholder": "Selecteer…",
+        "newAmount": "Nieuw bedrag (€)",
+        "label": "Omschrijving",
+        "amount": "Bedrag (€)",
+        "frequency": "Frequentie",
+        "month": "Maand"
+      },
+      "impact": {
+        "title": "Impact",
+        "empty": "Vul het scenario aan om de impact te zien.",
+        "currentMonthly": "Huidig / maand",
+        "projectedMonthly": "Verwacht / maand",
+        "annualSavings": "Jaarlijkse besparing",
+        "monthlyChange": "{sign}{percent}% / maand"
+      }
+    },
+    "deletionStatus": {
+      "title": "Accountverwijdering",
+      "subtitle": "Gedetailleerde status van je aanvraag en annulatieperiode.",
+      "metaTitle": "Verwijderingsstatus",
+      "metaDescription": "Status van de verwijderingsaanvraag van je Ankora-account.",
+      "statusLabel": "Status:",
+      "requestedOn": "Aangevraagd op {date}.",
+      "statusPending": "In afwachting",
+      "statusCancelled": "Geannuleerd",
+      "statusCompleted": "Voltooid",
+      "scheduledFor": "Verwijdering gepland",
+      "daysLeft": "Resterende dagen",
+      "auditLogs": "Audit logs",
+      "auditLogsValue": "Gepseudonimiseerd, nooit verwijderd",
+      "daysCount": "{days, plural, =0 {Vandaag} one {# dag} other {# dagen}}",
+      "backToSettings": "Terug naar instellingen",
+      "cancelledOn": "Aanvraag geannuleerd op {date}. Je account blijft behouden.",
+      "cancelledNoDate": "Aanvraag geannuleerd. Je account blijft behouden.",
+      "cancelButton": "Verwijdering annuleren",
+      "cancelling": "Annuleren…",
+      "toastCancelled": "Aanvraag geannuleerd — je account blijft behouden"
+    },
+    "cockpit": {
+      "capaciteEpargneReelle": {
+        "title": "Real Savings Capacity",
+        "messagePositive": "This is what you truly have left every month, with no surprises.",
+        "messageNegative": "Warning — your overall lifestyle exceeds your income.",
+        "tooltip": "This subtracts every charge (smoothed over the year) and your daily allowance from your monthly income. That is what is actually left for savings or unexpected expenses."
+      },
+      "santeProvisions": {
+        "title": "Provisions Health",
+        "cibleTheorique": "Ideal theoretical target:",
+        "soldeActuel": "Current balance:",
+        "statutAJour": "On track ✨",
+        "deficit": "Deficit detected:",
+        "rattrapageDescription": "Includes +{amount} € to recover the deficit over 3 months.",
+        "tooltip": "The algorithm computes how much your Savings account should hold today to absorb all upcoming periodic charges smoothly."
+      },
+      "virements": {
+        "title": "Transfer Assistant",
+        "provisionsMensuelles": "Monthly provisions:",
+        "facturesAnnuelles": "Periodic bills this month:",
+        "aVirer": "Transfer to Savings:",
+        "aRecuperer": "Pull from Savings:",
+        "aucun": "No transfer needed this month. Provisions exactly cover the periodic bills.",
+        "descriptionAVirer": "Covers your monthly provisions, minus the bills due this month.",
+        "descriptionDepuis": "This month’s periodic bills exceed your provision. Use your savings!",
+        "detailHeader": "Breakdown of the {amount} € provisions:"
+      },
+      "notifications": {
+        "transferToSavings": "Remember to transfer {amount} € to Savings this month.",
+        "transferFromSavings": "You need to pull {amount} € from Savings to cover this month’s bills.",
+        "chargeOverdue": "{label} is overdue (was due on {day}).",
+        "chargeDueSoon": "{label} due in {days} day(s)."
+      }
+    }
+  },
+  "glossary": {
+    "title": "Woordenboek",
+    "subtitle": "15 essentiële termen voor het begrijpen van je budgetbeheer en persoonlijke financiën.",
+    "metaTitle": "Woordenboek — Financiële termen",
+    "metaDescription": "Woordenboek van 15 essentiële termen voor budgetbeheer: uitvlakkingsbudget, bucket-rekening, noodspaargeld, en meer.",
+    "breadcrumb": {
+      "home": "Startpagina",
+      "glossary": "Woordenboek"
+    },
+    "section": {
+      "whyItMatters": "Waarom dit belangrijk is",
+      "example": "Concreet voorbeeld",
+      "relatedTerms": "Gerelateerde termen"
+    }
+  },
+  "errors": {
+    "generic": "Er is een fout opgetreden. Probeer opnieuw.",
+    "session": {
+      "expired": "Sessie verlopen. Log opnieuw in.",
+      "rateLimited": "Te veel aanvragen. Wacht een minuut."
+    },
+    "auth": {
+      "invalidCredentials": "E-mail of wachtwoord is niet correct.",
+      "signupFailed": "Registratie niet mogelijk. Probeer later opnieuw.",
+      "googleFailed": "Google-login niet beschikbaar. Probeer later opnieuw.",
+      "rateLimited": "Te veel pogingen. Probeer binnen enkele minuten opnieuw.",
+      "serviceTemporarilyUnavailable": "Dienst tijdelijk niet beschikbaar. Probeer binnen enkele minuten opnieuw.",
+      "passwordResetFailed": "Kan het wachtwoord niet bijwerken.",
+      "linkExpired": "Link verlopen. Vraag een nieuwe link aan.",
+      "mfaEnrollFailed": "Kan de inschrijving niet starten.",
+      "mfaChallengeFailed": "MFA-challenge niet mogelijk.",
+      "mfaCodeInvalid": "Code niet correct. Probeer opnieuw.",
+      "mfaDisableFailed": "Kan de 2FA niet uitschakelen."
+    },
+    "db": {
+      "workspaceNotFound": "Geen bewerkbare workspace.",
+      "updateFailed": "Bijwerken niet mogelijk.",
+      "notEditable": "Je hebt geen bewerkingsrechten op deze ruimte."
+    },
+    "validation": {
+      "generic": "Gegevens niet geldig.",
+      "auth": {
+        "email": {
+          "invalid": "E-mailadres niet geldig."
+        },
+        "password": {
+          "required": "Wachtwoord verplicht.",
+          "tooShort": "Minimum 12 tekens.",
+          "tooLong": "Maximum 128 tekens.",
+          "lowercase": "Minstens één kleine letter.",
+          "uppercase": "Minstens één hoofdletter.",
+          "digit": "Minstens één cijfer."
+        },
+        "passwordConfirm": {
+          "mismatch": "De wachtwoorden komen niet overeen."
+        },
+        "acceptTos": {
+          "required": "Je moet de gebruiksvoorwaarden aanvaarden."
+        },
+        "acceptPrivacy": {
+          "required": "Je moet het privacybeleid aanvaarden."
+        }
+      },
+      "charge": {
+        "label": {
+          "required": "Omschrijving verplicht.",
+          "tooLong": "Maximum 120 tekens."
+        },
+        "amount": {
+          "invalid": "Bedrag niet geldig.",
+          "negative": "Het bedrag moet ≥ 0 zijn.",
+          "tooHigh": "Bedrag te hoog."
+        },
+        "frequency": {
+          "invalid": "Frequentie niet geldig."
+        },
+        "dueMonth": {
+          "range": "Maand tussen 1 en 12."
+        },
+        "paidFrom": {
+          "invalid": "Debetrekening niet geldig."
+        }
+      },
+      "account": {
+        "kind": {
+          "invalid": "Type rekening niet geldig."
+        },
+        "balance": {
+          "invalid": "Saldo niet geldig.",
+          "outOfRange": "Waarde buiten de grenzen."
+        },
+        "label": {
+          "required": "Omschrijving verplicht.",
+          "tooLong": "Maximum 80 tekens."
+        }
+      },
+      "workspace": {
+        "name": {
+          "required": "Naam verplicht.",
+          "tooLong": "Maximum 80 tekens."
+        },
+        "income": {
+          "invalid": "Nettoloon niet geldig.",
+          "negative": "Moet ≥ 0 zijn.",
+          "tooHigh": "Nettoloon te hoog."
+        },
+        "transfer": {
+          "invalid": "Bedrag niet geldig.",
+          "negative": "Moet ≥ 0 zijn.",
+          "tooHigh": "Bedrag te hoog."
+        }
+      },
+      "expense": {
+        "label": {
+          "required": "Omschrijving verplicht.",
+          "tooLong": "Maximum 120 tekens."
+        },
+        "amount": {
+          "invalid": "Bedrag niet geldig.",
+          "negative": "Moet ≥ 0 zijn.",
+          "tooHigh": "Bedrag te hoog."
+        },
+        "date": {
+          "format": "Verwacht formaat: YYYY-MM-DD."
+        },
+        "category": {
+          "invalid": "Categorie niet geldig."
+        }
+      },
+      "settings": {
+        "displayName": {
+          "required": "Naam verplicht.",
+          "tooLong": "Maximum 80 tekens."
+        },
+        "locale": {
+          "invalid": "Taal niet geldig."
+        },
+        "factorId": {
+          "invalid": "Identificator niet geldig."
+        },
+        "mfaCode": {
+          "invalid": "Code van 6 cijfers."
+        },
+        "deletion": {
+          "confirm": "Dit adres komt niet overeen met je account."
+        }
+      },
+      "onboarding": {
+        "workspace": {
+          "required": "Naam verplicht.",
+          "tooLong": "Maximum 80 tekens."
+        },
+        "income": {
+          "invalid": "Nettoloon niet geldig.",
+          "negative": "Moet ≥ 0 zijn.",
+          "tooHigh": "Nettoloon te hoog."
+        },
+        "firstCharge": {
+          "label": {
+            "required": "Omschrijving verplicht.",
+            "tooLong": "Maximum 120 tekens."
+          },
+          "amount": {
+            "invalid": "Bedrag niet geldig.",
+            "negative": "Moet ≥ 0 zijn.",
+            "tooHigh": "Bedrag te hoog."
+          },
+          "dueMonth": {
+            "range": "Maand tussen 1 en 12."
+          }
+        }
+      }
+    },
+    "charges": {
+      "createFailed": "Kan de vaste kost niet aanmaken.",
+      "updateFailed": "Kan de vaste kost niet bijwerken.",
+      "deleteFailed": "Kan de vaste kost niet verwijderen."
+    },
+    "accounts": {
+      "balanceUpdateFailed": "Kan het saldo niet bijwerken.",
+      "renameFailed": "Kan de rekening niet hernoemen.",
+      "incomeUpdateFailed": "Kan het nettoloon niet bijwerken.",
+      "transferUpdateFailed": "Kan de overschrijving niet bijwerken."
+    },
+    "expenses": {
+      "createFailed": "Kan de uitgave niet aanmaken.",
+      "deleteFailed": "Kan de uitgave niet verwijderen."
+    },
+    "settings": {
+      "profileUpdateFailed": "Kan het profiel niet bijwerken.",
+      "deletionRequestFailed": "Kan de verwijdering niet inplannen.",
+      "deletionCancelFailed": "Kan de aanvraag niet annuleren.",
+      "exportLimited": "Export beperkt tot één keer per 5 minuten."
+    },
+    "onboarding": {
+      "workspaceNotFound": "Workspace niet gevonden. Contacteer de support.",
+      "workspaceUpdateFailed": "Kan de workspace niet bijwerken.",
+      "chargeFailed": "Workspace aangemaakt maar vaste kost niet opgeslagen."
     },
     "locale": {
       "invalid": "Taal niet geldig."
-    },
-    "factorId": {
-      "invalid": "Identificator niet geldig."
-    },
-    "mfaCode": {
-      "invalid": "Code van 6 cijfers."
-    },
-    "deletion": {
-      "confirm": "Dit adres komt niet overeen met je account."
     }
-    },
-    "onboarding": {
-    "workspace": {
-      "required": "Naam verplicht.",
-      "tooLong": "Maximum 80 tekens."
-    },
-    "income": {
-      "invalid": "Nettoloon niet geldig.",
-      "negative": "Moet ≥ 0 zijn.",
-      "tooHigh": "Nettoloon te hoog."
-    },
-    "firstCharge": {
-      "label": {
-      "required": "Omschrijving verplicht.",
-      "tooLong": "Maximum 120 tekens."
-      },
-      "amount": {
-      "invalid": "Bedrag niet geldig.",
-      "negative": "Moet ≥ 0 zijn.",
-      "tooHigh": "Bedrag te hoog."
-      },
-      "dueMonth": {
-      "range": "Maand tussen 1 en 12."
-      }
-    }
-    }
-  },
-  "charges": {
-    "createFailed": "Kan de vaste kost niet aanmaken.",
-    "updateFailed": "Kan de vaste kost niet bijwerken.",
-    "deleteFailed": "Kan de vaste kost niet verwijderen."
-  },
-  "accounts": {
-    "balanceUpdateFailed": "Kan het saldo niet bijwerken.",
-    "renameFailed": "Kan de rekening niet hernoemen.",
-    "incomeUpdateFailed": "Kan het nettoloon niet bijwerken.",
-    "transferUpdateFailed": "Kan de overschrijving niet bijwerken."
-  },
-  "expenses": {
-    "createFailed": "Kan de uitgave niet aanmaken.",
-    "deleteFailed": "Kan de uitgave niet verwijderen."
-  },
-  "settings": {
-    "profileUpdateFailed": "Kan het profiel niet bijwerken.",
-    "deletionRequestFailed": "Kan de verwijdering niet inplannen.",
-    "deletionCancelFailed": "Kan de aanvraag niet annuleren.",
-    "exportLimited": "Export beperkt tot één keer per 5 minuten."
-  },
-  "onboarding": {
-    "workspaceNotFound": "Workspace niet gevonden. Contacteer de support.",
-    "workspaceUpdateFailed": "Kan de workspace niet bijwerken.",
-    "chargeFailed": "Workspace aangemaakt maar vaste kost niet opgeslagen."
-  },
-  "locale": {
-    "invalid": "Taal niet geldig."
-  }
   },
   "opengraphImage": {
-  "trustHosting": "🇧🇪 België · EU-gehost",
-  "trustNoBank": "Geen bankaggregatie",
-  "trustFree": "0 € Fase 1"
+    "trustHosting": "🇧🇪 België · EU-gehost",
+    "trustNoBank": "Geen bankaggregatie",
+    "trustFree": "0 € Fase 1"
   }
 }

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,6 +1,6 @@
 # ankora.be — Full content export for LLMs
 
-Last generated: 2026-04-28
+Last generated: 2026-05-03
 Canonical URL: https://ankora.be
 License: content available for citation with attribution. Code is proprietary.
 
@@ -26,6 +26,7 @@ Ankora is built and operated in Belgium by a solo indie developer. The app delib
 
 ## Core concepts
 
+- [Cashflow waterfall](https://ankora.be/): three canonical steps — income → daily expenses → available money. Earmarked provisions are surfaced as a discreet sub-caption under expenses (smoothing mechanism), not as a standalone step.
 - [Smoothed budget](https://ankora.be/glossaire/budget-de-lissage): converting irregular annual charges into monthly contributions
 - [Bucket account](https://ankora.be/glossaire/compte-bucket): sub-savings-account earmarked for a specific goal
 - [Saving capacity](https://ankora.be/glossaire/capacite-d-epargne): maximum structural savings without cutting into baseline standard of living

--- a/src/lib/domain/cockpit/__tests__/assistant-virements.test.ts
+++ b/src/lib/domain/cockpit/__tests__/assistant-virements.test.ts
@@ -1,0 +1,394 @@
+import { describe, it, expect } from 'vitest';
+import Decimal from 'decimal.js';
+
+import { calculerAssistantVirements } from '@/lib/domain/cockpit/assistant-virements';
+import type { CockpitCharge, ReferencePeriod } from '@/lib/domain/cockpit/types';
+
+const ZERO = new Decimal(0);
+
+const charge = (over: Partial<CockpitCharge>): CockpitCharge => ({
+  id: over.id ?? 'c-' + Math.random().toString(36).slice(2),
+  label: over.label ?? 'Test',
+  amount: over.amount ?? new Decimal(0),
+  frequency: over.frequency ?? 'monthly',
+  paymentMonths: over.paymentMonths ?? [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+  paymentDay: over.paymentDay ?? 1,
+  isActive: over.isActive ?? true,
+});
+
+const ref = (year: number, month: number): ReferencePeriod => ({ year, month });
+
+describe('calculerAssistantVirements — direction', () => {
+  it('returns "aucun" when there are no periodic charges', () => {
+    const out = calculerAssistantVirements({
+      charges: [charge({ amount: new Decimal(900), frequency: 'monthly' })],
+      ref: ref(2026, 5),
+      rattrapageMensuel: ZERO,
+    });
+    expect(out.direction).toBe('aucun');
+    expect(out.transfertRecommande.toNumber()).toBe(0);
+    expect(out.transfertRecommandeAjuste.toNumber()).toBe(0);
+  });
+
+  it('returns "vers_epargne" when no periodic bill is due this month', () => {
+    const out = calculerAssistantVirements({
+      charges: [charge({ amount: new Decimal(1200), frequency: 'annual', paymentMonths: [3] })],
+      ref: ref(2026, 5),
+      rattrapageMensuel: ZERO,
+    });
+    expect(out.direction).toBe('vers_epargne');
+    expect(out.transfertRecommandeAjuste.toNumber()).toBe(100);
+  });
+
+  it('returns "depuis_epargne" when periodic bills exceed provisions', () => {
+    const out = calculerAssistantVirements({
+      charges: [
+        charge({ amount: new Decimal(53), frequency: 'annual', paymentMonths: [4] }), // 4.42/m
+        charge({ amount: new Decimal(300), frequency: 'annual', paymentMonths: [4] }), // 25/m
+      ],
+      ref: ref(2026, 4), // both due
+      rattrapageMensuel: ZERO,
+    });
+    // provision = 4.4166… + 25 = 29.4166…
+    // périodiques avril = 53 + 300 = 353
+    // transfert = 29.4166… - 353 ≈ -323.58
+    expect(out.direction).toBe('depuis_epargne');
+    expect(out.transfertRecommandeAjuste.toFixed(2)).toBe('-323.58');
+  });
+
+  it('returns "aucun" when the math lands exactly on zero', () => {
+    // Annual 1200 → provision 100/mo. Due in May. In May: provision (100) - bill (1200) = -1100.
+    // To make it exactly 0, we need a charge whose amount equals its monthly provision.
+    // Trivially: empty list.
+    const out = calculerAssistantVirements({
+      charges: [],
+      ref: ref(2026, 5),
+      rattrapageMensuel: ZERO,
+    });
+    expect(out.direction).toBe('aucun');
+  });
+
+  it('treats inactive charges as if absent', () => {
+    const out = calculerAssistantVirements({
+      charges: [
+        charge({
+          amount: new Decimal(1200),
+          frequency: 'annual',
+          paymentMonths: [3],
+          isActive: false,
+        }),
+      ],
+      ref: ref(2026, 3),
+      rattrapageMensuel: ZERO,
+    });
+    expect(out.provisionMensuelleTotale.toNumber()).toBe(0);
+    expect(out.totalPeriodiquesMois.toNumber()).toBe(0);
+    expect(out.direction).toBe('aucun');
+  });
+});
+
+describe('calculerAssistantVirements — provisions', () => {
+  it('reproduces @thierry real fixture (provision 59€)', () => {
+    const charges = [
+      charge({ id: 'dashlane', amount: new Decimal(53), frequency: 'annual', paymentMonths: [4] }),
+      charge({
+        id: 'swde',
+        amount: new Decimal(45),
+        frequency: 'quarterly',
+        paymentMonths: [1, 4, 7, 10],
+      }),
+      charge({
+        id: 'taxe-voiture',
+        amount: new Decimal(300),
+        frequency: 'annual',
+        paymentMonths: [6],
+      }),
+      charge({
+        id: 'taxe-poubelle',
+        amount: new Decimal(120),
+        frequency: 'annual',
+        paymentMonths: [3],
+      }),
+      charge({
+        id: 'taxe-egout',
+        amount: new Decimal(55),
+        frequency: 'annual',
+        paymentMonths: [3],
+      }),
+    ];
+    const out = calculerAssistantVirements({
+      charges,
+      ref: ref(2026, 5), // mai → no periodic due
+      rattrapageMensuel: ZERO,
+    });
+    expect(out.provisionMensuelleTotale.toFixed(2)).toBe('59.00');
+    expect(out.totalPeriodiquesMois.toNumber()).toBe(0);
+    expect(out.transfertRecommandeAjuste.toFixed(2)).toBe('59.00');
+    expect(out.direction).toBe('vers_epargne');
+  });
+
+  it('reproduces @thierry real fixture in April (Dashlane + S.W.D.E due → 6€ to transfer)', () => {
+    const charges = [
+      charge({ id: 'dashlane', amount: new Decimal(53), frequency: 'annual', paymentMonths: [4] }),
+      charge({
+        id: 'swde',
+        amount: new Decimal(45),
+        frequency: 'quarterly',
+        paymentMonths: [1, 4, 7, 10],
+      }),
+      charge({
+        id: 'taxe-voiture',
+        amount: new Decimal(300),
+        frequency: 'annual',
+        paymentMonths: [6],
+      }),
+      charge({
+        id: 'taxe-poubelle',
+        amount: new Decimal(120),
+        frequency: 'annual',
+        paymentMonths: [3],
+      }),
+      charge({
+        id: 'taxe-egout',
+        amount: new Decimal(55),
+        frequency: 'annual',
+        paymentMonths: [3],
+      }),
+    ];
+    const out = calculerAssistantVirements({
+      charges,
+      ref: ref(2026, 4), // April : Dashlane + S.W.D.E due
+      rattrapageMensuel: ZERO,
+    });
+    // provision 59, bills due = 53 + 45 = 98
+    // transfert = 59 - 98 = -39 → depuis_epargne
+    expect(out.totalPeriodiquesMois.toNumber()).toBe(98);
+    expect(out.transfertRecommandeAjuste.toFixed(2)).toBe('-39.00');
+    expect(out.direction).toBe('depuis_epargne');
+  });
+
+  it('reproduces ADR-012 example: virer 6€ when only Dashlane (53€) is due in April', () => {
+    // Per ADR-012: provisionMensuelleTotale = 59, Dashlane only due in April → 59 - 53 = 6.
+    // Real Thierry has S.W.D.E too but ADR's pedagogical example assumes only Dashlane.
+    const charges = [
+      charge({ id: 'dashlane', amount: new Decimal(53), frequency: 'annual', paymentMonths: [4] }),
+      // 4 dummy provisions to round provision to ~59€ (without bills due in April)
+      charge({ id: 'a', amount: new Decimal(180), frequency: 'annual', paymentMonths: [6] }),
+      charge({ id: 'b', amount: new Decimal(120), frequency: 'annual', paymentMonths: [3] }),
+      charge({ id: 'c', amount: new Decimal(120), frequency: 'annual', paymentMonths: [9] }),
+      charge({ id: 'd', amount: new Decimal(235), frequency: 'annual', paymentMonths: [12] }),
+    ];
+    // 53/12 + 180/12 + 120/12 + 120/12 + 235/12 = (53+180+120+120+235)/12 = 708/12 = 59
+    const out = calculerAssistantVirements({
+      charges,
+      ref: ref(2026, 4),
+      rattrapageMensuel: ZERO,
+    });
+    expect(out.provisionMensuelleTotale.toFixed(2)).toBe('59.00');
+    expect(out.totalPeriodiquesMois.toNumber()).toBe(53);
+    expect(out.transfertRecommandeAjuste.toFixed(2)).toBe('6.00');
+    expect(out.direction).toBe('vers_epargne');
+  });
+});
+
+describe('calculerAssistantVirements — semiannual support', () => {
+  it('lisses semiannual amount across 6 months for provision math', () => {
+    const out = calculerAssistantVirements({
+      charges: [
+        charge({ amount: new Decimal(600), frequency: 'semiannual', paymentMonths: [3, 9] }),
+      ],
+      ref: ref(2026, 5),
+      rattrapageMensuel: ZERO,
+    });
+    expect(out.provisionMensuelleTotale.toNumber()).toBe(100);
+    expect(out.transfertRecommandeAjuste.toNumber()).toBe(100);
+    expect(out.direction).toBe('vers_epargne');
+  });
+
+  it('detects a semiannual bill due in the reference month', () => {
+    const out = calculerAssistantVirements({
+      charges: [
+        charge({ amount: new Decimal(600), frequency: 'semiannual', paymentMonths: [3, 9] }),
+      ],
+      ref: ref(2026, 9),
+      rattrapageMensuel: ZERO,
+    });
+    expect(out.totalPeriodiquesMois.toNumber()).toBe(600);
+    expect(out.transfertRecommandeAjuste.toNumber()).toBe(-500);
+    expect(out.direction).toBe('depuis_epargne');
+  });
+
+  it('mixes semiannual + quarterly + annual in the same workspace', () => {
+    const out = calculerAssistantVirements({
+      charges: [
+        charge({ amount: new Decimal(600), frequency: 'semiannual', paymentMonths: [3, 9] }),
+        charge({ amount: new Decimal(45), frequency: 'quarterly', paymentMonths: [1, 4, 7, 10] }),
+        charge({ amount: new Decimal(1200), frequency: 'annual', paymentMonths: [12] }),
+      ],
+      ref: ref(2026, 5), // none due in May
+      rattrapageMensuel: ZERO,
+    });
+    // 600/6 + 45/3 + 1200/12 = 100 + 15 + 100 = 215
+    expect(out.provisionMensuelleTotale.toNumber()).toBe(215);
+    expect(out.totalPeriodiquesMois.toNumber()).toBe(0);
+    expect(out.direction).toBe('vers_epargne');
+  });
+});
+
+describe('calculerAssistantVirements — rattrapage', () => {
+  it('adds rattrapage to the recommended transfer', () => {
+    const out = calculerAssistantVirements({
+      charges: [charge({ amount: new Decimal(1200), frequency: 'annual', paymentMonths: [3] })],
+      ref: ref(2026, 5),
+      rattrapageMensuel: new Decimal(50),
+    });
+    // provision 100, no bill, rattrapage +50 → 150
+    expect(out.transfertRecommande.toNumber()).toBe(100);
+    expect(out.transfertRecommandeAjuste.toNumber()).toBe(150);
+    expect(out.direction).toBe('vers_epargne');
+  });
+
+  it('keeps "depuis_epargne" when bills - provisions + rattrapage is still negative', () => {
+    const out = calculerAssistantVirements({
+      charges: [
+        charge({ amount: new Decimal(1200), frequency: 'annual', paymentMonths: [3] }), // 100/mo
+        charge({ amount: new Decimal(500), frequency: 'annual', paymentMonths: [5] }), // 41.66/mo
+      ],
+      ref: ref(2026, 5),
+      rattrapageMensuel: new Decimal(20),
+    });
+    // provision = 141.66…, due in May = 500
+    // transfert = 141.66… - 500 + 20 = -338.33…
+    expect(out.direction).toBe('depuis_epargne');
+    expect(out.transfertRecommandeAjuste.toFixed(2)).toBe('-338.33');
+  });
+
+  it('flips the direction when rattrapage is large enough', () => {
+    const out = calculerAssistantVirements({
+      charges: [charge({ amount: new Decimal(60), frequency: 'monthly' })], // not periodic
+      ref: ref(2026, 5),
+      rattrapageMensuel: new Decimal(150),
+    });
+    // provision = 0, no periodic, rattrapage 150 → vers_epargne 150
+    expect(out.transfertRecommandeAjuste.toNumber()).toBe(150);
+    expect(out.direction).toBe('vers_epargne');
+  });
+});
+
+describe('calculerAssistantVirements — détail provisions', () => {
+  it('exposes per-charge breakdown', () => {
+    const out = calculerAssistantVirements({
+      charges: [
+        charge({
+          id: 'a',
+          label: 'A',
+          amount: new Decimal(120),
+          frequency: 'annual',
+          paymentMonths: [3],
+        }),
+        charge({
+          id: 'b',
+          label: 'B',
+          amount: new Decimal(300),
+          frequency: 'quarterly',
+          paymentMonths: [1, 4, 7, 10],
+        }),
+        charge({ id: 'c', label: 'C', amount: new Decimal(900), frequency: 'monthly' }),
+      ],
+      ref: ref(2026, 5),
+      rattrapageMensuel: ZERO,
+    });
+    expect(out.detailProvisions).toHaveLength(2); // monthly excluded
+    const a = out.detailProvisions.find((d) => d.chargeId === 'a');
+    const b = out.detailProvisions.find((d) => d.chargeId === 'b');
+    expect(a).toBeDefined();
+    expect(b).toBeDefined();
+    expect(a!.provisionLissee.toNumber()).toBe(10);
+    expect(b!.provisionLissee.toNumber()).toBe(100);
+  });
+
+  it('returns an empty détail when only monthly charges exist', () => {
+    const out = calculerAssistantVirements({
+      charges: [charge({ amount: new Decimal(900), frequency: 'monthly' })],
+      ref: ref(2026, 5),
+      rattrapageMensuel: ZERO,
+    });
+    expect(out.detailProvisions).toHaveLength(0);
+  });
+
+  it('keeps Decimal precision in provisionLissee', () => {
+    const out = calculerAssistantVirements({
+      charges: [
+        charge({ id: 'd', amount: new Decimal(53), frequency: 'annual', paymentMonths: [4] }),
+      ],
+      ref: ref(2026, 5),
+      rattrapageMensuel: ZERO,
+    });
+    expect(out.detailProvisions[0]!.provisionLissee.toFixed(6)).toBe('4.416667');
+  });
+
+  it('returns label in détail entry (UI consumes it directly)', () => {
+    const out = calculerAssistantVirements({
+      charges: [
+        charge({
+          id: 'water',
+          label: 'S.W.D.E.',
+          amount: new Decimal(45),
+          frequency: 'quarterly',
+          paymentMonths: [1, 4, 7, 10],
+        }),
+      ],
+      ref: ref(2026, 5),
+      rattrapageMensuel: ZERO,
+    });
+    expect(out.detailProvisions[0]!.label).toBe('S.W.D.E.');
+    expect(out.detailProvisions[0]!.frequency).toBe('quarterly');
+  });
+});
+
+describe('calculerAssistantVirements — robustness', () => {
+  it('handles a charge whose paymentMonths is a single entry', () => {
+    const out = calculerAssistantVirements({
+      charges: [charge({ amount: new Decimal(120), frequency: 'annual', paymentMonths: [11] })],
+      ref: ref(2026, 11),
+      rattrapageMensuel: ZERO,
+    });
+    expect(out.totalPeriodiquesMois.toNumber()).toBe(120);
+  });
+
+  it('handles a charge whose paymentMonths covers all 12 months', () => {
+    // Edge case: a "monthly-shaped quarterly" — uncommon but valid.
+    const out = calculerAssistantVirements({
+      charges: [
+        charge({
+          amount: new Decimal(60),
+          frequency: 'quarterly',
+          paymentMonths: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+        }),
+      ],
+      ref: ref(2026, 5),
+      rattrapageMensuel: ZERO,
+    });
+    expect(out.provisionMensuelleTotale.toNumber()).toBe(20);
+    expect(out.totalPeriodiquesMois.toNumber()).toBe(60);
+    expect(out.transfertRecommandeAjuste.toNumber()).toBe(-40);
+  });
+
+  it('returns zero direction "aucun" when only inactive periodic charges remain', () => {
+    const out = calculerAssistantVirements({
+      charges: [
+        charge({
+          amount: new Decimal(300),
+          frequency: 'annual',
+          paymentMonths: [3],
+          isActive: false,
+        }),
+      ],
+      ref: ref(2026, 5),
+      rattrapageMensuel: ZERO,
+    });
+    expect(out.provisionMensuelleTotale.toNumber()).toBe(0);
+    expect(out.totalPeriodiquesMois.toNumber()).toBe(0);
+    expect(out.direction).toBe('aucun');
+  });
+});

--- a/src/lib/domain/cockpit/__tests__/capacite-epargne-reelle.test.ts
+++ b/src/lib/domain/cockpit/__tests__/capacite-epargne-reelle.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest';
+import Decimal from 'decimal.js';
+
+import { capaciteEpargneReelle } from '@/lib/domain/cockpit/capacite-epargne-reelle';
+import type { CockpitCharge } from '@/lib/domain/cockpit/types';
+
+const charge = (over: Partial<CockpitCharge>): CockpitCharge => ({
+  id: over.id ?? 'c-' + Math.random().toString(36).slice(2),
+  label: 'Test',
+  amount: new Decimal(0),
+  frequency: 'monthly',
+  paymentMonths: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+  paymentDay: 1,
+  isActive: true,
+  ...over,
+});
+
+describe('capaciteEpargneReelle', () => {
+  it('equals revenus when there are no charges and no plafond', () => {
+    const out = capaciteEpargneReelle({
+      revenus: new Decimal(2000),
+      charges: [],
+      plafondQuotidien: new Decimal(0),
+    });
+    expect(out.capacite.toNumber()).toBe(2000);
+    expect(out.isPositive).toBe(true);
+    expect(out.effortFinancierLisse.toNumber()).toBe(0);
+  });
+
+  it('subtracts the plafond quotidien even if charges are zero', () => {
+    const out = capaciteEpargneReelle({
+      revenus: new Decimal(2000),
+      charges: [],
+      plafondQuotidien: new Decimal(500),
+    });
+    expect(out.capacite.toNumber()).toBe(1500);
+  });
+
+  it('subtracts a single monthly charge', () => {
+    const out = capaciteEpargneReelle({
+      revenus: new Decimal(2000),
+      charges: [charge({ amount: new Decimal(900), frequency: 'monthly' })],
+      plafondQuotidien: new Decimal(500),
+    });
+    // 2000 - 900 - 500 = 600
+    expect(out.capacite.toNumber()).toBe(600);
+    expect(out.effortFinancierLisse.toNumber()).toBe(900);
+  });
+
+  it('lisses an annual charge across 12 months', () => {
+    const out = capaciteEpargneReelle({
+      revenus: new Decimal(2000),
+      charges: [charge({ amount: new Decimal(1200), frequency: 'annual', paymentMonths: [3] })],
+      plafondQuotidien: new Decimal(0),
+    });
+    expect(out.capacite.toNumber()).toBe(1900);
+  });
+
+  it('lisses a semiannual charge across 6 months', () => {
+    const out = capaciteEpargneReelle({
+      revenus: new Decimal(1000),
+      charges: [
+        charge({ amount: new Decimal(600), frequency: 'semiannual', paymentMonths: [3, 9] }),
+      ],
+      plafondQuotidien: new Decimal(0),
+    });
+    expect(out.capacite.toNumber()).toBe(900);
+  });
+
+  it('lisses a quarterly charge across 3 months', () => {
+    const out = capaciteEpargneReelle({
+      revenus: new Decimal(1000),
+      charges: [
+        charge({ amount: new Decimal(45), frequency: 'quarterly', paymentMonths: [1, 4, 7, 10] }),
+      ],
+      plafondQuotidien: new Decimal(0),
+    });
+    expect(out.capacite.toNumber()).toBe(985);
+  });
+
+  it('returns negative when charges exceed revenus', () => {
+    const out = capaciteEpargneReelle({
+      revenus: new Decimal(1000),
+      charges: [charge({ amount: new Decimal(1500), frequency: 'monthly' })],
+      plafondQuotidien: new Decimal(0),
+    });
+    expect(out.capacite.toNumber()).toBe(-500);
+    expect(out.isPositive).toBe(false);
+  });
+
+  it('returns negative when plafond exceeds revenus on its own', () => {
+    const out = capaciteEpargneReelle({
+      revenus: new Decimal(800),
+      charges: [],
+      plafondQuotidien: new Decimal(1000),
+    });
+    expect(out.capacite.toNumber()).toBe(-200);
+  });
+
+  it('handles revenus = 0 (massively negative)', () => {
+    const out = capaciteEpargneReelle({
+      revenus: new Decimal(0),
+      charges: [charge({ amount: new Decimal(100), frequency: 'monthly' })],
+      plafondQuotidien: new Decimal(50),
+    });
+    expect(out.capacite.toNumber()).toBe(-150);
+  });
+
+  it('treats capacite = 0 as positive (≥ 0)', () => {
+    const out = capaciteEpargneReelle({
+      revenus: new Decimal(1000),
+      charges: [],
+      plafondQuotidien: new Decimal(1000),
+    });
+    expect(out.capacite.toNumber()).toBe(0);
+    expect(out.isPositive).toBe(true);
+  });
+
+  it('mixes monthly + annual + quarterly + semiannual', () => {
+    // Reproduces the @thierry fixture (≈ 59€ provisions) plus 1500€ monthly,
+    // 2000 revenus, 500 plafond.
+    const charges = [
+      charge({ amount: new Decimal(1500), frequency: 'monthly' }),
+      charge({ amount: new Decimal(53), frequency: 'annual', paymentMonths: [4] }),
+      charge({
+        amount: new Decimal(45),
+        frequency: 'quarterly',
+        paymentMonths: [1, 4, 7, 10],
+      }),
+      charge({ amount: new Decimal(300), frequency: 'annual', paymentMonths: [6] }),
+      charge({ amount: new Decimal(120), frequency: 'annual', paymentMonths: [3] }),
+      charge({ amount: new Decimal(55), frequency: 'annual', paymentMonths: [3] }),
+      charge({ amount: new Decimal(600), frequency: 'semiannual', paymentMonths: [2, 8] }),
+    ];
+    // monthly = 1500
+    // provisions = 53/12 + 45/3 + 300/12 + 120/12 + 55/12 + 600/6
+    //            = 4.4166… + 15 + 25 + 10 + 4.5833… + 100 = 159
+    // effort = 1659
+    // capacite = 2000 - 1659 - 500 = -159
+    const out = capaciteEpargneReelle({
+      revenus: new Decimal(2000),
+      charges,
+      plafondQuotidien: new Decimal(500),
+    });
+    expect(out.effortFinancierLisse.toFixed(2)).toBe('1659.00');
+    expect(out.capacite.toFixed(2)).toBe('-159.00');
+  });
+
+  it('keeps decimal precision for divisions that recur', () => {
+    // 53 / 12 over many additions should stay close to exact.
+    const charges = Array.from({ length: 12 }, () =>
+      charge({ amount: new Decimal(53), frequency: 'annual', paymentMonths: [4] }),
+    );
+    const out = capaciteEpargneReelle({
+      revenus: new Decimal(0),
+      charges,
+      plafondQuotidien: new Decimal(0),
+    });
+    // 12 × 53/12 = 53 exactly, capacite = -53.
+    expect(out.capacite.toFixed(6)).toBe('-53.000000');
+  });
+
+  it('ignores inactive charges', () => {
+    const out = capaciteEpargneReelle({
+      revenus: new Decimal(2000),
+      charges: [
+        charge({ amount: new Decimal(900), frequency: 'monthly' }),
+        charge({ amount: new Decimal(800), frequency: 'monthly', isActive: false }),
+      ],
+      plafondQuotidien: new Decimal(0),
+    });
+    expect(out.capacite.toNumber()).toBe(1100);
+  });
+
+  it('exposes effort separately from capacite (UI breakdown)', () => {
+    const out = capaciteEpargneReelle({
+      revenus: new Decimal(3000),
+      charges: [
+        charge({ amount: new Decimal(1500), frequency: 'monthly' }),
+        charge({ amount: new Decimal(1200), frequency: 'annual', paymentMonths: [3] }),
+      ],
+      plafondQuotidien: new Decimal(500),
+    });
+    expect(out.effortFinancierLisse.toNumber()).toBe(1600); // 1500 + 100
+    expect(out.capacite.toNumber()).toBe(900); // 3000 - 1600 - 500
+  });
+
+  it('handles a workspace where plafond is the only outflow (early signup)', () => {
+    const out = capaciteEpargneReelle({
+      revenus: new Decimal(2500),
+      charges: [],
+      plafondQuotidien: new Decimal(700),
+    });
+    expect(out.capacite.toNumber()).toBe(1800);
+    expect(out.isPositive).toBe(true);
+  });
+});

--- a/src/lib/domain/cockpit/__tests__/effort-financier-lisse.test.ts
+++ b/src/lib/domain/cockpit/__tests__/effort-financier-lisse.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import Decimal from 'decimal.js';
+
+import {
+  effortFinancierLisse,
+  provisionsMensuellesLissees,
+  totalChargesMensuelles,
+} from '@/lib/domain/cockpit/effort-financier-lisse';
+import type { CockpitCharge } from '@/lib/domain/cockpit/types';
+
+const charge = (over: Partial<CockpitCharge>): CockpitCharge => ({
+  id: over.id ?? 'c-' + Math.random().toString(36).slice(2),
+  label: 'Test',
+  amount: new Decimal(0),
+  frequency: 'monthly',
+  paymentMonths: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+  paymentDay: 1,
+  isActive: true,
+  ...over,
+});
+
+describe('totalChargesMensuelles', () => {
+  it('returns 0 when there are no charges', () => {
+    expect(totalChargesMensuelles([]).toNumber()).toBe(0);
+  });
+
+  it('sums only monthly charges', () => {
+    const charges: CockpitCharge[] = [
+      charge({ amount: new Decimal(900), frequency: 'monthly' }),
+      charge({ amount: new Decimal(60), frequency: 'monthly' }),
+      charge({ amount: new Decimal(300), frequency: 'annual', paymentMonths: [3] }),
+      charge({ amount: new Decimal(45), frequency: 'quarterly', paymentMonths: [1, 4, 7, 10] }),
+    ];
+    expect(totalChargesMensuelles(charges).toNumber()).toBe(960);
+  });
+
+  it('ignores inactive monthly charges', () => {
+    const charges = [
+      charge({ amount: new Decimal(800), frequency: 'monthly', isActive: false }),
+      charge({ amount: new Decimal(150), frequency: 'monthly' }),
+    ];
+    expect(totalChargesMensuelles(charges).toNumber()).toBe(150);
+  });
+});
+
+describe('provisionsMensuellesLissees', () => {
+  it('returns 0 when there are no charges', () => {
+    expect(provisionsMensuellesLissees([]).toNumber()).toBe(0);
+  });
+
+  it('skips monthly charges entirely', () => {
+    const charges = [charge({ amount: new Decimal(1000), frequency: 'monthly' })];
+    expect(provisionsMensuellesLissees(charges).toNumber()).toBe(0);
+  });
+
+  it('divides annual charges by 12', () => {
+    const charges = [
+      charge({ amount: new Decimal(1200), frequency: 'annual', paymentMonths: [3] }),
+    ];
+    expect(provisionsMensuellesLissees(charges).toNumber()).toBe(100);
+  });
+
+  it('divides semiannual charges by 6', () => {
+    const charges = [
+      charge({ amount: new Decimal(600), frequency: 'semiannual', paymentMonths: [3, 9] }),
+    ];
+    expect(provisionsMensuellesLissees(charges).toNumber()).toBe(100);
+  });
+
+  it('divides quarterly charges by 3', () => {
+    const charges = [
+      charge({ amount: new Decimal(45), frequency: 'quarterly', paymentMonths: [1, 4, 7, 10] }),
+    ];
+    expect(provisionsMensuellesLissees(charges).toNumber()).toBe(15);
+  });
+
+  it("matches @thierry's real Dashlane fixture", () => {
+    const charges = [
+      charge({ id: 'dashlane', amount: new Decimal(53), frequency: 'annual', paymentMonths: [4] }),
+      charge({
+        id: 'swde',
+        amount: new Decimal(45),
+        frequency: 'quarterly',
+        paymentMonths: [1, 4, 7, 10],
+      }),
+      charge({
+        id: 'taxe-voiture',
+        amount: new Decimal(300),
+        frequency: 'annual',
+        paymentMonths: [6],
+      }),
+      charge({
+        id: 'taxe-poubelle',
+        amount: new Decimal(120),
+        frequency: 'annual',
+        paymentMonths: [3],
+      }),
+      charge({
+        id: 'taxe-egout',
+        amount: new Decimal(55),
+        frequency: 'annual',
+        paymentMonths: [3],
+      }),
+    ];
+    // 53/12 + 45/3 + 300/12 + 120/12 + 55/12 = 4.4166… + 15 + 25 + 10 + 4.5833… = 59
+    expect(provisionsMensuellesLissees(charges).toFixed(2)).toBe('59.00');
+  });
+
+  it('ignores inactive periodic charges', () => {
+    const charges = [
+      charge({
+        amount: new Decimal(1200),
+        frequency: 'annual',
+        paymentMonths: [3],
+        isActive: false,
+      }),
+    ];
+    expect(provisionsMensuellesLissees(charges).toNumber()).toBe(0);
+  });
+});
+
+describe('effortFinancierLisse', () => {
+  it('is the sum of monthly + provisions', () => {
+    const charges = [
+      charge({ amount: new Decimal(1500), frequency: 'monthly' }),
+      charge({ amount: new Decimal(1200), frequency: 'annual', paymentMonths: [3] }),
+      charge({ amount: new Decimal(45), frequency: 'quarterly', paymentMonths: [1, 4, 7, 10] }),
+    ];
+    // 1500 + (100 + 15) = 1615
+    expect(effortFinancierLisse(charges).toNumber()).toBe(1615);
+  });
+
+  it('returns 0 for an empty list', () => {
+    expect(effortFinancierLisse([]).toNumber()).toBe(0);
+  });
+
+  it('keeps internal precision (no premature rounding)', () => {
+    // 53 / 12 = 4.4166666… — stored as Decimal, should NOT collapse to 4.42
+    const charges = [charge({ amount: new Decimal(53), frequency: 'annual', paymentMonths: [4] })];
+    expect(effortFinancierLisse(charges).toFixed(6)).toBe('4.416667');
+  });
+});

--- a/src/lib/domain/cockpit/__tests__/notifications.test.ts
+++ b/src/lib/domain/cockpit/__tests__/notifications.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest';
+import Decimal from 'decimal.js';
+
+import { genererNotifications } from '@/lib/domain/cockpit/notifications';
+import { paymentKey, type CockpitCharge, type ReferencePeriod } from '@/lib/domain/cockpit/types';
+
+const charge = (over: Partial<CockpitCharge>): CockpitCharge => ({
+  id: over.id ?? 'c-' + Math.random().toString(36).slice(2),
+  label: over.label ?? 'Test',
+  amount: over.amount ?? new Decimal(0),
+  frequency: over.frequency ?? 'monthly',
+  paymentMonths: over.paymentMonths ?? [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+  paymentDay: over.paymentDay ?? 15,
+  isActive: over.isActive ?? true,
+});
+
+const ref = (year: number, month: number): ReferencePeriod => ({ year, month });
+const noPayments = new Map<string, boolean>();
+
+describe('genererNotifications — guard rails', () => {
+  it('returns nothing when isCurrentMonth is false', () => {
+    const out = genererNotifications({
+      transfertRecommandeAjuste: new Decimal(100),
+      charges: [charge({ paymentDay: 15 })],
+      payments: noPayments,
+      ref: ref(2026, 5),
+      todayDayOfMonth: 1,
+      isCurrentMonth: false,
+    });
+    expect(out).toHaveLength(0);
+  });
+
+  it('returns nothing when nothing is actionable', () => {
+    const out = genererNotifications({
+      transfertRecommandeAjuste: new Decimal(0),
+      charges: [],
+      payments: noPayments,
+      ref: ref(2026, 5),
+      todayDayOfMonth: 1,
+      isCurrentMonth: true,
+    });
+    expect(out).toHaveLength(0);
+  });
+});
+
+describe('genererNotifications — transfer suggestions', () => {
+  it('emits info "transfer_to_savings" when ajusté > 0', () => {
+    const out = genererNotifications({
+      transfertRecommandeAjuste: new Decimal(59),
+      charges: [],
+      payments: noPayments,
+      ref: ref(2026, 5),
+      todayDayOfMonth: 1,
+      isCurrentMonth: true,
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]!.kind).toBe('transfer_to_savings');
+    expect(out[0]!.level).toBe('info');
+    expect(out[0]!.values).toEqual({ amount: '59.00' });
+  });
+
+  it('emits warning "transfer_from_savings" with absolute amount when < 0', () => {
+    const out = genererNotifications({
+      transfertRecommandeAjuste: new Decimal(-241.5),
+      charges: [],
+      payments: noPayments,
+      ref: ref(2026, 6),
+      todayDayOfMonth: 1,
+      isCurrentMonth: true,
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]!.kind).toBe('transfer_from_savings');
+    expect(out[0]!.level).toBe('warning');
+    expect(out[0]!.values).toEqual({ amount: '241.50' });
+  });
+
+  it('does NOT emit a transfer notification when ajusté = 0', () => {
+    const out = genererNotifications({
+      transfertRecommandeAjuste: new Decimal(0),
+      charges: [],
+      payments: noPayments,
+      ref: ref(2026, 5),
+      todayDayOfMonth: 1,
+      isCurrentMonth: true,
+    });
+    expect(out.find((n) => n.kind.startsWith('transfer_'))).toBeUndefined();
+  });
+});
+
+describe('genererNotifications — per-charge alerts', () => {
+  it('emits "charge_overdue" with danger level when paymentDay < today', () => {
+    const out = genererNotifications({
+      transfertRecommandeAjuste: new Decimal(0),
+      charges: [charge({ id: 'rent', label: 'Loyer', paymentDay: 5, paymentMonths: [5] })],
+      payments: noPayments,
+      ref: ref(2026, 5),
+      todayDayOfMonth: 10,
+      isCurrentMonth: true,
+    });
+    const overdue = out.find((n) => n.kind === 'charge_overdue');
+    expect(overdue).toBeDefined();
+    expect(overdue!.level).toBe('danger');
+    expect(overdue!.values).toEqual({ label: 'Loyer', day: 5 });
+    expect(overdue!.id).toBe('charge_overdue-rent');
+  });
+
+  it('emits "charge_due_soon" with warning level when ≤ 3 days away', () => {
+    const out = genererNotifications({
+      transfertRecommandeAjuste: new Decimal(0),
+      charges: [charge({ id: 'phone', label: 'Telecom', paymentDay: 18, paymentMonths: [5] })],
+      payments: noPayments,
+      ref: ref(2026, 5),
+      todayDayOfMonth: 16,
+      isCurrentMonth: true,
+    });
+    const dueSoon = out.find((n) => n.kind === 'charge_due_soon');
+    expect(dueSoon).toBeDefined();
+    expect(dueSoon!.level).toBe('warning');
+    expect(dueSoon!.values).toEqual({ label: 'Telecom', days: 2 });
+  });
+
+  it('does NOT alert when the charge is paid for the current period', () => {
+    const out = genererNotifications({
+      transfertRecommandeAjuste: new Decimal(0),
+      charges: [charge({ id: 'rent', paymentDay: 5, paymentMonths: [5] })],
+      payments: new Map<string, boolean>([[paymentKey('rent', 2026, 5), true]]),
+      ref: ref(2026, 5),
+      todayDayOfMonth: 10,
+      isCurrentMonth: true,
+    });
+    expect(out.find((n) => n.kind.startsWith('charge_'))).toBeUndefined();
+  });
+
+  it('does NOT alert for charges not due this month', () => {
+    const out = genererNotifications({
+      transfertRecommandeAjuste: new Decimal(0),
+      charges: [
+        charge({ paymentDay: 5, paymentMonths: [3] }), // due in March
+      ],
+      payments: noPayments,
+      ref: ref(2026, 5),
+      todayDayOfMonth: 1,
+      isCurrentMonth: true,
+    });
+    expect(out).toHaveLength(0);
+  });
+
+  it('does NOT alert for inactive charges', () => {
+    const out = genererNotifications({
+      transfertRecommandeAjuste: new Decimal(0),
+      charges: [charge({ paymentDay: 1, paymentMonths: [5], isActive: false })],
+      payments: noPayments,
+      ref: ref(2026, 5),
+      todayDayOfMonth: 28,
+      isCurrentMonth: true,
+    });
+    expect(out).toHaveLength(0);
+  });
+
+  it('does NOT alert when the charge is more than 3 days away', () => {
+    const out = genererNotifications({
+      transfertRecommandeAjuste: new Decimal(0),
+      charges: [charge({ paymentDay: 25, paymentMonths: [5] })],
+      payments: noPayments,
+      ref: ref(2026, 5),
+      todayDayOfMonth: 10,
+      isCurrentMonth: true,
+    });
+    expect(out).toHaveLength(0);
+  });
+
+  it('emits multiple notifications when several charges qualify', () => {
+    const out = genererNotifications({
+      transfertRecommandeAjuste: new Decimal(50),
+      charges: [
+        charge({ id: 'a', label: 'A', paymentDay: 5, paymentMonths: [5] }), // overdue
+        charge({ id: 'b', label: 'B', paymentDay: 12, paymentMonths: [5] }), // due soon
+        charge({ id: 'c', label: 'C', paymentDay: 28, paymentMonths: [5] }), // far future
+      ],
+      payments: noPayments,
+      ref: ref(2026, 5),
+      todayDayOfMonth: 10,
+      isCurrentMonth: true,
+    });
+    // 1 transfer + 1 overdue (a) + 1 due_soon (b) = 3
+    expect(out).toHaveLength(3);
+    expect(out.filter((n) => n.kind === 'charge_overdue')).toHaveLength(1);
+    expect(out.filter((n) => n.kind === 'charge_due_soon')).toHaveLength(1);
+  });
+});

--- a/src/lib/domain/cockpit/__tests__/previsions.test.ts
+++ b/src/lib/domain/cockpit/__tests__/previsions.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import Decimal from 'decimal.js';
+
+import { genererPrevisions } from '@/lib/domain/cockpit/previsions';
+import type { CockpitCharge, ReferencePeriod } from '@/lib/domain/cockpit/types';
+
+const charge = (over: Partial<CockpitCharge>): CockpitCharge => ({
+  id: over.id ?? 'c-' + Math.random().toString(36).slice(2),
+  label: over.label ?? 'Test',
+  amount: over.amount ?? new Decimal(0),
+  frequency: over.frequency ?? 'monthly',
+  paymentMonths: over.paymentMonths ?? [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+  paymentDay: over.paymentDay ?? 1,
+  isActive: over.isActive ?? true,
+});
+
+const ref = (year: number, month: number): ReferencePeriod => ({ year, month });
+
+describe('genererPrevisions', () => {
+  it('returns 6 entries by default', () => {
+    const out = genererPrevisions({
+      charges: [],
+      ref: ref(2026, 5),
+      revenus: new Decimal(2000),
+      plafondQuotidien: new Decimal(500),
+    });
+    expect(out).toHaveLength(6);
+  });
+
+  it('starts at the reference month', () => {
+    const out = genererPrevisions({
+      charges: [],
+      ref: ref(2026, 5),
+      revenus: new Decimal(2000),
+      plafondQuotidien: new Decimal(500),
+    });
+    expect(out[0]).toMatchObject({ year: 2026, month: 5 });
+    expect(out[1]).toMatchObject({ year: 2026, month: 6 });
+    expect(out[5]).toMatchObject({ year: 2026, month: 10 });
+  });
+
+  it('wraps year correctly when crossing December → January', () => {
+    const out = genererPrevisions({
+      charges: [],
+      ref: ref(2026, 10),
+      revenus: new Decimal(2000),
+      plafondQuotidien: new Decimal(500),
+    });
+    expect(out[0]).toMatchObject({ year: 2026, month: 10 });
+    expect(out[2]).toMatchObject({ year: 2026, month: 12 });
+    expect(out[3]).toMatchObject({ year: 2027, month: 1 });
+    expect(out[5]).toMatchObject({ year: 2027, month: 3 });
+  });
+
+  it('sums charges due in each projected month', () => {
+    const charges = [
+      charge({ amount: new Decimal(900), frequency: 'monthly' }),
+      charge({ amount: new Decimal(300), frequency: 'annual', paymentMonths: [6] }),
+    ];
+    const out = genererPrevisions({
+      charges,
+      ref: ref(2026, 5),
+      revenus: new Decimal(2000),
+      plafondQuotidien: new Decimal(500),
+    });
+    // May: 900 (monthly) → 900
+    // June: 900 + 300 → 1200
+    expect(out[0]!.totalCharges.toNumber()).toBe(900);
+    expect(out[1]!.totalCharges.toNumber()).toBe(1200);
+  });
+
+  it('marges = revenus - charges - plafond', () => {
+    const out = genererPrevisions({
+      charges: [charge({ amount: new Decimal(900), frequency: 'monthly' })],
+      ref: ref(2026, 5),
+      revenus: new Decimal(2000),
+      plafondQuotidien: new Decimal(500),
+    });
+    // 2000 - 900 - 500 = 600
+    expect(out[0]!.margePrevue.toNumber()).toBe(600);
+  });
+
+  it('produces negative marge when charges + plafond exceed revenus', () => {
+    const out = genererPrevisions({
+      charges: [charge({ amount: new Decimal(2000), frequency: 'monthly' })],
+      ref: ref(2026, 5),
+      revenus: new Decimal(2000),
+      plafondQuotidien: new Decimal(500),
+    });
+    expect(out[0]!.margePrevue.toNumber()).toBe(-500);
+  });
+
+  it('honors a custom horizon', () => {
+    const out = genererPrevisions({
+      charges: [],
+      ref: ref(2026, 5),
+      revenus: new Decimal(2000),
+      plafondQuotidien: new Decimal(0),
+      horizonMonths: 12,
+    });
+    expect(out).toHaveLength(12);
+    expect(out[11]).toMatchObject({ year: 2027, month: 4 });
+  });
+
+  it('throws RangeError when horizon < 1', () => {
+    expect(() =>
+      genererPrevisions({
+        charges: [],
+        ref: ref(2026, 5),
+        revenus: new Decimal(2000),
+        plafondQuotidien: new Decimal(0),
+        horizonMonths: 0,
+      }),
+    ).toThrow(RangeError);
+  });
+
+  it('ignores inactive charges', () => {
+    const out = genererPrevisions({
+      charges: [charge({ amount: new Decimal(900), frequency: 'monthly', isActive: false })],
+      ref: ref(2026, 5),
+      revenus: new Decimal(2000),
+      plafondQuotidien: new Decimal(0),
+    });
+    expect(out[0]!.totalCharges.toNumber()).toBe(0);
+  });
+});

--- a/src/lib/domain/cockpit/__tests__/sante-provisions.test.ts
+++ b/src/lib/domain/cockpit/__tests__/sante-provisions.test.ts
@@ -1,0 +1,457 @@
+import { describe, it, expect } from 'vitest';
+import Decimal from 'decimal.js';
+
+import {
+  calculerEpargneRequiseParCharge,
+  calculerSanteProvisions,
+  RATTRAPAGE_MONTHS,
+} from '@/lib/domain/cockpit/sante-provisions';
+import { paymentKey, type CockpitCharge, type ReferencePeriod } from '@/lib/domain/cockpit/types';
+
+const charge = (over: Partial<CockpitCharge>): CockpitCharge => ({
+  id: over.id ?? 'c-' + Math.random().toString(36).slice(2),
+  label: over.label ?? 'Test',
+  amount: over.amount ?? new Decimal(0),
+  frequency: over.frequency ?? 'annual',
+  paymentMonths: over.paymentMonths ?? [3],
+  paymentDay: over.paymentDay ?? 1,
+  isActive: over.isActive ?? true,
+});
+
+const ref = (year: number, month: number): ReferencePeriod => ({ year, month });
+const noPayments = new Map<string, boolean>();
+
+const RATTRAPAGE_DIVISOR = RATTRAPAGE_MONTHS;
+
+describe('calculerEpargneRequiseParCharge — annual', () => {
+  it('returns 0 for monthly charges (no provisioning needed)', () => {
+    const c = charge({ amount: new Decimal(900), frequency: 'monthly' });
+    const out = calculerEpargneRequiseParCharge({
+      charge: c,
+      ref: ref(2026, 5),
+      payments: noPayments,
+    });
+    expect(out.toNumber()).toBe(0);
+  });
+
+  it('returns 0 for inactive charges', () => {
+    const c = charge({ amount: new Decimal(1200), paymentMonths: [3], isActive: false });
+    const out = calculerEpargneRequiseParCharge({
+      charge: c,
+      ref: ref(2026, 5),
+      payments: noPayments,
+    });
+    expect(out.toNumber()).toBe(0);
+  });
+
+  it('annual charge — 1 month before due → 11/12 of amount required', () => {
+    const c = charge({ amount: new Decimal(1200), paymentMonths: [3] });
+    // ref month 2, due month 3, monthsLeft = 1, safeMonthsLeft = 1
+    // requise = 1200 - 1200/12 × 1 = 1200 - 100 = 1100
+    const out = calculerEpargneRequiseParCharge({
+      charge: c,
+      ref: ref(2026, 2),
+      payments: noPayments,
+    });
+    expect(out.toNumber()).toBe(1100);
+  });
+
+  it('annual charge — 11 months before due (just settled) → 1/12 of amount required', () => {
+    const c = charge({ amount: new Decimal(1200), paymentMonths: [3] });
+    // ref month 4, due month 3 next year (wrap), monthsLeft = 11, safeMonthsLeft = 11
+    // requise = 1200 - 100 × 11 = 100
+    const out = calculerEpargneRequiseParCharge({
+      charge: c,
+      ref: ref(2026, 4),
+      payments: noPayments,
+    });
+    expect(out.toNumber()).toBe(100);
+  });
+
+  it('annual charge — due this month, NOT paid → full amount required', () => {
+    const c = charge({ amount: new Decimal(1200), paymentMonths: [3] });
+    const out = calculerEpargneRequiseParCharge({
+      charge: c,
+      ref: ref(2026, 3),
+      payments: noPayments,
+    });
+    expect(out.toNumber()).toBe(1200);
+  });
+
+  it('annual charge — due this month, ALREADY paid → 0 required (cycle reset)', () => {
+    const c = charge({ id: 'taxe', amount: new Decimal(1200), paymentMonths: [3] });
+    const payments = new Map<string, boolean>([[paymentKey('taxe', 2026, 3), true]]);
+    // After payment, nextMois rolls to next year's March → monthsLeft = 12
+    // requise = 1200 - 100 × 12 = 0
+    const out = calculerEpargneRequiseParCharge({
+      charge: c,
+      ref: ref(2026, 3),
+      payments,
+    });
+    expect(out.toNumber()).toBe(0);
+  });
+});
+
+describe('calculerEpargneRequiseParCharge — quarterly', () => {
+  it('quarterly — exactly between two due months → mid-cycle requirement', () => {
+    const c = charge({
+      amount: new Decimal(45),
+      frequency: 'quarterly',
+      paymentMonths: [1, 4, 7, 10],
+    });
+    // ref month 5, next due 7 (in 2 months), cycleMonths = 3, safeMonthsLeft = 2
+    // requise = 45 - 15 × 2 = 15
+    const out = calculerEpargneRequiseParCharge({
+      charge: c,
+      ref: ref(2026, 5),
+      payments: noPayments,
+    });
+    expect(out.toNumber()).toBe(15);
+  });
+
+  it('quarterly — just after a due month → almost full cycle to save', () => {
+    const c = charge({
+      amount: new Decimal(45),
+      frequency: 'quarterly',
+      paymentMonths: [1, 4, 7, 10],
+    });
+    // ref month 2, next due 4 (in 2 months), safeMonthsLeft = 2
+    // requise = 45 - 15 × 2 = 15
+    const out = calculerEpargneRequiseParCharge({
+      charge: c,
+      ref: ref(2026, 2),
+      payments: noPayments,
+    });
+    expect(out.toNumber()).toBe(15);
+  });
+
+  it('quarterly — due this month and paid → 1/3 of cycle elapsed → ~0', () => {
+    const c = charge({
+      id: 'water',
+      amount: new Decimal(45),
+      frequency: 'quarterly',
+      paymentMonths: [1, 4, 7, 10],
+    });
+    const payments = new Map<string, boolean>([[paymentKey('water', 2026, 4), true]]);
+    // After paying April, nextMois = July → monthsLeft = 3, safeMonthsLeft = 3
+    // requise = 45 - 15 × 3 = 0
+    const out = calculerEpargneRequiseParCharge({
+      charge: c,
+      ref: ref(2026, 4),
+      payments,
+    });
+    expect(out.toNumber()).toBe(0);
+  });
+
+  it('quarterly — wrap-around December → January', () => {
+    const c = charge({
+      amount: new Decimal(45),
+      frequency: 'quarterly',
+      paymentMonths: [1, 4, 7, 10],
+    });
+    // ref month 12, next due Jan (wraps), monthsLeft = 1, safeMonthsLeft = 1
+    // requise = 45 - 15 × 1 = 30
+    const out = calculerEpargneRequiseParCharge({
+      charge: c,
+      ref: ref(2026, 12),
+      payments: noPayments,
+    });
+    expect(out.toNumber()).toBe(30);
+  });
+});
+
+describe('calculerEpargneRequiseParCharge — semiannual (Ankora extension)', () => {
+  it('semiannual — 3 months before due → mid-cycle requirement', () => {
+    const c = charge({
+      amount: new Decimal(600),
+      frequency: 'semiannual',
+      paymentMonths: [3, 9],
+    });
+    // ref month 6, next due 9, monthsLeft = 3, cycleMonths = 6, safeMonthsLeft = 3
+    // requise = 600 - 100 × 3 = 300
+    const out = calculerEpargneRequiseParCharge({
+      charge: c,
+      ref: ref(2026, 6),
+      payments: noPayments,
+    });
+    expect(out.toNumber()).toBe(300);
+  });
+
+  it('semiannual — wrap-around December → March', () => {
+    const c = charge({
+      amount: new Decimal(600),
+      frequency: 'semiannual',
+      paymentMonths: [3, 9],
+    });
+    // ref 12, next due 3 (wrap), monthsLeft = 3, safeMonthsLeft = 3
+    // requise = 600 - 100 × 3 = 300
+    const out = calculerEpargneRequiseParCharge({
+      charge: c,
+      ref: ref(2026, 12),
+      payments: noPayments,
+    });
+    expect(out.toNumber()).toBe(300);
+  });
+
+  it('semiannual — due this month and paid → cycle reset to 6 months saving', () => {
+    const c = charge({
+      id: 'sem',
+      amount: new Decimal(600),
+      frequency: 'semiannual',
+      paymentMonths: [3, 9],
+    });
+    const payments = new Map<string, boolean>([[paymentKey('sem', 2026, 3), true]]);
+    // After March payment, nextMois = Sept → monthsLeft = 6, safeMonthsLeft = 6
+    // requise = 600 - 100 × 6 = 0
+    const out = calculerEpargneRequiseParCharge({
+      charge: c,
+      ref: ref(2026, 3),
+      payments,
+    });
+    expect(out.toNumber()).toBe(0);
+  });
+});
+
+describe('calculerEpargneRequiseParCharge — wrap-around scenarios', () => {
+  it('annual due in January, ref November → 2 months left', () => {
+    const c = charge({ amount: new Decimal(1200), paymentMonths: [1] });
+    // ref 11, next due 1 (wrap), monthsLeft = 2
+    // requise = 1200 - 100 × 2 = 1000
+    const out = calculerEpargneRequiseParCharge({
+      charge: c,
+      ref: ref(2026, 11),
+      payments: noPayments,
+    });
+    expect(out.toNumber()).toBe(1000);
+  });
+
+  it('annual due in January, ref December → 1 month left', () => {
+    const c = charge({ amount: new Decimal(1200), paymentMonths: [1] });
+    const out = calculerEpargneRequiseParCharge({
+      charge: c,
+      ref: ref(2026, 12),
+      payments: noPayments,
+    });
+    expect(out.toNumber()).toBe(1100);
+  });
+
+  it('annual due in December, ref January → 11 months left', () => {
+    const c = charge({ amount: new Decimal(1200), paymentMonths: [12] });
+    // ref 1, next due 12, monthsLeft = 11, safeMonthsLeft = 11
+    // requise = 1200 - 100 × 11 = 100
+    const out = calculerEpargneRequiseParCharge({
+      charge: c,
+      ref: ref(2026, 1),
+      payments: noPayments,
+    });
+    expect(out.toNumber()).toBe(100);
+  });
+
+  it('paymentMonths sorted ascending regardless of input order', () => {
+    const c = charge({
+      amount: new Decimal(45),
+      frequency: 'quarterly',
+      paymentMonths: [10, 1, 7, 4], // unsorted
+    });
+    const out = calculerEpargneRequiseParCharge({
+      charge: c,
+      ref: ref(2026, 5),
+      payments: noPayments,
+    });
+    // Same as the sorted [1,4,7,10] case: next = 7, monthsLeft = 2 → requise = 15
+    expect(out.toNumber()).toBe(15);
+  });
+
+  it('handles empty paymentMonths defensively (returns 0)', () => {
+    const c = charge({
+      amount: new Decimal(1200),
+      paymentMonths: [], // pathological — shouldn't happen but the algo must not crash
+    });
+    const out = calculerEpargneRequiseParCharge({
+      charge: c,
+      ref: ref(2026, 5),
+      payments: noPayments,
+    });
+    expect(out.toNumber()).toBe(0);
+  });
+});
+
+describe('calculerSanteProvisions — aggregation', () => {
+  it('returns "a_jour" when there are no periodic charges', () => {
+    const out = calculerSanteProvisions({
+      charges: [charge({ amount: new Decimal(900), frequency: 'monthly' })],
+      payments: noPayments,
+      soldeEpargneActuel: new Decimal(0),
+      ref: ref(2026, 5),
+    });
+    expect(out.statut).toBe('a_jour');
+    expect(out.totalEpargneTheorique.toNumber()).toBe(0);
+    expect(out.deficitEpargne.toNumber()).toBe(0);
+    expect(out.rattrapageMensuel.toNumber()).toBe(0);
+  });
+
+  it('returns "a_jour" when balance covers the théorique exactly', () => {
+    const out = calculerSanteProvisions({
+      charges: [charge({ amount: new Decimal(1200), paymentMonths: [3] })],
+      payments: noPayments,
+      soldeEpargneActuel: new Decimal(1100), // 1200 - 100 × 1 (ref = month 2)
+      ref: ref(2026, 2),
+    });
+    expect(out.statut).toBe('a_jour');
+    expect(out.deficitEpargne.toNumber()).toBe(0);
+  });
+
+  it('returns "a_jour" when balance is over-provisioned (negative deficit)', () => {
+    const out = calculerSanteProvisions({
+      charges: [charge({ amount: new Decimal(1200), paymentMonths: [3] })],
+      payments: noPayments,
+      soldeEpargneActuel: new Decimal(5000),
+      ref: ref(2026, 2),
+    });
+    expect(out.statut).toBe('a_jour');
+    expect(out.deficitEpargne.lt(0)).toBe(true);
+    expect(out.rattrapageMensuel.toNumber()).toBe(0);
+  });
+
+  it('returns "deficit" with rattrapage = deficit / 3', () => {
+    const out = calculerSanteProvisions({
+      charges: [charge({ amount: new Decimal(1200), paymentMonths: [3] })],
+      payments: noPayments,
+      soldeEpargneActuel: new Decimal(0),
+      ref: ref(2026, 2),
+    });
+    // Théorique = 1100, solde = 0, déficit = 1100, rattrapage = 1100/3
+    expect(out.statut).toBe('deficit');
+    expect(out.deficitEpargne.toNumber()).toBe(1100);
+    expect(out.rattrapageMensuel.toFixed(2)).toBe(
+      new Decimal(1100).dividedBy(RATTRAPAGE_DIVISOR).toFixed(2),
+    );
+  });
+
+  it('exposes per-charge breakdown', () => {
+    const out = calculerSanteProvisions({
+      charges: [
+        charge({ id: 'a', amount: new Decimal(120), paymentMonths: [3] }),
+        charge({ id: 'b', amount: new Decimal(300), paymentMonths: [6] }),
+      ],
+      payments: noPayments,
+      soldeEpargneActuel: new Decimal(50),
+      ref: ref(2026, 2),
+    });
+    expect(out.detailParCharge).toHaveLength(2);
+    expect(out.detailParCharge.find((d) => d.chargeId === 'a')).toBeDefined();
+    expect(out.detailParCharge.find((d) => d.chargeId === 'b')).toBeDefined();
+  });
+
+  it("reproduces @thierry's real fixture (5 periodic charges)", () => {
+    const charges = [
+      charge({ id: 'dashlane', amount: new Decimal(53), paymentMonths: [4] }),
+      charge({
+        id: 'swde',
+        amount: new Decimal(45),
+        frequency: 'quarterly',
+        paymentMonths: [1, 4, 7, 10],
+      }),
+      charge({ id: 'taxe-voiture', amount: new Decimal(300), paymentMonths: [6] }),
+      charge({ id: 'taxe-poubelle', amount: new Decimal(120), paymentMonths: [3] }),
+      charge({ id: 'taxe-egout', amount: new Decimal(55), paymentMonths: [3] }),
+    ];
+    const out = calculerSanteProvisions({
+      charges,
+      payments: noPayments,
+      soldeEpargneActuel: new Decimal(200),
+      ref: ref(2026, 5),
+    });
+    // Just assert structure — exact values are tested per-charge above.
+    expect(out.detailParCharge).toHaveLength(5);
+    expect(out.totalEpargneTheorique.gt(0)).toBe(true);
+  });
+
+  it('skips inactive charges entirely', () => {
+    const out = calculerSanteProvisions({
+      charges: [charge({ amount: new Decimal(1200), paymentMonths: [3], isActive: false })],
+      payments: noPayments,
+      soldeEpargneActuel: new Decimal(0),
+      ref: ref(2026, 5),
+    });
+    expect(out.detailParCharge).toHaveLength(0);
+    expect(out.statut).toBe('a_jour');
+  });
+
+  it('uses payments to advance the cycle for paid bills', () => {
+    const c = charge({ id: 'taxe', amount: new Decimal(1200), paymentMonths: [3] });
+    const paymentsMap = new Map<string, boolean>([[paymentKey('taxe', 2026, 3), true]]);
+    const out = calculerSanteProvisions({
+      charges: [c],
+      payments: paymentsMap,
+      soldeEpargneActuel: new Decimal(0),
+      ref: ref(2026, 3),
+    });
+    // After payment, requise = 0 → solde 0 covers it → a_jour
+    expect(out.totalEpargneTheorique.toNumber()).toBe(0);
+    expect(out.statut).toBe('a_jour');
+  });
+
+  it('soldeEpargneActuel is echoed unchanged in the output', () => {
+    const out = calculerSanteProvisions({
+      charges: [],
+      payments: noPayments,
+      soldeEpargneActuel: new Decimal(123.45),
+      ref: ref(2026, 5),
+    });
+    expect(out.soldeEpargneActuel.toNumber()).toBe(123.45);
+  });
+});
+
+describe('calculerSanteProvisions — edge cases', () => {
+  it('large deficit produces large rattrapage (no cap at the domain layer)', () => {
+    const out = calculerSanteProvisions({
+      charges: [charge({ amount: new Decimal(12_000), paymentMonths: [3] })], // 1000/mo
+      payments: noPayments,
+      soldeEpargneActuel: new Decimal(0),
+      ref: ref(2026, 4), // 11 months from next March
+    });
+    // Théorique = 12000 - 1000 × 11 = 1000 → deficit = 1000 → rattrapage = 333.33
+    expect(out.deficitEpargne.toNumber()).toBe(1000);
+    expect(out.rattrapageMensuel.toFixed(2)).toBe('333.33');
+  });
+
+  it('rounds rattrapage with Decimal precision (no float drift)', () => {
+    const out = calculerSanteProvisions({
+      charges: [charge({ amount: new Decimal(100), paymentMonths: [12] })],
+      payments: noPayments,
+      soldeEpargneActuel: new Decimal(0),
+      ref: ref(2026, 1),
+    });
+    // Théorique = 100 - (100/12)×11 = 100 - 91.6666… = 8.3333…
+    // Rattrapage = 8.3333…/3 = 2.7777…
+    expect(out.rattrapageMensuel.toFixed(4)).toBe('2.7778');
+  });
+
+  it('mix of paid and unpaid charges in the same workspace', () => {
+    const charges = [
+      charge({ id: 'a', amount: new Decimal(120), paymentMonths: [3] }),
+      charge({ id: 'b', amount: new Decimal(300), paymentMonths: [3] }),
+    ];
+    const paymentsMap = new Map<string, boolean>([[paymentKey('a', 2026, 3), true]]);
+    const out = calculerSanteProvisions({
+      charges,
+      payments: paymentsMap,
+      soldeEpargneActuel: new Decimal(0),
+      ref: ref(2026, 3),
+    });
+    // a paid → requise = 0 ; b not paid → requise = 300
+    expect(out.totalEpargneTheorique.toNumber()).toBe(300);
+  });
+
+  it('handles a workspace with zero charges (empty cockpit)', () => {
+    const out = calculerSanteProvisions({
+      charges: [],
+      payments: noPayments,
+      soldeEpargneActuel: new Decimal(0),
+      ref: ref(2026, 5),
+    });
+    expect(out.statut).toBe('a_jour');
+    expect(out.detailParCharge).toHaveLength(0);
+  });
+});

--- a/src/lib/domain/cockpit/__tests__/simulateur.test.ts
+++ b/src/lib/domain/cockpit/__tests__/simulateur.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import Decimal from 'decimal.js';
+
+import { simulerEconomie } from '@/lib/domain/cockpit/simulateur';
+import type { CockpitCharge } from '@/lib/domain/cockpit/types';
+
+const charge = (over: Partial<CockpitCharge>): CockpitCharge => ({
+  id: over.id ?? 'c-' + Math.random().toString(36).slice(2),
+  label: over.label ?? 'Test',
+  amount: over.amount ?? new Decimal(0),
+  frequency: over.frequency ?? 'monthly',
+  paymentMonths: over.paymentMonths ?? [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+  paymentDay: over.paymentDay ?? 1,
+  isActive: over.isActive ?? true,
+});
+
+describe('simulerEconomie', () => {
+  it('monthly — économie = différence directe', () => {
+    const out = simulerEconomie({
+      charge: charge({ amount: new Decimal(80), frequency: 'monthly' }),
+      nouveauPrix: new Decimal(50),
+    });
+    expect(out.difference.toNumber()).toBe(30);
+    expect(out.economieMensuelleLissee.toNumber()).toBe(30);
+    expect(out.economieAnnuelle.toNumber()).toBe(360);
+  });
+
+  it('quarterly — économie / 3', () => {
+    const out = simulerEconomie({
+      charge: charge({ amount: new Decimal(60), frequency: 'quarterly' }),
+      nouveauPrix: new Decimal(45),
+    });
+    expect(out.difference.toNumber()).toBe(15);
+    expect(out.economieMensuelleLissee.toNumber()).toBe(5);
+    expect(out.economieAnnuelle.toNumber()).toBe(60);
+  });
+
+  it('semiannual — économie / 6', () => {
+    const out = simulerEconomie({
+      charge: charge({ amount: new Decimal(600), frequency: 'semiannual' }),
+      nouveauPrix: new Decimal(540),
+    });
+    expect(out.difference.toNumber()).toBe(60);
+    expect(out.economieMensuelleLissee.toNumber()).toBe(10);
+    expect(out.economieAnnuelle.toNumber()).toBe(120);
+  });
+
+  it('annual — économie / 12', () => {
+    const out = simulerEconomie({
+      charge: charge({ amount: new Decimal(53), frequency: 'annual' }),
+      nouveauPrix: new Decimal(35),
+    });
+    expect(out.difference.toNumber()).toBe(18);
+    expect(out.economieMensuelleLissee.toFixed(2)).toBe('1.50');
+    expect(out.economieAnnuelle.toNumber()).toBe(18);
+  });
+
+  it('handles a price increase (negative économie)', () => {
+    const out = simulerEconomie({
+      charge: charge({ amount: new Decimal(50), frequency: 'monthly' }),
+      nouveauPrix: new Decimal(70),
+    });
+    expect(out.difference.toNumber()).toBe(-20);
+    expect(out.economieMensuelleLissee.toNumber()).toBe(-20);
+    expect(out.economieAnnuelle.toNumber()).toBe(-240);
+  });
+
+  it('returns zero when nouveauPrix equals current amount', () => {
+    const out = simulerEconomie({
+      charge: charge({ amount: new Decimal(100), frequency: 'monthly' }),
+      nouveauPrix: new Decimal(100),
+    });
+    expect(out.difference.toNumber()).toBe(0);
+    expect(out.economieMensuelleLissee.toNumber()).toBe(0);
+    expect(out.economieAnnuelle.toNumber()).toBe(0);
+  });
+
+  it('preserves Decimal precision on annual / 12 calculations', () => {
+    const out = simulerEconomie({
+      charge: charge({ amount: new Decimal(53), frequency: 'annual' }),
+      nouveauPrix: new Decimal(0),
+    });
+    // diff = 53, lissée = 53/12 = 4.4166…, annuelle = 53
+    expect(out.economieMensuelleLissee.toFixed(6)).toBe('4.416667');
+    expect(out.economieAnnuelle.toNumber()).toBe(53);
+  });
+});

--- a/src/lib/domain/cockpit/assistant-virements.ts
+++ b/src/lib/domain/cockpit/assistant-virements.ts
@@ -1,0 +1,98 @@
+import Decimal from 'decimal.js';
+
+import { provisionsMensuellesLissees } from './effort-financier-lisse';
+import {
+  CYCLE_MONTHS,
+  isPeriodicFrequency,
+  periodicCharges,
+  type CockpitCharge,
+  type CockpitFrequency,
+  type ReferencePeriod,
+} from './types';
+
+export type DetailProvision = Readonly<{
+  chargeId: string;
+  label: string;
+  frequency: Exclude<CockpitFrequency, 'monthly'>;
+  montantOriginal: Decimal;
+  /** amount / cycleMonths — the smoothed monthly contribution for this charge. */
+  provisionLissee: Decimal;
+}>;
+
+export type AssistantVirementsInput = Readonly<{
+  charges: readonly CockpitCharge[];
+  ref: ReferencePeriod;
+  /** Comes from `calculerSanteProvisions(...).rattrapageMensuel` (≥ 0). */
+  rattrapageMensuel: Decimal;
+}>;
+
+export type VirementDirection = 'vers_epargne' | 'depuis_epargne' | 'aucun';
+
+export type AssistantVirementsOutput = Readonly<{
+  provisionMensuelleTotale: Decimal;
+  totalPeriodiquesMois: Decimal;
+  /** provision - périodiques (raw, before rattrapage). May be negative. */
+  transfertRecommande: Decimal;
+  /** transfertRecommande + rattrapageMensuel. May be negative. */
+  transfertRecommandeAjuste: Decimal;
+  direction: VirementDirection;
+  detailProvisions: readonly DetailProvision[];
+}>;
+
+/**
+ * Assistant Virements (ADR-012) — the differentiating cockpit calculation.
+ *
+ *   provisionMensuelleTotale = Σ(periodic charge amount / cycleMonths)
+ *   totalPeriodiquesMois     = Σ(periodic charge amount where ref.month ∈ paymentMonths)
+ *   transfertRecommande      = provision - périodiquesMois
+ *   transfertRecommandeAjuste = transfertRecommande + rattrapageMensuel
+ *
+ * Direction:
+ *   > 0  → "vers_epargne"   (top up the savings buffer)
+ *   < 0  → "depuis_epargne" (pull from savings to settle the periodic bills)
+ *   = 0  → "aucun"          (perfect equilibrium for the month)
+ */
+export function calculerAssistantVirements(
+  input: AssistantVirementsInput,
+): AssistantVirementsOutput {
+  const periodics = periodicCharges(input.charges);
+
+  // Defensive narrowing: the spec excludes monthly from this list and
+  // `Exclude<CockpitFrequency, 'monthly'>` makes it safe in the output type.
+  const detailProvisions: DetailProvision[] = periodics.map((c) => {
+    if (!isPeriodicFrequency(c.frequency)) {
+      throw new Error('periodicCharges leaked a monthly charge — invariant broken');
+    }
+    const cycleMonths = CYCLE_MONTHS[c.frequency];
+    return {
+      chargeId: c.id,
+      label: c.label,
+      frequency: c.frequency as Exclude<CockpitFrequency, 'monthly'>,
+      montantOriginal: c.amount,
+      provisionLissee: c.amount.dividedBy(cycleMonths),
+    };
+  });
+
+  const provisionMensuelleTotale = provisionsMensuellesLissees(input.charges);
+
+  const totalPeriodiquesMois = periodics
+    .filter((c) => c.paymentMonths.includes(input.ref.month))
+    .reduce((acc, c) => acc.plus(c.amount), new Decimal(0));
+
+  const transfertRecommande = provisionMensuelleTotale.minus(totalPeriodiquesMois);
+  const transfertRecommandeAjuste = transfertRecommande.plus(input.rattrapageMensuel);
+
+  let direction: VirementDirection;
+  if (transfertRecommandeAjuste.gt(0)) direction = 'vers_epargne';
+  else if (transfertRecommandeAjuste.lt(0)) direction = 'depuis_epargne';
+  else direction = 'aucun';
+
+  return {
+    provisionMensuelleTotale,
+    totalPeriodiquesMois,
+    transfertRecommande,
+    transfertRecommandeAjuste,
+    direction,
+    detailProvisions,
+  };
+}

--- a/src/lib/domain/cockpit/capacite-epargne-reelle.ts
+++ b/src/lib/domain/cockpit/capacite-epargne-reelle.ts
@@ -1,0 +1,43 @@
+import Decimal from 'decimal.js';
+
+import { effortFinancierLisse } from './effort-financier-lisse';
+import type { CockpitCharge } from './types';
+
+export type CapaciteEpargneReelleInput = Readonly<{
+  revenus: Decimal;
+  charges: readonly CockpitCharge[];
+  plafondQuotidien: Decimal;
+}>;
+
+export type CapaciteEpargneReelleOutput = Readonly<{
+  /** Σ charges mensuelles + provisions lissées (cf. ADR-009 + effort-financier-lisse). */
+  effortFinancierLisse: Decimal;
+  /** revenus - effort - plafond. May be negative. */
+  capacite: Decimal;
+  /** Convenience flag for the UI. */
+  isPositive: boolean;
+}>;
+
+/**
+ * Capacité d'Épargne Réelle (ADR-009) =
+ *   Revenus - Effort_Financier_Lissé - Plafond_Quotidien
+ *
+ * The KPI hero of the cockpit. Designed to be stable mois-après-mois (the
+ * lissage absorbs the volatility of periodic bills) and to be honest about
+ * whether the user's lifestyle fits inside their income on a true annual
+ * basis.
+ *
+ * No clamping: if revenus = 0 or plafond > revenus, this returns a negative
+ * value and the UI layer is responsible for messaging the user.
+ */
+export function capaciteEpargneReelle(
+  input: CapaciteEpargneReelleInput,
+): CapaciteEpargneReelleOutput {
+  const effort = effortFinancierLisse(input.charges);
+  const capacite = input.revenus.minus(effort).minus(input.plafondQuotidien);
+  return {
+    effortFinancierLisse: effort,
+    capacite,
+    isPositive: capacite.gte(0),
+  };
+}

--- a/src/lib/domain/cockpit/effort-financier-lisse.ts
+++ b/src/lib/domain/cockpit/effort-financier-lisse.ts
@@ -1,0 +1,39 @@
+import Decimal from 'decimal.js';
+
+import { CYCLE_MONTHS, monthlyCharges, periodicCharges, type CockpitCharge } from './types';
+
+/**
+ * Sum of every active monthly charge.
+ * Inactive charges are ignored (they don't impact the cockpit).
+ */
+export function totalChargesMensuelles(charges: readonly CockpitCharge[]): Decimal {
+  return monthlyCharges(charges).reduce((acc, c) => acc.plus(c.amount), new Decimal(0));
+}
+
+/**
+ * Sum of the monthly equivalent of every active periodic charge.
+ *  annual     → amount / 12
+ *  semiannual → amount / 6
+ *  quarterly  → amount / 3
+ *  monthly    → 0  (already counted in `totalChargesMensuelles`)
+ *
+ * Decimal precision is preserved internally; rounding is the UI layer's job.
+ */
+export function provisionsMensuellesLissees(charges: readonly CockpitCharge[]): Decimal {
+  return periodicCharges(charges).reduce(
+    (acc, c) => acc.plus(c.amount.dividedBy(CYCLE_MONTHS[c.frequency])),
+    new Decimal(0),
+  );
+}
+
+/**
+ * Effort Financier Lissé (ADR-009) =
+ *   Σ charges mensuelles + Σ provisions mensuelles lissées
+ *
+ * Cf. spec dashboard-cockpit-vraie-vision-2026-05-03 §1.
+ * This is what the user "really" pays each month once you smooth out the
+ * periodic bills. It's the input to `capaciteEpargneReelle`.
+ */
+export function effortFinancierLisse(charges: readonly CockpitCharge[]): Decimal {
+  return totalChargesMensuelles(charges).plus(provisionsMensuellesLissees(charges));
+}

--- a/src/lib/domain/cockpit/index.ts
+++ b/src/lib/domain/cockpit/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Cockpit domain — pure financial calculations powering the v1.0 dashboard.
+ *
+ * Cf. specs/dashboard-cockpit-vraie-vision-2026-05-03.md (vault Athenaeum)
+ * and ADRs 008-012 (`docs/adr/`).
+ *
+ * Zero dependency on Supabase or Next.js — all functions consume `Decimal`
+ * inputs and return `Decimal` outputs.
+ */
+
+export * from './types';
+export * from './effort-financier-lisse';
+export * from './capacite-epargne-reelle';
+export * from './assistant-virements';
+export * from './sante-provisions';
+export * from './notifications';
+export * from './previsions';
+export * from './simulateur';

--- a/src/lib/domain/cockpit/notifications.ts
+++ b/src/lib/domain/cockpit/notifications.ts
@@ -1,0 +1,98 @@
+import Decimal from 'decimal.js';
+
+import { paymentKey, type CockpitCharge, type PaymentLedger, type ReferencePeriod } from './types';
+
+export type NotificationLevel = 'info' | 'warning' | 'danger';
+
+export type NotificationKind =
+  | 'transfer_to_savings'
+  | 'transfer_from_savings'
+  | 'charge_overdue'
+  | 'charge_due_soon';
+
+export type CockpitNotification = Readonly<{
+  kind: NotificationKind;
+  level: NotificationLevel;
+  /** i18n message key — the UI layer renders the text via next-intl. */
+  messageKey: string;
+  /** Values interpolated by the i18n layer — kept as plain JSON-friendly types. */
+  values: Readonly<Record<string, string | number>>;
+  /** Stable id for React keys; format: `${kind}-${chargeId?}`. */
+  id: string;
+}>;
+
+export type NotificationsInput = Readonly<{
+  /** ADR-012 output. Sign drives the transfer notification. */
+  transfertRecommandeAjuste: Decimal;
+  charges: readonly CockpitCharge[];
+  payments: PaymentLedger;
+  ref: ReferencePeriod;
+  /** Today's day-of-month (1..31). Caller passes it explicitly so the
+   *  domain stays deterministic and timezone-agnostic. */
+  todayDayOfMonth: number;
+  /** Whether the displayed month is the current real-life month. Notifications
+   *  for past or future months would be noise. ADR-011 requires this guard. */
+  isCurrentMonth: boolean;
+}>;
+
+const DUE_SOON_THRESHOLD_DAYS = 3;
+
+/**
+ * Generates the cockpit's reactive notifications (bell + badge).
+ * No notifications are produced for past or future months — only the
+ * "live" month carries actionable signals.
+ */
+export function genererNotifications(input: NotificationsInput): readonly CockpitNotification[] {
+  if (!input.isCurrentMonth) return [];
+
+  const out: CockpitNotification[] = [];
+
+  // 1. Transfer suggestion (positive → vers épargne, negative → depuis épargne).
+  if (input.transfertRecommandeAjuste.gt(0)) {
+    out.push({
+      kind: 'transfer_to_savings',
+      level: 'info',
+      messageKey: 'app.cockpit.notifications.transferToSavings',
+      values: { amount: input.transfertRecommandeAjuste.toFixed(2) },
+      id: 'transfer_to_savings',
+    });
+  } else if (input.transfertRecommandeAjuste.lt(0)) {
+    out.push({
+      kind: 'transfer_from_savings',
+      level: 'warning',
+      messageKey: 'app.cockpit.notifications.transferFromSavings',
+      values: { amount: input.transfertRecommandeAjuste.abs().toFixed(2) },
+      id: 'transfer_from_savings',
+    });
+  }
+
+  // 2. Per-charge notifications for unpaid bills due this month.
+  for (const c of input.charges) {
+    if (!c.isActive) continue;
+    if (!c.paymentMonths.includes(input.ref.month)) continue;
+    const isPaid = input.payments.get(paymentKey(c.id, input.ref.year, input.ref.month)) === true;
+    if (isPaid) continue;
+
+    const joursRestants = c.paymentDay - input.todayDayOfMonth;
+
+    if (joursRestants < 0) {
+      out.push({
+        kind: 'charge_overdue',
+        level: 'danger',
+        messageKey: 'app.cockpit.notifications.chargeOverdue',
+        values: { label: c.label, day: c.paymentDay },
+        id: `charge_overdue-${c.id}`,
+      });
+    } else if (joursRestants <= DUE_SOON_THRESHOLD_DAYS) {
+      out.push({
+        kind: 'charge_due_soon',
+        level: 'warning',
+        messageKey: 'app.cockpit.notifications.chargeDueSoon',
+        values: { label: c.label, days: joursRestants },
+        id: `charge_due_soon-${c.id}`,
+      });
+    }
+  }
+
+  return out;
+}

--- a/src/lib/domain/cockpit/previsions.ts
+++ b/src/lib/domain/cockpit/previsions.ts
@@ -1,0 +1,57 @@
+import Decimal from 'decimal.js';
+
+import type { CockpitCharge, ReferencePeriod } from './types';
+
+export type PrevisionMonth = Readonly<{
+  /** Calendar year of the projected month. */
+  year: number;
+  /** 1..12 */
+  month: number;
+  /** Sum of every active charge whose paymentMonths includes this month. */
+  totalCharges: Decimal;
+  /** revenus - totalCharges - plafondQuotidien — same calc as the marge brute. */
+  margePrevue: Decimal;
+}>;
+
+export type PrevisionsInput = Readonly<{
+  charges: readonly CockpitCharge[];
+  ref: ReferencePeriod;
+  revenus: Decimal;
+  plafondQuotidien: Decimal;
+  /** How many months to project. Spec is fixed at 6; exposed for testing. */
+  horizonMonths?: number;
+}>;
+
+const DEFAULT_HORIZON = 6;
+
+/**
+ * Projects the next N months (default 6, per spec). Each month carries the
+ * total cash that will leave the account (charges due that month) and the
+ * resulting marge brute. The UI renders the bar chart from this list.
+ *
+ * Year wraps when ref.month + i overflows December.
+ */
+export function genererPrevisions(input: PrevisionsInput): readonly PrevisionMonth[] {
+  const horizon = input.horizonMonths ?? DEFAULT_HORIZON;
+  if (horizon < 1) {
+    throw new RangeError('horizonMonths must be >= 1');
+  }
+
+  const out: PrevisionMonth[] = [];
+  for (let i = 0; i < horizon; i += 1) {
+    const offset = input.ref.month + i; // 1-based
+    const month = ((offset - 1) % 12) + 1; // 1..12
+    const yearDelta = Math.floor((offset - 1) / 12);
+    const year = input.ref.year + yearDelta;
+
+    const totalCharges = input.charges
+      .filter((c) => c.isActive && c.paymentMonths.includes(month))
+      .reduce((acc, c) => acc.plus(c.amount), new Decimal(0));
+
+    const margePrevue = input.revenus.minus(totalCharges).minus(input.plafondQuotidien);
+
+    out.push({ year, month, totalCharges, margePrevue });
+  }
+
+  return out;
+}

--- a/src/lib/domain/cockpit/sante-provisions.ts
+++ b/src/lib/domain/cockpit/sante-provisions.ts
@@ -1,0 +1,155 @@
+import Decimal from 'decimal.js';
+
+import {
+  CYCLE_MONTHS,
+  isPeriodicFrequency,
+  paymentKey,
+  type CockpitCharge,
+  type PaymentLedger,
+  type ReferencePeriod,
+} from './types';
+
+/** Rattrapage horizon — fixed at 3 months per ADR-011. */
+export const RATTRAPAGE_MONTHS = 3;
+
+export type EpargneRequiseInput = Readonly<{
+  charge: CockpitCharge;
+  ref: ReferencePeriod;
+  payments: PaymentLedger;
+}>;
+
+/**
+ * For a given periodic charge `c` and a reference month `M`, compute how
+ * much of the cycle's smoothing should already be sitting in the
+ * provisions account.
+ *
+ * Algorithm — copied verbatim from ADR-011:
+ *
+ *   1. nextMois = first month ∈ paymentMonths with month ≥ M.
+ *      If nextMois = M and the charge is already paid this period,
+ *      advance nextMois to the next entry (with rollover).
+ *      If no nextMois found at all, rollover to paymentMonths[0].
+ *
+ *   2. monthsLeft = nextMois - M
+ *      If nextMois < M (we wrapped to next year) OR
+ *         nextMois = M AND already paid → +12.
+ *      If nextMois = M AND not paid → 0.
+ *
+ *   3. cycleMonths = 12 (annual) / 6 (semiannual) / 3 (quarterly)
+ *
+ *   4. safeMonthsLeft is `monthsLeft` reduced into the cycle window.
+ *
+ *   5. epargneRequise = amount - (amount / cycleMonths × safeMonthsLeft)
+ */
+export function calculerEpargneRequiseParCharge(input: EpargneRequiseInput): Decimal {
+  const { charge: c, ref, payments } = input;
+
+  if (!isPeriodicFrequency(c.frequency)) {
+    // Monthly charges have no provisioning target.
+    return new Decimal(0);
+  }
+  if (!c.isActive || c.paymentMonths.length === 0) {
+    return new Decimal(0);
+  }
+
+  const sortedMonths = [...c.paymentMonths].sort((a, b) => a - b);
+  const isPayeCeMois = payments.get(paymentKey(c.id, ref.year, ref.month)) === true;
+
+  // Step 1 — locate nextMois.
+  let nextMois = sortedMonths.find((m) => m >= ref.month);
+  if (nextMois === ref.month && isPayeCeMois) {
+    // The reference month has been settled — skip to the following entry.
+    const after = sortedMonths.find((m) => m > ref.month);
+    nextMois = after ?? sortedMonths[0];
+  }
+  if (nextMois === undefined) {
+    nextMois = sortedMonths[0];
+  }
+  // We've guarded `length === 0` already; nextMois is now always defined.
+  const next = nextMois as number;
+
+  // Step 2 — monthsLeft with wrap-around.
+  let monthsLeft = next - ref.month;
+  if (next < ref.month || (next === ref.month && isPayeCeMois)) {
+    monthsLeft += 12;
+  }
+  if (next === ref.month && !isPayeCeMois) {
+    monthsLeft = 0;
+  }
+
+  // Step 3 — cycleMonths.
+  const cycleMonths = CYCLE_MONTHS[c.frequency];
+
+  // Step 4 — safeMonthsLeft, reduced into the cycle window.
+  let safeMonthsLeft: number;
+  if (monthsLeft === 0) {
+    safeMonthsLeft = 0;
+  } else if (monthsLeft % cycleMonths === 0) {
+    safeMonthsLeft = cycleMonths;
+  } else {
+    safeMonthsLeft = monthsLeft % cycleMonths;
+  }
+
+  // Step 5 — épargne requise.
+  return c.amount.minus(c.amount.dividedBy(cycleMonths).times(safeMonthsLeft));
+}
+
+export type SanteProvisionsInput = Readonly<{
+  charges: readonly CockpitCharge[];
+  payments: PaymentLedger;
+  soldeEpargneActuel: Decimal;
+  ref: ReferencePeriod;
+}>;
+
+export type SanteProvisionsDetailEntry = Readonly<{
+  chargeId: string;
+  epargneRequise: Decimal;
+}>;
+
+export type SanteProvisionsOutput = Readonly<{
+  totalEpargneTheorique: Decimal;
+  soldeEpargneActuel: Decimal;
+  /** > 0 when the user is under target; ≤ 0 when on track or over. */
+  deficitEpargne: Decimal;
+  /** deficitEpargne / 3 when positive, else 0. */
+  rattrapageMensuel: Decimal;
+  statut: 'a_jour' | 'deficit';
+  detailParCharge: readonly SanteProvisionsDetailEntry[];
+}>;
+
+/**
+ * Aggregate Santé des Provisions calculation (ADR-011).
+ * Returns both the global totals and the per-charge breakdown so the UI
+ * can display the full ledger without re-iterating.
+ */
+export function calculerSanteProvisions(input: SanteProvisionsInput): SanteProvisionsOutput {
+  const detailParCharge: SanteProvisionsDetailEntry[] = input.charges
+    .filter((c) => c.isActive && isPeriodicFrequency(c.frequency))
+    .map((c) => ({
+      chargeId: c.id,
+      epargneRequise: calculerEpargneRequiseParCharge({
+        charge: c,
+        ref: input.ref,
+        payments: input.payments,
+      }),
+    }));
+
+  const totalEpargneTheorique = detailParCharge.reduce(
+    (acc, d) => acc.plus(d.epargneRequise),
+    new Decimal(0),
+  );
+
+  const deficitEpargne = totalEpargneTheorique.minus(input.soldeEpargneActuel);
+  const rattrapageMensuel = deficitEpargne.gt(0)
+    ? deficitEpargne.dividedBy(RATTRAPAGE_MONTHS)
+    : new Decimal(0);
+
+  return {
+    totalEpargneTheorique,
+    soldeEpargneActuel: input.soldeEpargneActuel,
+    deficitEpargne,
+    rattrapageMensuel,
+    statut: deficitEpargne.gt(0) ? 'deficit' : 'a_jour',
+    detailParCharge,
+  };
+}

--- a/src/lib/domain/cockpit/simulateur.ts
+++ b/src/lib/domain/cockpit/simulateur.ts
@@ -1,0 +1,37 @@
+import Decimal from 'decimal.js';
+
+import { CYCLE_MONTHS, type CockpitCharge } from './types';
+
+export type SimulateurInput = Readonly<{
+  charge: CockpitCharge;
+  /** Hypothesis for the new amount of the charge (Decimal, not Number). */
+  nouveauPrix: Decimal;
+}>;
+
+export type SimulateurOutput = Readonly<{
+  /** charge.amount - nouveauPrix (positive = saving, negative = extra cost). */
+  difference: Decimal;
+  /** difference / cycleMonths — what the change is worth on a monthly basis. */
+  economieMensuelleLissee: Decimal;
+  /** difference × (12 / cycleMonths) — annualised projection. */
+  economieAnnuelle: Decimal;
+}>;
+
+/**
+ * Simulateur d'Action (spec §9). Given a charge and a hypothetical new
+ * price, computes the smoothed monthly impact.
+ *
+ *   difference            = ancien - nouveau
+ *   economieMensuelleLissee = difference / cycleMonths
+ *   economieAnnuelle      = difference × (12 / cycleMonths)
+ *
+ * No I/O: the UI is responsible for actually mutating the charge in DB
+ * (Server Action `updateCharge`, PR-D8).
+ */
+export function simulerEconomie(input: SimulateurInput): SimulateurOutput {
+  const cycleMonths = CYCLE_MONTHS[input.charge.frequency];
+  const difference = input.charge.amount.minus(input.nouveauPrix);
+  const economieMensuelleLissee = difference.dividedBy(cycleMonths);
+  const economieAnnuelle = difference.times(new Decimal(12).dividedBy(cycleMonths));
+  return { difference, economieMensuelleLissee, economieAnnuelle };
+}

--- a/src/lib/domain/cockpit/types.ts
+++ b/src/lib/domain/cockpit/types.ts
@@ -1,0 +1,100 @@
+import Decimal from 'decimal.js';
+
+/**
+ * Cockpit-flavoured frequency. Mirrors `ChargeFrequency` from `domain/types`
+ * but is locally re-declared so this module stays self-contained.
+ */
+export type CockpitFrequency = 'monthly' | 'quarterly' | 'semiannual' | 'annual';
+
+/**
+ * Number of months a charge spans for smoothing purposes.
+ *   monthly    → 1  (no smoothing — already monthly)
+ *   quarterly  → 3
+ *   semiannual → 6  (extension over the original IronBudget spec — Ankora
+ *                    has supported this frequency since the initial schema
+ *                    and the cockpit must handle it)
+ *   annual     → 12
+ */
+export const CYCLE_MONTHS: Record<CockpitFrequency, number> = Object.freeze({
+  monthly: 1,
+  quarterly: 3,
+  semiannual: 6,
+  annual: 12,
+});
+
+/**
+ * Account type sémantique adopté par ADR-008.
+ *  - income_bills : compte courant qui reçoit le salaire et paye les charges fixes mensuelles
+ *  - provisions   : compte épargne qui lisse les charges périodiques
+ *  - daily_card   : carte quotidienne (courses / essence / loisirs) avec plafond mensuel
+ */
+export type AccountType = 'income_bills' | 'provisions' | 'daily_card';
+
+/**
+ * Cockpit-shaped charge. The DB carries this through `payment_months[]`
+ * (the months the charge falls due) and `payment_day` (day of month).
+ *
+ * `paymentMonths` MUST be sorted ascending and contain values 1..12.
+ * Empty arrays are not allowed (a charge with no due months is meaningless).
+ */
+export type CockpitCharge = Readonly<{
+  id: string;
+  label: string;
+  /** Decimal — not a Number — so that 53 / 12 stays exact. */
+  amount: Decimal;
+  frequency: CockpitFrequency;
+  /** Sorted ascending, all values 1..12, length ≥ 1. */
+  paymentMonths: readonly number[];
+  /** 1..31 — used by the bell notifications, not by the smoothing math. */
+  paymentDay: number;
+  /** Whether this charge is enabled. Inactive charges are excluded from cockpit math. */
+  isActive: boolean;
+}>;
+
+/**
+ * Read-only map of "has this charge been paid for that period?".
+ * Key format: `${chargeId}-${year}-${month1to12}` (no zero-padding).
+ *
+ * Implemented as a plain Map so callers can construct it from the DB
+ * `charge_payments` rows without intermediate allocations:
+ *
+ *   const payments = new Map(rows.map(r => [`${r.charge_id}-${r.period_year}-${r.period_month}`, true]));
+ */
+export type PaymentLedger = ReadonlyMap<string, boolean>;
+
+/**
+ * Builds the canonical key used by `PaymentLedger`. Centralised here so
+ * producers and consumers can't drift on the format.
+ */
+export function paymentKey(chargeId: string, year: number, month: number): string {
+  return `${chargeId}-${year}-${month}`;
+}
+
+/**
+ * Reference period for cockpit calculations. The cockpit always projects
+ * around a single (year, month) — typically the user's selected month
+ * via the `?month=YYYY-MM` URL parameter (PR-D2).
+ */
+export type ReferencePeriod = Readonly<{
+  year: number;
+  month: number; // 1..12
+}>;
+
+export function isPeriodicFrequency(f: CockpitFrequency): boolean {
+  return f !== 'monthly';
+}
+
+/**
+ * Filters a list of charges down to the periodic ones (everything except
+ * `monthly`). Centralised because the cockpit makes this distinction in
+ * many places and a stray inclusion of monthlies in "provisions" math
+ * would be a hard-to-spot bug.
+ */
+export function periodicCharges(charges: readonly CockpitCharge[]): readonly CockpitCharge[] {
+  return charges.filter((c) => c.isActive && isPeriodicFrequency(c.frequency));
+}
+
+/** Same shape, restricted to monthly + active. */
+export function monthlyCharges(charges: readonly CockpitCharge[]): readonly CockpitCharge[] {
+  return charges.filter((c) => c.isActive && c.frequency === 'monthly');
+}

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -35,21 +35,27 @@ export type Database = {
     Tables: {
       accounts: {
         Row: {
+          account_type: string;
           balance: number;
+          display_name: string;
           kind: string;
           label: string;
           updated_at: string;
           workspace_id: string;
         };
         Insert: {
+          account_type: string;
           balance?: number;
+          display_name: string;
           kind: string;
           label: string;
           updated_at?: string;
           workspace_id: string;
         };
         Update: {
+          account_type?: string;
           balance?: number;
+          display_name?: string;
           kind?: string;
           label?: string;
           updated_at?: string;
@@ -116,30 +122,36 @@ export type Database = {
       categories: {
         Row: {
           color: string | null;
+          color_token: string;
           created_at: string;
           created_by: string;
           icon: string | null;
           id: string;
+          is_system: boolean;
           kind: string;
           name: string;
           workspace_id: string;
         };
         Insert: {
           color?: string | null;
+          color_token?: string;
           created_at?: string;
           created_by: string;
           icon?: string | null;
           id?: string;
+          is_system?: boolean;
           kind: string;
           name: string;
           workspace_id: string;
         };
         Update: {
           color?: string | null;
+          color_token?: string;
           created_at?: string;
           created_by?: string;
           icon?: string | null;
           id?: string;
+          is_system?: boolean;
           kind?: string;
           name?: string;
           workspace_id?: string;
@@ -161,6 +173,70 @@ export type Database = {
           },
         ];
       };
+      charge_payments: {
+        Row: {
+          bucket_id: string | null;
+          charge_id: string;
+          created_at: string;
+          created_by: string;
+          id: string;
+          note: string | null;
+          paid_amount: number;
+          paid_at: string;
+          period_month: number;
+          period_year: number;
+          workspace_id: string;
+        };
+        Insert: {
+          bucket_id?: string | null;
+          charge_id: string;
+          created_at?: string;
+          created_by: string;
+          id?: string;
+          note?: string | null;
+          paid_amount: number;
+          paid_at?: string;
+          period_month: number;
+          period_year: number;
+          workspace_id: string;
+        };
+        Update: {
+          bucket_id?: string | null;
+          charge_id?: string;
+          created_at?: string;
+          created_by?: string;
+          id?: string;
+          note?: string | null;
+          paid_amount?: number;
+          paid_at?: string;
+          period_month?: number;
+          period_year?: number;
+          workspace_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'charge_payments_charge_id_fkey';
+            columns: ['charge_id'];
+            isOneToOne: false;
+            referencedRelation: 'charges';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'charge_payments_created_by_fkey';
+            columns: ['created_by'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'charge_payments_workspace_id_fkey';
+            columns: ['workspace_id'];
+            isOneToOne: false;
+            referencedRelation: 'workspaces';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       charges: {
         Row: {
           amount: number;
@@ -174,6 +250,9 @@ export type Database = {
           label: string;
           notes: string | null;
           paid_from: string;
+          payment_day: number;
+          payment_months: number[];
+          sort_order: number;
           updated_at: string;
           workspace_id: string;
         };
@@ -189,6 +268,9 @@ export type Database = {
           label: string;
           notes?: string | null;
           paid_from?: string;
+          payment_day?: number;
+          payment_months?: number[];
+          sort_order?: number;
           updated_at?: string;
           workspace_id: string;
         };
@@ -204,6 +286,9 @@ export type Database = {
           label?: string;
           notes?: string | null;
           paid_from?: string;
+          payment_day?: number;
+          payment_months?: number[];
+          sort_order?: number;
           updated_at?: string;
           workspace_id?: string;
         };

--- a/supabase/migrations/20260503000001_pr_d1_accounts_typed.sql
+++ b/supabase/migrations/20260503000001_pr_d1_accounts_typed.sql
@@ -1,0 +1,86 @@
+-- =========================================================================
+-- PR-D1 (Voie D Foundations) — Migration 1/4
+-- accounts: account_type ENUM + display_name (additif)
+-- =========================================================================
+-- Cf. ADR-008 + amendement Cowork 2026-05-03 (mismatch resolution).
+--
+-- Decision: ADDITIVE migration. We keep the existing `kind` ('principal',
+-- 'vie_courante', 'epargne') + `label` columns intact during PR-D1 to avoid
+-- breaking `getWorkspaceSnapshot`, `accounts.ts` action, `AccountsClient.tsx`,
+-- `account.ts` schema and `AccountKind` domain type.
+--
+-- The new columns (`account_type`, `display_name`) carry the canonical
+-- IronBudget semantics from spec `dashboard-cockpit-vraie-vision-2026-05-03.md`:
+--   principal    → income_bills   (where salary lands, fixed monthly bills)
+--   vie_courante → daily_card     (daily-spending pot)
+--   epargne      → provisions     (smoothing buffer for periodic bills)
+--
+-- PR-D2 will deprecate `kind`/`label` once UI consumers migrate.
+-- =========================================================================
+
+-- -------------------------------------------------------------------------
+-- 1. Add new columns (nullable for the backfill window)
+-- -------------------------------------------------------------------------
+alter table public.accounts
+  add column if not exists account_type text
+    check (account_type in ('income_bills', 'provisions', 'daily_card')),
+  add column if not exists display_name text
+    check (display_name is null or char_length(display_name) between 1 and 50);
+
+-- -------------------------------------------------------------------------
+-- 2. Backfill from existing kind/label
+-- -------------------------------------------------------------------------
+update public.accounts
+   set account_type = case kind
+                        when 'principal'    then 'income_bills'
+                        when 'vie_courante' then 'daily_card'
+                        when 'epargne'      then 'provisions'
+                      end,
+       display_name = label
+ where account_type is null
+    or display_name is null;
+
+-- -------------------------------------------------------------------------
+-- 3. Enforce NOT NULL once the backfill is complete
+-- -------------------------------------------------------------------------
+alter table public.accounts
+  alter column account_type set not null,
+  alter column display_name set not null;
+
+-- -------------------------------------------------------------------------
+-- 4. UNIQUE per (workspace, account_type) — invariant: at most one
+--    income_bills / provisions / daily_card per workspace.
+--    The existing PK (workspace_id, kind) already enforces unicity per
+--    `kind`; this new index enforces the same on the canonical column.
+-- -------------------------------------------------------------------------
+create unique index if not exists accounts_workspace_account_type_unique
+  on public.accounts (workspace_id, account_type);
+
+-- -------------------------------------------------------------------------
+-- 5. seed_default_accounts: now writes both legacy and canonical columns.
+--    Kept SECURITY DEFINER so handle_new_user can call it during signup
+--    before the user has a session.
+-- -------------------------------------------------------------------------
+create or replace function public.seed_default_accounts(ws_id uuid)
+returns void language sql security definer set search_path = public as $$
+  insert into public.accounts (workspace_id, kind, label, account_type, display_name)
+  values
+    (ws_id, 'principal',    'Compte Principal',     'income_bills', 'Compte Principal'),
+    (ws_id, 'vie_courante', 'Vie Courante',         'daily_card',   'Carte Quotidien'),
+    (ws_id, 'epargne',      'Épargne & Provisions', 'provisions',   'Compte Épargne')
+  on conflict (workspace_id, kind) do nothing;
+$$;
+
+revoke execute on function public.seed_default_accounts(uuid) from public;
+
+-- -------------------------------------------------------------------------
+-- 6. Documentation comments
+-- -------------------------------------------------------------------------
+comment on column public.accounts.account_type is
+  'Canonical semantic type per ADR-008. Drives the cockpit logic (Assistant Virements, Santé Provisions). Never user-editable.';
+comment on column public.accounts.display_name is
+  'User-defined display name (PR-D2 will expose inline rename). Initially seeded from i18n defaults; users can rename to match their bank labels (e.g. "Belfius", "Revolut").';
+comment on column public.accounts.kind is
+  'DEPRECATED — kept during PR-D1 to avoid breaking legacy reads. Will be dropped in PR-D2 once UI consumers migrate to account_type.';
+comment on column public.accounts.label is
+  'DEPRECATED — kept during PR-D1 to avoid breaking legacy reads. Will be dropped in PR-D2 once UI consumers migrate to display_name.';

--- a/supabase/migrations/20260503000002_pr_d1_charges_enrichments.sql
+++ b/supabase/migrations/20260503000002_pr_d1_charges_enrichments.sql
@@ -1,0 +1,76 @@
+-- =========================================================================
+-- PR-D1 (Voie D Foundations) — Migration 2/4
+-- charges: payment_months[], payment_day, sort_order
+-- =========================================================================
+-- Cf. spec `dashboard-cockpit-vraie-vision-2026-05-03.md` §"Data models cibles".
+--
+-- Adds the schedule precision required by the cockpit:
+--   * payment_months  — multi-month schedule (e.g. trimestrielle [3, 6, 9, 12])
+--   * payment_day     — exact day of the month (1-31) for the bell notifications
+--   * sort_order      — user-customisable order (drag & drop in PR-D4)
+--
+-- `category_id` already exists from the initial schema (no-op here).
+-- `due_month` is preserved as-is during PR-D1 (legacy reads in
+-- getWorkspaceSnapshot / charges actions). PR-D4 will deprecate it once
+-- the UI exclusively reads `payment_months`.
+-- =========================================================================
+
+-- -------------------------------------------------------------------------
+-- 1. New columns
+-- -------------------------------------------------------------------------
+alter table public.charges
+  add column if not exists payment_months smallint[] not null
+    default array[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]::smallint[],
+  add column if not exists payment_day smallint not null default 1
+    check (payment_day between 1 and 31),
+  add column if not exists sort_order integer not null default 0;
+
+-- -------------------------------------------------------------------------
+-- 2. Constraint: every entry of payment_months must be in 1..12
+--    Postgres has no native check on array elements, so we use a CHECK
+--    expression that asserts MIN >= 1 AND MAX <= 12 over the array.
+-- -------------------------------------------------------------------------
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'charges_payment_months_range'
+  ) then
+    alter table public.charges
+      add constraint charges_payment_months_range
+      check (
+        array_length(payment_months, 1) is null
+        or (
+          array_length(payment_months, 1) between 1 and 12
+          and (select bool_and(m between 1 and 12) from unnest(payment_months) as m)
+        )
+      );
+  end if;
+end $$;
+
+-- -------------------------------------------------------------------------
+-- 3. Backfill payment_months from the existing due_month for periodic
+--    charges (monthly keep their default of all 12 months).
+-- -------------------------------------------------------------------------
+update public.charges
+   set payment_months = array[due_month]::smallint[]
+ where frequency in ('quarterly', 'semiannual', 'annual')
+   and payment_months = array[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]::smallint[];
+
+-- -------------------------------------------------------------------------
+-- 4. Index on workspace_id + sort_order to speed up the ordered list query
+-- -------------------------------------------------------------------------
+create index if not exists charges_workspace_sort_idx
+  on public.charges (workspace_id, sort_order, created_at);
+
+-- -------------------------------------------------------------------------
+-- 5. Documentation
+-- -------------------------------------------------------------------------
+comment on column public.charges.payment_months is
+  'Months (1-12) when this charge is due. Monthly charges default to all 12; periodic charges to a subset (e.g. trimestrielle [3,6,9,12]). Drives the Assistant Virements + Prévisions 6 mois algorithms.';
+comment on column public.charges.payment_day is
+  'Day of the month (1-31) when this charge falls due. Used by the bell notifications (J-3, J-1, en retard).';
+comment on column public.charges.sort_order is
+  'User-customisable order in the "À payer en {mois}" list (PR-D4 drag & drop). Default 0 = sort by created_at.';
+comment on column public.charges.due_month is
+  'DEPRECATED — kept during PR-D1 to avoid breaking legacy reads. Will be dropped in PR-D4 once the UI exclusively reads payment_months.';

--- a/supabase/migrations/20260503000003_pr_d1_categories_enrichments.sql
+++ b/supabase/migrations/20260503000003_pr_d1_categories_enrichments.sql
@@ -1,0 +1,106 @@
+-- =========================================================================
+-- PR-D1 (Voie D Foundations) — Migration 3/4
+-- categories: color_token + is_system + seed 8 default categories
+-- =========================================================================
+-- Cf. spec `dashboard-cockpit-vraie-vision-2026-05-03.md` §"Data models cibles".
+--
+-- The existing `categories` table (initial schema) already carries `name`,
+-- `color` (#hex) and `kind` ('fixed' | 'variable' | 'income'). We enrich it
+-- additively (per @cowork validation 2026-05-03) without renaming columns:
+--   * color_token  — Tailwind palette token (drives badge color in the UI)
+--   * is_system    — protected categories that cannot be deleted (e.g. "Autres")
+--
+-- The 8 default categories are seeded automatically at workspace creation
+-- via handle_new_user(). They are language-neutral by default (FR labels);
+-- the UI can override visually via color_token.
+-- =========================================================================
+
+-- -------------------------------------------------------------------------
+-- 1. New columns
+-- -------------------------------------------------------------------------
+alter table public.categories
+  add column if not exists color_token text not null default 'zinc'
+    check (color_token in ('blue', 'pink', 'rose', 'emerald', 'purple', 'amber', 'cyan', 'zinc')),
+  add column if not exists is_system boolean not null default false;
+
+-- -------------------------------------------------------------------------
+-- 2. seed_default_categories(workspace_id, owner_id)
+--    SECURITY DEFINER so handle_new_user can call it during signup
+--    before the user has a session, and so it bypasses the
+--    `categories_editor_write` RLS policy that requires
+--    `created_by = auth.uid()`.
+-- -------------------------------------------------------------------------
+create or replace function public.seed_default_categories(ws_id uuid, owner_id uuid)
+returns void language plpgsql security definer set search_path = public as $$
+begin
+  -- Idempotent: if any category exists for this workspace, do nothing.
+  -- Mostly relevant for the backfill block at the end of this migration.
+  if exists (select 1 from public.categories where workspace_id = ws_id) then
+    return;
+  end if;
+
+  insert into public.categories
+    (workspace_id, created_by, name, color_token, kind, is_system)
+  values
+    (ws_id, owner_id, 'Logement',     'blue',    'variable', false),
+    (ws_id, owner_id, 'Famille',      'pink',    'variable', false),
+    (ws_id, owner_id, 'Taxes',        'rose',    'fixed',    false),
+    (ws_id, owner_id, 'Santé',        'emerald', 'variable', false),
+    (ws_id, owner_id, 'Abonnements',  'purple',  'fixed',    false),
+    (ws_id, owner_id, 'Assurances',   'amber',   'fixed',    false),
+    (ws_id, owner_id, 'Transport',    'cyan',    'variable', false),
+    (ws_id, owner_id, 'Autres',       'zinc',    'variable', true);
+end $$;
+
+revoke execute on function public.seed_default_categories(uuid, uuid) from public;
+
+-- -------------------------------------------------------------------------
+-- 3. handle_new_user: also seed the 8 default categories at signup.
+--    Re-create the trigger function entirely (PostgreSQL doesn't support
+--    appending to a function body).
+-- -------------------------------------------------------------------------
+create or replace function public.handle_new_user()
+returns trigger language plpgsql security definer set search_path = public as $$
+declare
+  new_workspace_id uuid;
+begin
+  insert into public.users (id, email, display_name)
+  values (new.id, new.email, split_part(new.email, '@', 1));
+
+  insert into public.workspaces (owner_id, name)
+  values (new.id, 'Mon espace')
+  returning id into new_workspace_id;
+
+  insert into public.workspace_members (workspace_id, user_id, role)
+  values (new_workspace_id, new.id, 'owner');
+
+  insert into public.workspace_settings (workspace_id) values (new_workspace_id);
+
+  perform public.seed_default_accounts(new_workspace_id);
+  perform public.seed_default_categories(new_workspace_id, new.id);
+
+  return new;
+end $$;
+
+-- -------------------------------------------------------------------------
+-- 4. Backfill existing workspaces (idempotent — guarded by the early-return
+--    inside seed_default_categories).
+-- -------------------------------------------------------------------------
+do $$
+declare
+  ws record;
+begin
+  for ws in select id, owner_id from public.workspaces loop
+    perform public.seed_default_categories(ws.id, ws.owner_id);
+  end loop;
+end $$;
+
+-- -------------------------------------------------------------------------
+-- 5. Documentation
+-- -------------------------------------------------------------------------
+comment on column public.categories.color_token is
+  'Tailwind palette token (blue/pink/rose/emerald/purple/amber/cyan/zinc). Drives the badge color in the cockpit charge list.';
+comment on column public.categories.is_system is
+  'Protected category that cannot be deleted by the user (e.g. "Autres"). Enforced application-side; UI hides the delete button.';
+comment on function public.seed_default_categories(uuid, uuid) is
+  'Inserts the 8 default categories at workspace creation. Idempotent: no-op if any category already exists for the workspace.';

--- a/supabase/migrations/20260503000004_pr_d1_charge_payments.sql
+++ b/supabase/migrations/20260503000004_pr_d1_charge_payments.sql
@@ -1,0 +1,69 @@
+-- =========================================================================
+-- PR-D1 (Voie D Foundations) — Migration 4/4
+-- charge_payments: per-period payment tracking (toggle paye)
+-- =========================================================================
+-- Cf. ADR-007 (consolidation placeholder) + ADR-011 + spec
+-- `dashboard-cockpit-vraie-vision-2026-05-03.md` §"Data models cibles".
+--
+-- Each row records that a specific charge has been settled for a specific
+-- (year, month) period. The Santé Provisions algorithm (ADR-011) consults
+-- this table to know whether a periodic charge due "ce mois" has already
+-- been paid (which advances the wrap-around to the next cycle).
+--
+-- The UNIQUE (charge_id, period_year, period_month) constraint enforces
+-- one payment per period per charge — no double-counting.
+--
+-- `bucket_id` is reserved nullable for ADR-015 (savings_buckets, PR-D5+);
+-- it doesn't reference a real table yet — added as plain UUID for forward
+-- compatibility, with no FK so this migration stays self-contained.
+-- =========================================================================
+
+-- -------------------------------------------------------------------------
+-- 1. Table
+-- -------------------------------------------------------------------------
+create table if not exists public.charge_payments (
+  id            uuid primary key default uuid_generate_v4(),
+  charge_id     uuid not null references public.charges(id) on delete cascade,
+  workspace_id  uuid not null references public.workspaces(id) on delete cascade,
+  period_year   smallint not null check (period_year between 2000 and 2100),
+  period_month  smallint not null check (period_month between 1 and 12),
+  paid_at       timestamptz not null default now(),
+  paid_amount   numeric(12, 2) not null check (paid_amount >= 0),
+  bucket_id     uuid,
+  note          text check (note is null or char_length(note) <= 500),
+  created_by    uuid not null references public.users(id) on delete cascade,
+  created_at    timestamptz not null default now(),
+  unique (charge_id, period_year, period_month)
+);
+
+-- -------------------------------------------------------------------------
+-- 2. Indexes
+-- -------------------------------------------------------------------------
+create index if not exists charge_payments_period_idx
+  on public.charge_payments (workspace_id, period_year, period_month);
+
+create index if not exists charge_payments_charge_idx
+  on public.charge_payments (charge_id, period_year desc, period_month desc);
+
+-- -------------------------------------------------------------------------
+-- 3. Row-Level Security
+-- -------------------------------------------------------------------------
+alter table public.charge_payments enable row level security;
+alter table public.charge_payments force  row level security;
+
+create policy "charge_payments_member_select" on public.charge_payments
+  for select using (public.is_workspace_member(workspace_id));
+
+create policy "charge_payments_editor_write" on public.charge_payments
+  for all using (public.is_workspace_editor(workspace_id))
+  with check (public.is_workspace_editor(workspace_id) and created_by = auth.uid());
+
+-- -------------------------------------------------------------------------
+-- 4. Documentation
+-- -------------------------------------------------------------------------
+comment on table public.charge_payments is
+  'Per-period payment records for charges. UNIQUE on (charge_id, period_year, period_month) prevents double-counting. Drives the Santé Provisions algorithm (ADR-011) and the toggle paye UX (PR-D4).';
+comment on column public.charge_payments.bucket_id is
+  'Forward-compat reserved column for ADR-015 (savings_buckets). Plain UUID, no FK — will become FK to savings_buckets in PR-D5+.';
+comment on column public.charge_payments.paid_amount is
+  'Actual amount settled (may differ from charge.amount if user paid more/less). Defaults to charge.amount in the application layer.';


### PR DESCRIPTION
## Pourquoi

Première PR de la **Voie D** (cockpit cible — cf. spec canonique [`dashboard-cockpit-vraie-vision-2026-05-03.md`](https://github.com/thierryvm/ankora/blob/main/docs/) dans le vault Athenaeum). Pose la fondation data + algorithmique nécessaire à tout le reste de la Voie D (PR-D2 à PR-D8). Cette PR ne touche aucune UI : c'est volontaire et inscrit dans le scope.

ADRs porteurs : [ADR-007](docs/adr/ADR-007-payment-tracking-consolidation.md) (placeholder), [ADR-008](docs/adr/ADR-008-account-naming-and-typing.md), [ADR-009](docs/adr/ADR-009-capacite-epargne-reelle.md), [ADR-010](docs/adr/ADR-010-live-decrement-quotidien.md), [ADR-011](docs/adr/ADR-011-detection-deficit-plan-rattrapage.md), [ADR-012](docs/adr/ADR-012-assistant-virements.md).

## Quoi

### 1. Migrations Supabase (4 atomiques, additives, zéro casse)

| Migration | Apport |
|---|---|
| `20260503000001_pr_d1_accounts_typed.sql` | `accounts.account_type` ENUM (`income_bills`/`provisions`/`daily_card`) + `display_name`. Mapping backfill `principal→income_bills`, `vie_courante→daily_card`, `epargne→provisions`. UNIQUE `(workspace_id, account_type)`. `seed_default_accounts` updated. |
| `20260503000002_pr_d1_charges_enrichments.sql` | `charges.payment_months SMALLINT[]` + `payment_day SMALLINT` + `sort_order INTEGER`. Backfill `payment_months` depuis `due_month` pour les charges périodiques. |
| `20260503000003_pr_d1_categories_enrichments.sql` | `categories.color_token` (Tailwind palette) + `is_system`. Nouvelle fonction `seed_default_categories(ws_id, owner_id)` qui insère 8 catégories par défaut au signup (Logement, Famille, Taxes, Santé, Abonnements, Assurances, Transport, Autres). Hook ajouté à `handle_new_user`. |
| `20260503000004_pr_d1_charge_payments.sql` | Nouvelle table `charge_payments` avec UNIQUE `(charge_id, period_year, period_month)` + RLS member/editor + index période. |

**Pas de drop de colonne** : `kind` / `label` / `due_month` restent en place pour ne pas casser `getWorkspaceSnapshot`, `accounts.ts` action, `AccountsClient.tsx`. PR-D2 dépréciera après migration UI.

### 2. Module domain pur `src/lib/domain/cockpit/` (7 modules)

Tous purs, Decimal.js, zéro dépendance DB / Next.js. Réutilisables côté Server Component + Client Component.

| Module | Fonction principale | ADR |
|---|---|---|
| `effort-financier-lisse.ts` | `effortFinancierLisse()` = monthly + provisions lissées | 009 |
| `capacite-epargne-reelle.ts` | `capaciteEpargneReelle()` — KPI hero | 009 |
| `assistant-virements.ts` | `calculerAssistantVirements()` — direction + détail provisions | 012 |
| `sante-provisions.ts` | `calculerSanteProvisions()` + algorithme wrap-around par charge + `rattrapageMensuel` | 011 |
| `notifications.ts` | `genererNotifications()` — bell + badge, current-month-only | — |
| `previsions.ts` | `genererPrevisions()` — 6 mois bar chart data | — |
| `simulateur.ts` | `simulerEconomie()` — économie lissée selon fréquence | — |

**Extension semiannual** : tous les modules gèrent `cycleMonths = 6` (le repo Ankora supporte 4 fréquences alors que les ADRs n'en évoquaient que 3).

### 3. Tests Vitest (108 cas, coverage 99.6% lines / 97.71% branches sur cockpit)

Co-localisés dans `src/lib/domain/cockpit/__tests__/`. Couvre :
- Cas réel @thierry (Dashlane avril 53€ → 6€ à virer, conforme ADR-012 §exemple pédagogique)
- ≥3 cas semiannual par algorithme (provision/virements/santé/wrap-around)
- Wrap-around décembre→janvier pour annual + quarterly + semiannual
- Statut `a_jour` / `deficit`, rattrapage `deficit/3` Decimal-safe
- Notifications `transferToSavings`, `transferFromSavings`, `chargeOverdue`, `chargeDueSoon`
- Précision Decimal sur les divisions récurrentes (53/12 stable sur 12 itérations)

### 4. i18n (5 locales, parité)

Clés ajoutées en parité 5/5 :
- `app.accounts.types.{income_bills,provisions,daily_card}`
- `app.accounts.defaults.{income_bills,provisions,daily_card}`
- `app.cockpit.capaciteEpargneReelle.{title,messagePositive,messageNegative,tooltip}`
- `app.cockpit.santeProvisions.{title,cibleTheorique,soldeActuel,statutAJour,deficit,rattrapageDescription,tooltip}`
- `app.cockpit.virements.{title,provisionsMensuelles,facturesAnnuelles,aVirer,aRecuperer,aucun,descriptionAVirer,descriptionDepuis,detailHeader}`
- `app.cockpit.notifications.{transferToSavings,transferFromSavings,chargeOverdue,chargeDueSoon}`

**FR-BE et EN sont rédigés** ; **NL-BE / DE-DE / ES-ES sont stubbés en EN** (acceptable per scope, à traduire post-launch via skill `i18n-translator` quand v1.0 multi-langue arrivera).

### 5. Mise à jour `src/lib/supabase/types.ts`

Édition manuelle pour refléter les 4 migrations (le repo n'est pas linké à Supabase localement). Le CI peut regénérer via `npm run supabase:types` après deploy.

## Hors scope (strictement respecté)

- Aucun changement de `page.tsx` Dashboard
- Aucun nouveau composant UI client
- Aucune Server Action (sauf `renameAccount` déjà existante, **non touchée** ici)
- Aucune modification de `messages` déjà existantes (uniquement ajouts)
- Aucun refactor de `getWorkspaceSnapshot`

## Décisions architecturales notables (escaladées et validées avant code)

3 mismatchs détectés entre les ADRs et l'état actuel du repo, escaladés à @cowork **avant** d'écrire la moindre ligne. Validés GO :

1. **`accounts` déjà typée** (`kind` + `label` existaient depuis la migration `20260417000004_three_accounts_model.sql`). Décision **Option A** : ajout additif `account_type` + `display_name`. Dette tech à nettoyer en PR-D2.
2. **`categories` déjà existante** (avec `name` + `color #hex` + `kind` + `created_by NOT NULL`). Décision **Option A** : enrichissement additif `color_token` + `is_system`, pas de rename.
3. **`ChargeFrequency` a 4 valeurs** (les ADRs n'en mentionnaient que 3). Décision : étendre tous les algos cockpit pour gérer `semiannual` (`cycleMonths = 6`) + ≥3 cas Vitest par algorithme.

## Quality gates

- `npm run lint` → 0 erreur (3 warnings préexistants hors scope PR-D1)
- `npm run lint:use-server` → ✓ All "use server" files contain only async exports
- `npm run typecheck` → 0 erreur
- `npm run test` → 540/540 pass (108 nouveaux cockpit + 432 existants)
- `npm run test:coverage` → cockpit 99.6% lines / 97.71% branches
- `npm run build` → ✓ Compiled successfully

## Amendements ADR à prévoir post-merge (non bloquants)

ADR-008/009/010/011/012 ont été rédigés sans connaître l'état post `20260417000004_three_accounts_model.sql`. À amender dans une PR docs séparée :
- ADR-008 : ajouter section "Migration depuis `kind`/`label` existants"
- ADR-008 : noter que la table `categories` existait déjà (enrichissement additif, pas création)
- ADR-009/011/012 : noter que `ChargeFrequency` a 4 valeurs (incl. `semiannual`)

## Test plan (CI + reviewer)

- [x] Lint + typecheck + tests verts (en local)
- [x] Build prod réussi
- [ ] CI Lint + Typecheck + Unit Tests
- [ ] CI Security audit
- [ ] CI Playwright E2E
- [ ] CI Lighthouse CI (à monitorer — note : un échec récent a été signalé sur main, à vérifier si ce PR le résout / l'aggrave)
- [ ] Sourcery silent on dernier commit
- [ ] No conflict with main + mergeStateStatus CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)