### PR TITLE
feat(cockpit): PR-D2 — 3 typed account cards + inline rename

### DIFF
--- a/e2e/dashboard-account-rename.spec.ts
+++ b/e2e/dashboard-account-rename.spec.ts
@@ -1,0 +1,128 @@
+import { test, expect } from './helpers/test';
+import { adminClientOrNull, deleteSeededUser, seedOnboardedUser } from './helpers/seed';
+
+const admin = adminClientOrNull();
+
+test.describe('Dashboard — typed account cards + inline rename (PR-D2)', () => {
+  test.skip(!admin, 'Needs real Supabase (NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY).');
+
+  test('user clicks the Compte Principal title, types Belfius, presses Enter — value persists', async ({
+    page,
+  }) => {
+    if (!admin) return;
+
+    const user = await seedOnboardedUser(admin, [
+      {
+        label: 'Loyer',
+        amount: 800,
+        frequency: 'monthly',
+        dueMonth: 1,
+        paidFrom: 'principal',
+      },
+    ]);
+
+    try {
+      await page.goto('/login');
+      await page.getByLabel('Email').fill(user.email);
+      await page.getByLabel('Mot de passe').fill(user.password);
+      await page.getByRole('button', { name: /^se connecter$/i }).click();
+      await page.waitForURL(/\/app\b/, { timeout: 15_000 });
+
+      // Locate the income_bills card via the data attribute that AccountCard exposes.
+      const card = page.locator('[data-account-type="income_bills"]');
+      await expect(card).toBeVisible();
+
+      // Default name comes from the i18n default (Compte Principal in fr-BE).
+      await expect(card.getByRole('button', { name: /Renommer le compte/i })).toContainText(
+        'Compte Principal',
+      );
+
+      // Click the title → input appears prefilled.
+      await card.getByRole('button', { name: /Renommer le compte/i }).click();
+      const input = card.getByRole('textbox');
+      await expect(input).toBeFocused();
+      await expect(input).toHaveValue('Compte Principal');
+
+      // Replace the value and submit with Enter.
+      await input.fill('Belfius');
+      await input.press('Enter');
+
+      // Optimistic update + revalidatePath: the title is back as a button with the new value.
+      await expect(
+        card.getByRole('button', { name: /Renommer le compte « Belfius »/i }),
+      ).toBeVisible();
+
+      // Refresh and assert persistence.
+      await page.reload();
+      await expect(
+        page.locator('[data-account-type="income_bills"]').getByRole('button', {
+          name: /Renommer le compte « Belfius »/i,
+        }),
+      ).toBeVisible();
+
+      // Confirm DB state via admin client (defensive).
+      const { data: row, error } = await admin
+        .from('accounts')
+        .select('display_name, account_type')
+        .eq('workspace_id', user.workspaceId)
+        .eq('account_type', 'income_bills')
+        .single();
+      expect(error).toBeNull();
+      expect(row?.display_name).toBe('Belfius');
+    } finally {
+      await deleteSeededUser(admin, user.userId);
+    }
+  });
+
+  test('Esc cancels the rename without persisting', async ({ page }) => {
+    if (!admin) return;
+
+    const user = await seedOnboardedUser(admin, []);
+
+    try {
+      await page.goto('/login');
+      await page.getByLabel('Email').fill(user.email);
+      await page.getByLabel('Mot de passe').fill(user.password);
+      await page.getByRole('button', { name: /^se connecter$/i }).click();
+      await page.waitForURL(/\/app\b/, { timeout: 15_000 });
+
+      // Without charges the dashboard renders an empty-state card and not the
+      // typed account cards. Provide one so the cards render.
+      await admin.from('charges').insert({
+        workspace_id: user.workspaceId,
+        created_by: user.userId,
+        label: 'Test',
+        amount: 100,
+        frequency: 'monthly',
+        due_month: 1,
+        is_active: true,
+        paid_from: 'principal',
+      });
+      await page.reload();
+
+      const card = page.locator('[data-account-type="provisions"]');
+      await expect(card).toBeVisible();
+
+      await card.getByRole('button', { name: /Renommer le compte/i }).click();
+      const input = card.getByRole('textbox');
+      await input.fill('Should not persist');
+      await input.press('Escape');
+
+      // Back to button with the original (i18n default) name.
+      await expect(
+        card.getByRole('button', { name: /Renommer le compte « Compte Épargne »/i }),
+      ).toBeVisible();
+
+      // DB unchanged.
+      const { data: row } = await admin
+        .from('accounts')
+        .select('display_name')
+        .eq('workspace_id', user.workspaceId)
+        .eq('account_type', 'provisions')
+        .single();
+      expect(row?.display_name).toBe('Compte Épargne');
+    } finally {
+      await deleteSeededUser(admin, user.userId);
+    }
+  });
+});

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -693,6 +693,12 @@
         "income_bills": "Main Account",
         "provisions": "Savings Account",
         "daily_card": "Daily Card"
+      },
+      "rename": {
+        "placeholder": "E.g. Belfius, Revolut, ING…",
+        "inputLabel": "New account name",
+        "editLabel": "Rename account \"{name}\"",
+        "errorInvalid": "Invalid name (1 to 50 characters, no < or >)."
       }
     },
     "expenses": {
@@ -1058,6 +1064,16 @@
     },
     "locale": {
       "invalid": "Ungültige Sprache."
+    },
+    "account": {
+      "type": {
+        "invalid": "Invalid account type."
+      },
+      "displayName": {
+        "required": "The account name is required.",
+        "tooLong": "The account name is too long (max 50 characters).",
+        "invalidChars": "The account name cannot contain < or >."
+      }
     }
   },
   "opengraphImage": {

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -1045,7 +1045,8 @@
       "balanceUpdateFailed": "Saldo konnte nicht aktualisiert werden.",
       "renameFailed": "Konto konnte nicht umbenannt werden.",
       "incomeUpdateFailed": "Einkommen konnte nicht aktualisiert werden.",
-      "transferUpdateFailed": "Überweisung konnte nicht aktualisiert werden."
+      "transferUpdateFailed": "Überweisung konnte nicht aktualisiert werden.",
+      "notFound": "This account could not be found."
     },
     "expenses": {
       "createFailed": "Ausgabe konnte nicht erstellt werden.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1045,7 +1045,8 @@
       "balanceUpdateFailed": "Unable to update the balance.",
       "renameFailed": "Unable to rename the account.",
       "incomeUpdateFailed": "Unable to update the income.",
-      "transferUpdateFailed": "Unable to update the transfer."
+      "transferUpdateFailed": "Unable to update the transfer.",
+      "notFound": "This account could not be found."
     },
     "expenses": {
       "createFailed": "Unable to create the expense.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -693,6 +693,12 @@
         "income_bills": "Main Account",
         "provisions": "Savings Account",
         "daily_card": "Daily Card"
+      },
+      "rename": {
+        "placeholder": "E.g. Belfius, Revolut, ING…",
+        "inputLabel": "New account name",
+        "editLabel": "Rename account \"{name}\"",
+        "errorInvalid": "Invalid name (1 to 50 characters, no < or >)."
       }
     },
     "expenses": {
@@ -1058,6 +1064,16 @@
     },
     "locale": {
       "invalid": "Invalid language."
+    },
+    "account": {
+      "type": {
+        "invalid": "Invalid account type."
+      },
+      "displayName": {
+        "required": "The account name is required.",
+        "tooLong": "The account name is too long (max 50 characters).",
+        "invalidChars": "The account name cannot contain < or >."
+      }
     }
   },
   "opengraphImage": {

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -1045,7 +1045,8 @@
       "balanceUpdateFailed": "No se ha podido actualizar el saldo.",
       "renameFailed": "No se ha podido renombrar la cuenta.",
       "incomeUpdateFailed": "No se ha podido actualizar el ingreso.",
-      "transferUpdateFailed": "No se ha podido actualizar la transferencia."
+      "transferUpdateFailed": "No se ha podido actualizar la transferencia.",
+      "notFound": "This account could not be found."
     },
     "expenses": {
       "createFailed": "No se ha podido crear el gasto.",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -693,6 +693,12 @@
         "income_bills": "Main Account",
         "provisions": "Savings Account",
         "daily_card": "Daily Card"
+      },
+      "rename": {
+        "placeholder": "E.g. Belfius, Revolut, ING…",
+        "inputLabel": "New account name",
+        "editLabel": "Rename account \"{name}\"",
+        "errorInvalid": "Invalid name (1 to 50 characters, no < or >)."
       }
     },
     "expenses": {
@@ -1058,6 +1064,16 @@
     },
     "locale": {
       "invalid": "Idioma inválido."
+    },
+    "account": {
+      "type": {
+        "invalid": "Invalid account type."
+      },
+      "displayName": {
+        "required": "The account name is required.",
+        "tooLong": "The account name is too long (max 50 characters).",
+        "invalidChars": "The account name cannot contain < or >."
+      }
     }
   },
   "opengraphImage": {

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -693,6 +693,12 @@
         "income_bills": "Compte Principal",
         "provisions": "Compte Épargne",
         "daily_card": "Carte Quotidien"
+      },
+      "rename": {
+        "placeholder": "Ex: Belfius, Revolut, ING…",
+        "inputLabel": "Nouveau nom du compte",
+        "editLabel": "Renommer le compte « {name} »",
+        "errorInvalid": "Nom invalide (1 à 50 caractères, sans < ou >)."
       }
     },
     "expenses": {
@@ -1058,6 +1064,16 @@
     },
     "locale": {
       "invalid": "Langue invalide."
+    },
+    "account": {
+      "type": {
+        "invalid": "Type de compte invalide."
+      },
+      "displayName": {
+        "required": "Le nom du compte est requis.",
+        "tooLong": "Le nom est trop long (max 50 caractères).",
+        "invalidChars": "Le nom ne peut pas contenir < ou >."
+      }
     }
   },
   "opengraphImage": {

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -1045,7 +1045,8 @@
       "balanceUpdateFailed": "Impossible de mettre à jour le solde.",
       "renameFailed": "Impossible de renommer le compte.",
       "incomeUpdateFailed": "Impossible de mettre à jour le revenu.",
-      "transferUpdateFailed": "Impossible de mettre à jour le virement."
+      "transferUpdateFailed": "Impossible de mettre à jour le virement.",
+      "notFound": "Ce compte est introuvable."
     },
     "expenses": {
       "createFailed": "Impossible de créer la dépense.",

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -693,6 +693,12 @@
         "income_bills": "Main Account",
         "provisions": "Savings Account",
         "daily_card": "Daily Card"
+      },
+      "rename": {
+        "placeholder": "E.g. Belfius, Revolut, ING…",
+        "inputLabel": "New account name",
+        "editLabel": "Rename account \"{name}\"",
+        "errorInvalid": "Invalid name (1 to 50 characters, no < or >)."
       }
     },
     "expenses": {
@@ -1058,6 +1064,16 @@
     },
     "locale": {
       "invalid": "Taal niet geldig."
+    },
+    "account": {
+      "type": {
+        "invalid": "Invalid account type."
+      },
+      "displayName": {
+        "required": "The account name is required.",
+        "tooLong": "The account name is too long (max 50 characters).",
+        "invalidChars": "The account name cannot contain < or >."
+      }
     }
   },
   "opengraphImage": {

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -1045,7 +1045,8 @@
       "balanceUpdateFailed": "Kan het saldo niet bijwerken.",
       "renameFailed": "Kan de rekening niet hernoemen.",
       "incomeUpdateFailed": "Kan het nettoloon niet bijwerken.",
-      "transferUpdateFailed": "Kan de overschrijving niet bijwerken."
+      "transferUpdateFailed": "Kan de overschrijving niet bijwerken.",
+      "notFound": "This account could not be found."
     },
     "expenses": {
       "createFailed": "Kan de uitgave niet aanmaken.",

--- a/src/app/[locale]/app/page.tsx
+++ b/src/app/[locale]/app/page.tsx
@@ -8,25 +8,26 @@ import {
   PiggyBank,
   Receipt,
   Shield,
-  Wallet,
 } from 'lucide-react';
 
 import { Link } from '@/i18n/navigation';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { AccountCard } from '@/components/features/AccountCard';
 import { Budget, Expenses, Provision, Transfer, money } from '@/lib/domain';
-import type { AccountKind } from '@/lib/domain/types';
 import { getWorkspaceSnapshot } from '@/lib/data/workspace-snapshot';
+import type { AccountType } from '@/lib/schemas/account';
 import type { Locale } from '@/i18n/routing';
 import { formatCurrency, formatDate, formatMonth } from '@/lib/i18n/formatters';
 
-const ACCOUNT_ICONS: Record<AccountKind, typeof Landmark> = {
-  principal: Landmark,
-  vie_courante: Wallet,
-  epargne: PiggyBank,
-};
-
-const ACCOUNT_ORDER: AccountKind[] = ['principal', 'vie_courante', 'epargne'];
+/**
+ * Render order for the typed account cards in the cockpit Bloc 1.
+ * Matches the canonical spec dashboard-cockpit-vraie-vision-2026-05-03.md:
+ *   1. income_bills (where salary lands)
+ *   2. provisions (savings buffer)
+ *   3. daily_card (daily-spending pot)
+ */
+const ACCOUNT_TYPE_ORDER: readonly AccountType[] = ['income_bills', 'provisions', 'daily_card'];
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('app.dashboard');
@@ -84,7 +85,7 @@ export default async function DashboardPage() {
   const epargneGoesToEpargne = plan.epargneTransferNet.gte(0);
   const missingSetup =
     snapshot.monthlyIncome === null || snapshot.vieCouranteMonthlyTransfer === null;
-  const accountByKind = new Map(snapshot.accounts.map((a) => [a.kind, a]));
+  const accountByType = new Map(snapshot.accounts.map((a) => [a.accountType, a]));
 
   return (
     <div className="flex flex-col gap-8">
@@ -278,25 +279,17 @@ export default async function DashboardPage() {
           )}
 
           <div className="grid gap-4 md:grid-cols-3">
-            {ACCOUNT_ORDER.map((kind) => {
-              const account = accountByKind.get(kind);
-              const Icon = ACCOUNT_ICONS[kind];
+            {ACCOUNT_TYPE_ORDER.map((accountType) => {
+              const account = accountByType.get(accountType);
+              if (!account) return null;
               return (
-                <Card key={kind}>
-                  <CardHeader className="pb-2">
-                    <div className="text-muted-foreground flex items-center gap-2">
-                      <Icon className="h-4 w-4" aria-hidden />
-                      <CardTitle className="text-xs font-medium tracking-wide uppercase">
-                        {account?.label ?? kind}
-                      </CardTitle>
-                    </div>
-                  </CardHeader>
-                  <CardContent>
-                    <p className="text-xl font-semibold tabular-nums">
-                      {fmtMoney(money(account?.balance ?? 0))}
-                    </p>
-                  </CardContent>
-                </Card>
+                <AccountCard
+                  key={accountType}
+                  accountType={accountType}
+                  displayName={account.displayName}
+                  balance={account.balance}
+                  locale={locale}
+                />
               );
             })}
           </div>

--- a/src/components/features/AccountCard.tsx
+++ b/src/components/features/AccountCard.tsx
@@ -1,0 +1,82 @@
+import { CreditCard, PiggyBank, Wallet, type LucideIcon } from 'lucide-react';
+import { getTranslations } from 'next-intl/server';
+
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { formatCurrency } from '@/lib/i18n/formatters';
+import type { Locale } from '@/i18n/routing';
+import { money } from '@/lib/domain/types';
+import type { AccountType } from '@/lib/schemas/account';
+
+import { AccountCardEditableTitle } from './AccountCardEditableTitle';
+
+type AccountCardProps = {
+  accountType: AccountType;
+  displayName: string;
+  balance: number;
+  locale: Locale;
+};
+
+const TYPE_VISUAL: Record<
+  AccountType,
+  Readonly<{ icon: LucideIcon; iconColor: string; ringColor: string }>
+> = {
+  income_bills: {
+    icon: Wallet,
+    iconColor: 'text-blue-500',
+    ringColor: 'ring-blue-500/15',
+  },
+  provisions: {
+    icon: PiggyBank,
+    iconColor: 'text-emerald-500',
+    ringColor: 'ring-emerald-500/15',
+  },
+  daily_card: {
+    icon: CreditCard,
+    iconColor: 'text-purple-500',
+    ringColor: 'ring-purple-500/15',
+  },
+};
+
+/**
+ * Cockpit account card (3 are rendered side-by-side on the dashboard).
+ *
+ * - Server Component: drives the static visual + reads i18n.
+ * - Delegates the title to <AccountCardEditableTitle/>, the only Client
+ *   Component slice (so we keep optimistic-update wiring narrow).
+ *
+ * Visual semantics per account_type are locked by the canonical spec
+ * `dashboard-cockpit-vraie-vision-2026-05-03.md` (Bloc 1).
+ */
+export async function AccountCard({ accountType, displayName, balance, locale }: AccountCardProps) {
+  const t = await getTranslations('app.accounts');
+  const visual = TYPE_VISUAL[accountType];
+  const Icon = visual.icon;
+  const subLabel = t(`types.${accountType}`);
+  const balanceLabel = formatCurrency(money(balance), locale);
+
+  return (
+    <Card
+      className={`group ring-1 ring-inset ${visual.ringColor} transition-shadow hover:shadow-md`}
+      data-account-type={accountType}
+    >
+      <CardHeader className="flex flex-row items-start gap-3 pb-2">
+        <Icon className={`h-6 w-6 shrink-0 ${visual.iconColor}`} aria-hidden strokeWidth={1.5} />
+        <div className="min-w-0 flex-1">
+          <AccountCardEditableTitle
+            accountType={accountType}
+            displayName={displayName}
+            subLabel={subLabel}
+          />
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p
+          className="text-2xl font-semibold tracking-tight tabular-nums"
+          aria-label={t('balance.srLabel', { label: displayName })}
+        >
+          {balanceLabel}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/features/AccountCardEditableTitle.tsx
+++ b/src/components/features/AccountCardEditableTitle.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useId, useOptimistic, useRef, useState, useTransition } from 'react';
+import { Edit2 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+import { renameAccountByTypeAction } from '@/lib/actions/accounts';
+import { accountDisplayNameSchema, type AccountType } from '@/lib/schemas/account';
+import { useActionErrorTranslator } from '@/lib/i18n/action-errors';
+import { toast } from '@/components/ui/toast';
+
+type Props = {
+  accountType: AccountType;
+  displayName: string;
+  subLabel: string;
+};
+
+/**
+ * Inline-editable account title. Click → input; Enter/blur → save; Esc → cancel.
+ *
+ * Pattern (cf. ADR-010 — same idiom transposed from QuotidienCard):
+ *   - useOptimistic for the snappy update (sub-100ms perceived latency)
+ *   - useTransition to serialise concurrent submissions
+ *   - Server Action revalidatePath('/[locale]/app','page') re-syncs
+ *   - On error: revert + toast + log
+ *
+ * Validation runs both client-side (instant feedback) and server-side
+ * (defense in depth, RLS still applies).
+ */
+export function AccountCardEditableTitle({ accountType, displayName, subLabel }: Props) {
+  const t = useTranslations('app.accounts.rename');
+  const translateError = useActionErrorTranslator();
+  const inputId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [optimisticName, setOptimisticName] = useOptimistic(
+    displayName,
+    (_prev, next: string) => next,
+  );
+  const [isPending, startTransition] = useTransition();
+  // Draft is created on entering edit mode and discarded on exit, so it
+  // never needs to track `displayName` updates outside that window.
+  const [draft, setDraft] = useState(displayName);
+
+  function enterEdit() {
+    setDraft(optimisticName);
+    setIsEditing(true);
+    queueMicrotask(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    });
+  }
+
+  function exitEdit() {
+    setIsEditing(false);
+  }
+
+  function submit() {
+    const trimmed = draft.trim();
+    // No-op if unchanged.
+    if (trimmed === optimisticName) {
+      setIsEditing(false);
+      return;
+    }
+    const parsed = accountDisplayNameSchema.safeParse(trimmed);
+    if (!parsed.success) {
+      toast.error(t('errorInvalid'));
+      inputRef.current?.focus();
+      return;
+    }
+    const next = parsed.data;
+    setIsEditing(false);
+    startTransition(async () => {
+      setOptimisticName(next);
+      const result = await renameAccountByTypeAction({
+        accountType,
+        displayName: next,
+      });
+      if (!result.ok) {
+        toast.error(translateError(result.errorCode));
+        // Optimistic state is cleared automatically by React on the next
+        // server-rendered prop, so we just surface the error to the user.
+      }
+    });
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      submit();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      exitEdit();
+    }
+  }
+
+  if (isEditing) {
+    return (
+      <div className="flex flex-col gap-1">
+        <label htmlFor={inputId} className="sr-only">
+          {t('inputLabel')}
+        </label>
+        <input
+          id={inputId}
+          ref={inputRef}
+          type="text"
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          onBlur={submit}
+          onKeyDown={handleKeyDown}
+          maxLength={50}
+          required
+          autoComplete="off"
+          spellCheck={false}
+          className="border-border bg-background focus-visible:ring-brand-700 w-full rounded-md border px-2 py-1 text-base font-semibold tracking-tight focus-visible:ring-2 focus-visible:outline-none"
+          placeholder={t('placeholder')}
+          aria-describedby={`${inputId}-sub`}
+        />
+        <p id={`${inputId}-sub`} className="text-muted-foreground text-xs">
+          {subLabel}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <button
+        type="button"
+        onClick={enterEdit}
+        className="hover:bg-muted/50 focus-visible:bg-muted/50 -mx-1 -my-0.5 flex items-center gap-1.5 rounded-md px-1 py-0.5 text-left text-base font-semibold tracking-tight transition-colors focus-visible:outline-none"
+        aria-label={t('editLabel', { name: optimisticName })}
+        disabled={isPending}
+      >
+        <span className="truncate">{optimisticName}</span>
+        <Edit2
+          className="h-3.5 w-3.5 shrink-0 opacity-0 transition-opacity group-hover:opacity-50 focus-visible:opacity-50"
+          aria-hidden
+          strokeWidth={1.5}
+        />
+      </button>
+      <p className="text-muted-foreground text-xs">{subLabel}</p>
+    </div>
+  );
+}

--- a/src/components/features/AccountCardEditableTitle.tsx
+++ b/src/components/features/AccountCardEditableTitle.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useId, useOptimistic, useRef, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
 import { Edit2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
@@ -30,6 +31,7 @@ type Props = {
 export function AccountCardEditableTitle({ accountType, displayName, subLabel }: Props) {
   const t = useTranslations('app.accounts.rename');
   const translateError = useActionErrorTranslator();
+  const router = useRouter();
   const inputId = useId();
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -79,8 +81,11 @@ export function AccountCardEditableTitle({ accountType, displayName, subLabel }:
       });
       if (!result.ok) {
         toast.error(translateError(result.errorCode));
-        // Optimistic state is cleared automatically by React on the next
-        // server-rendered prop, so we just surface the error to the user.
+        // useOptimistic only snaps back when the component re-renders. The
+        // failed Server Action did NOT call revalidatePath, so we trigger
+        // an explicit refresh to re-fetch the Server Component tree and
+        // restore the canonical displayName from the DB.
+        router.refresh();
       }
     });
   }
@@ -129,7 +134,7 @@ export function AccountCardEditableTitle({ accountType, displayName, subLabel }:
       <button
         type="button"
         onClick={enterEdit}
-        className="hover:bg-muted/50 focus-visible:bg-muted/50 -mx-1 -my-0.5 flex items-center gap-1.5 rounded-md px-1 py-0.5 text-left text-base font-semibold tracking-tight transition-colors focus-visible:outline-none"
+        className="group hover:bg-muted/50 focus-visible:bg-muted/50 -mx-1 -my-0.5 flex items-center gap-1.5 rounded-md px-1 py-0.5 text-left text-base font-semibold tracking-tight transition-colors focus-visible:outline-none"
         aria-label={t('editLabel', { name: optimisticName })}
         disabled={isPending}
       >

--- a/src/components/features/__tests__/AccountCardEditableTitle.test.tsx
+++ b/src/components/features/__tests__/AccountCardEditableTitle.test.tsx
@@ -6,6 +6,7 @@ import messages from '../../../../messages/fr-BE.json';
 
 const renameMock = vi.hoisted(() => vi.fn());
 const toastErrorMock = vi.hoisted(() => vi.fn());
+const routerRefreshMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/actions/accounts', () => ({
   renameAccountByTypeAction: renameMock,
@@ -13,6 +14,12 @@ vi.mock('@/lib/actions/accounts', () => ({
 
 vi.mock('@/components/ui/toast', () => ({
   toast: { error: toastErrorMock, success: vi.fn() },
+}));
+
+// next/navigation is unavailable under jsdom; the App Router context is
+// not mounted in unit tests, so we stub the hook outright.
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: routerRefreshMock, push: vi.fn(), replace: vi.fn() }),
 }));
 
 import { AccountCardEditableTitle } from '@/components/features/AccountCardEditableTitle';
@@ -35,6 +42,7 @@ describe('<AccountCardEditableTitle />', () => {
   beforeEach(() => {
     renameMock.mockReset();
     toastErrorMock.mockReset();
+    routerRefreshMock.mockReset();
   });
 
   it('renders the display name as a button by default', () => {
@@ -103,7 +111,7 @@ describe('<AccountCardEditableTitle />', () => {
     expect(renameMock).not.toHaveBeenCalled();
   });
 
-  it('shows an error toast when the Server Action returns ok: false', async () => {
+  it('shows an error toast and refreshes the route when the Server Action returns ok: false', async () => {
     renameMock.mockResolvedValue({ ok: false, errorCode: 'errors.accounts.renameFailed' });
     renderWithIntl(<AccountCardEditableTitle {...baseProps} />);
     fireEvent.click(screen.getByRole('button', { name: /Renommer le compte/i }));
@@ -115,6 +123,9 @@ describe('<AccountCardEditableTitle />', () => {
     await waitFor(() => {
       expect(toastErrorMock).toHaveBeenCalled();
     });
+    // router.refresh() forces the Server Component tree to re-render so
+    // that useOptimistic snaps back to the canonical displayName.
+    expect(routerRefreshMock).toHaveBeenCalledTimes(1);
   });
 
   it('exposes an aria-label that names the current account', () => {

--- a/src/components/features/__tests__/AccountCardEditableTitle.test.tsx
+++ b/src/components/features/__tests__/AccountCardEditableTitle.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+
+import messages from '../../../../messages/fr-BE.json';
+
+const renameMock = vi.hoisted(() => vi.fn());
+const toastErrorMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/actions/accounts', () => ({
+  renameAccountByTypeAction: renameMock,
+}));
+
+vi.mock('@/components/ui/toast', () => ({
+  toast: { error: toastErrorMock, success: vi.fn() },
+}));
+
+import { AccountCardEditableTitle } from '@/components/features/AccountCardEditableTitle';
+
+function renderWithIntl(ui: React.ReactNode) {
+  return render(
+    <NextIntlClientProvider locale="fr-BE" messages={messages} timeZone="Europe/Brussels">
+      {ui}
+    </NextIntlClientProvider>,
+  );
+}
+
+const baseProps = {
+  accountType: 'income_bills' as const,
+  displayName: 'Compte Principal',
+  subLabel: 'Salaires & Factures',
+};
+
+describe('<AccountCardEditableTitle />', () => {
+  beforeEach(() => {
+    renameMock.mockReset();
+    toastErrorMock.mockReset();
+  });
+
+  it('renders the display name as a button by default', () => {
+    renderWithIntl(<AccountCardEditableTitle {...baseProps} />);
+    const button = screen.getByRole('button', { name: /Renommer le compte/i });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('Compte Principal');
+  });
+
+  it('shows the sub-label below the title', () => {
+    renderWithIntl(<AccountCardEditableTitle {...baseProps} />);
+    expect(screen.getByText('Salaires & Factures')).toBeInTheDocument();
+  });
+
+  it('switches to an input on click', async () => {
+    renderWithIntl(<AccountCardEditableTitle {...baseProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /Renommer le compte/i }));
+    const input = await screen.findByRole('textbox');
+    expect(input).toHaveValue('Compte Principal');
+    expect(input).toHaveAttribute('maxLength', '50');
+  });
+
+  it('reverts on Escape without calling the Server Action', async () => {
+    renderWithIntl(<AccountCardEditableTitle {...baseProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /Renommer le compte/i }));
+    const input = await screen.findByRole('textbox');
+    fireEvent.change(input, { target: { value: 'Belfius' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(renameMock).not.toHaveBeenCalled();
+    // Back to button mode
+    expect(screen.getByRole('button', { name: /Renommer le compte/i })).toBeInTheDocument();
+  });
+
+  it('calls renameAccountByTypeAction on Enter with the trimmed new name', async () => {
+    renameMock.mockResolvedValue({ ok: true });
+    renderWithIntl(<AccountCardEditableTitle {...baseProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /Renommer le compte/i }));
+    const input = await screen.findByRole('textbox');
+    await act(async () => {
+      fireEvent.change(input, { target: { value: '  Belfius  ' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+    });
+    await waitFor(() => {
+      expect(renameMock).toHaveBeenCalledWith({
+        accountType: 'income_bills',
+        displayName: 'Belfius',
+      });
+    });
+  });
+
+  it('skips the Server Action when the value is unchanged', async () => {
+    renderWithIntl(<AccountCardEditableTitle {...baseProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /Renommer le compte/i }));
+    const input = await screen.findByRole('textbox');
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(renameMock).not.toHaveBeenCalled();
+  });
+
+  it('shows an error toast when client validation rejects HTML chars', async () => {
+    renderWithIntl(<AccountCardEditableTitle {...baseProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /Renommer le compte/i }));
+    const input = await screen.findByRole('textbox');
+    fireEvent.change(input, { target: { value: '<script>' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(toastErrorMock).toHaveBeenCalledTimes(1);
+    expect(renameMock).not.toHaveBeenCalled();
+  });
+
+  it('shows an error toast when the Server Action returns ok: false', async () => {
+    renameMock.mockResolvedValue({ ok: false, errorCode: 'errors.accounts.renameFailed' });
+    renderWithIntl(<AccountCardEditableTitle {...baseProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /Renommer le compte/i }));
+    const input = await screen.findByRole('textbox');
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Belfius' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+    });
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalled();
+    });
+  });
+
+  it('exposes an aria-label that names the current account', () => {
+    renderWithIntl(<AccountCardEditableTitle {...baseProps} />);
+    const button = screen.getByRole('button', { name: 'Renommer le compte « Compte Principal »' });
+    expect(button).toBeInTheDocument();
+  });
+});

--- a/src/lib/actions/accounts.ts
+++ b/src/lib/actions/accounts.ts
@@ -2,7 +2,11 @@
 
 import { createClient } from '@/lib/supabase/server';
 import { revalidateAppPath, revalidateDashboard } from '@/lib/actions/revalidate';
-import { accountBalanceSchema, accountLabelSchema } from '@/lib/schemas/account';
+import {
+  accountBalanceSchema,
+  accountLabelSchema,
+  accountRenameByTypeSchema,
+} from '@/lib/schemas/account';
 import { monthlyIncomeSchema, vieCouranteTransferSchema } from '@/lib/schemas/workspace';
 import { AuditEvent, logAuditEvent } from '@/lib/security/audit-log';
 import { rateLimit } from '@/lib/security/rate-limit';
@@ -102,6 +106,47 @@ export async function renameAccountAction(input: unknown): Promise<ActionResult>
     .eq('kind', parsed.data.kind);
 
   if (error) return { ok: false, errorCode: 'errors.accounts.renameFailed' };
+
+  revalidateAccountPaths();
+  return { ok: true };
+}
+
+// =========================================================================
+// Rename an account by canonical account_type (ADR-008)
+// =========================================================================
+// Distinct from `renameAccountAction` (legacy `kind`) so PR-D2 cards can
+// drive the rename through the canonical column without churning every
+// existing consumer. Both server actions write to the same row — they
+// only differ in how they identify it.
+export async function renameAccountByTypeAction(input: unknown): Promise<ActionResult> {
+  const ctx = await resolveSessionWorkspace();
+  if (!ctx.ok) return { ok: false, errorCode: ctx.errorCode };
+
+  const rl = await rateLimit('mutation', `user:${ctx.user.id}`);
+  if (!rl.success) return { ok: false, errorCode: 'errors.session.rateLimited' };
+
+  const parsed = accountRenameByTypeSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      errorCode: 'errors.validation.generic',
+      fieldErrors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+    };
+  }
+
+  const { error } = await ctx.supabase
+    .from('accounts')
+    .update({ display_name: parsed.data.displayName })
+    .eq('workspace_id', ctx.workspaceId)
+    .eq('account_type', parsed.data.accountType);
+
+  if (error) return { ok: false, errorCode: 'errors.accounts.renameFailed' };
+
+  await logAuditEvent(
+    AuditEvent.ACCOUNT_RENAMED,
+    { userId: ctx.user.id, workspaceId: ctx.workspaceId },
+    { resource_type: 'account', resource_id: parsed.data.accountType },
+  );
 
   revalidateAccountPaths();
   return { ok: true };

--- a/src/lib/actions/accounts.ts
+++ b/src/lib/actions/accounts.ts
@@ -134,13 +134,20 @@ export async function renameAccountByTypeAction(input: unknown): Promise<ActionR
     };
   }
 
-  const { error } = await ctx.supabase
+  // .select() forces Supabase to return the updated rows so we can detect
+  // the no-op case (RLS rejected the row, account_type doesn't exist for
+  // this workspace, etc.) — `error` alone is null when no row matches.
+  const { data, error } = await ctx.supabase
     .from('accounts')
     .update({ display_name: parsed.data.displayName })
     .eq('workspace_id', ctx.workspaceId)
-    .eq('account_type', parsed.data.accountType);
+    .eq('account_type', parsed.data.accountType)
+    .select('account_type');
 
   if (error) return { ok: false, errorCode: 'errors.accounts.renameFailed' };
+  if (!data || data.length === 0) {
+    return { ok: false, errorCode: 'errors.accounts.notFound' };
+  }
 
   await logAuditEvent(
     AuditEvent.ACCOUNT_RENAMED,

--- a/src/lib/data/workspace-snapshot.ts
+++ b/src/lib/data/workspace-snapshot.ts
@@ -9,6 +9,7 @@ import {
   type ChargePaidFrom,
   type Expense,
 } from '@/lib/domain/types';
+import type { AccountType } from '@/lib/domain/cockpit/types';
 
 /**
  * Canonical timezone for month-boundary calculations on the dashboard.
@@ -39,8 +40,14 @@ function getCurrentMonthBoundariesISO(): { startISO: string; nextStartISO: strin
 }
 
 export type AccountSnapshot = {
+  /** Legacy column — kept until PR-D-final migrates every consumer to accountType. */
   kind: AccountKind;
+  /** Legacy column — kept until PR-D-final migrates every consumer to displayName. */
   label: string;
+  /** ADR-008 canonical type. Drives cockpit logic + UI typed cards (PR-D2+). */
+  accountType: AccountType;
+  /** ADR-008 user-defined display name. Editable inline since PR-D2. */
+  displayName: string;
   balance: number;
 };
 
@@ -115,7 +122,10 @@ export async function getWorkspaceSnapshot(): Promise<WorkspaceSnapshot> {
       .select('id, label, amount, frequency, due_month, category_id, is_active, notes, paid_from')
       .eq('workspace_id', workspaceId)
       .order('created_at', { ascending: true }),
-    supabase.from('accounts').select('kind, label, balance').eq('workspace_id', workspaceId),
+    supabase
+      .from('accounts')
+      .select('kind, label, account_type, display_name, balance')
+      .eq('workspace_id', workspaceId),
     supabase
       .from('expenses')
       .select('id, label, amount, occurred_on, category_id, note, paid_from')
@@ -153,6 +163,8 @@ export async function getWorkspaceSnapshot(): Promise<WorkspaceSnapshot> {
   const accounts: AccountSnapshot[] = (accountsRes.data ?? []).map((a) => ({
     kind: a.kind as AccountKind,
     label: a.label,
+    accountType: a.account_type as AccountType,
+    displayName: a.display_name,
     balance: Number(a.balance),
   }));
 

--- a/src/lib/schemas/account.ts
+++ b/src/lib/schemas/account.ts
@@ -4,6 +4,31 @@ export const accountKindSchema = z.enum(['principal', 'vie_courante', 'epargne']
   error: 'account.kind.invalid',
 });
 
+/**
+ * ADR-008 canonical account type. Drives cockpit logic + UI typed cards (PR-D2+).
+ * The `kind` enum above is legacy and will be deprecated post PR-D-final.
+ */
+export const accountTypeSchema = z.enum(['income_bills', 'provisions', 'daily_card'], {
+  error: 'account.type.invalid',
+});
+
+/**
+ * Display-name input shared by every rename surface. The regex blocks `<` / `>`
+ * to keep the value HTML-safe end-to-end (Zod validates client-side AND
+ * server-side; the rendered <input value> still relies on React escaping).
+ */
+export const accountDisplayNameSchema = z
+  .string()
+  .trim()
+  .min(1, { message: 'account.displayName.required' })
+  .max(50, { message: 'account.displayName.tooLong' })
+  .regex(/^[^<>]*$/, { message: 'account.displayName.invalidChars' });
+
+export const accountRenameByTypeSchema = z.object({
+  accountType: accountTypeSchema,
+  displayName: accountDisplayNameSchema,
+});
+
 export const accountBalanceSchema = z.object({
   kind: accountKindSchema,
   balance: z
@@ -23,8 +48,10 @@ export const accountLabelSchema = z.object({
 });
 
 export type AccountKind = z.infer<typeof accountKindSchema>;
+export type AccountType = z.infer<typeof accountTypeSchema>;
 export type AccountBalanceInput = z.infer<typeof accountBalanceSchema>;
 export type AccountLabelInput = z.infer<typeof accountLabelSchema>;
+export type AccountRenameByTypeInput = z.infer<typeof accountRenameByTypeSchema>;
 
 /**
  * Maps the DB `kind` (snake_case) to the i18n message sub-namespace (camelCase)

--- a/src/lib/security/audit-log.ts
+++ b/src/lib/security/audit-log.ts
@@ -28,6 +28,7 @@ export const AuditEvent = {
   EXPENSE_UPDATED: 'expense.updated',
   EXPENSE_DELETED: 'expense.deleted',
   ACCOUNT_BALANCE_UPDATED: 'account.balance_updated',
+  ACCOUNT_RENAMED: 'account.renamed',
 
   // GDPR
   GDPR_CONSENT_GIVEN: 'gdpr.consent_given',

--- a/tests/schemas/account.test.ts
+++ b/tests/schemas/account.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  accountDisplayNameSchema,
+  accountKindSchema,
+  accountRenameByTypeSchema,
+  accountTypeSchema,
+} from '@/lib/schemas/account';
+
+describe('accountTypeSchema', () => {
+  it.each(['income_bills', 'provisions', 'daily_card'] as const)('accepts %s', (value) => {
+    expect(accountTypeSchema.safeParse(value).success).toBe(true);
+  });
+
+  it('rejects legacy kind values', () => {
+    expect(accountTypeSchema.safeParse('principal').success).toBe(false);
+    expect(accountTypeSchema.safeParse('vie_courante').success).toBe(false);
+    expect(accountTypeSchema.safeParse('epargne').success).toBe(false);
+  });
+
+  it('rejects unrelated strings', () => {
+    expect(accountTypeSchema.safeParse('').success).toBe(false);
+    expect(accountTypeSchema.safeParse('savings').success).toBe(false);
+  });
+});
+
+describe('accountKindSchema (legacy, kept for back-compat)', () => {
+  it('still accepts the 3 legacy kinds', () => {
+    expect(accountKindSchema.safeParse('principal').success).toBe(true);
+    expect(accountKindSchema.safeParse('vie_courante').success).toBe(true);
+    expect(accountKindSchema.safeParse('epargne').success).toBe(true);
+  });
+});
+
+describe('accountDisplayNameSchema', () => {
+  it('accepts a typical bank name', () => {
+    expect(accountDisplayNameSchema.parse('Belfius')).toBe('Belfius');
+  });
+
+  it('trims whitespace', () => {
+    expect(accountDisplayNameSchema.parse('  Belfius  ')).toBe('Belfius');
+  });
+
+  it('rejects empty strings (after trim)', () => {
+    expect(accountDisplayNameSchema.safeParse('   ').success).toBe(false);
+  });
+
+  it('rejects strings longer than 50 characters', () => {
+    const tooLong = 'a'.repeat(51);
+    expect(accountDisplayNameSchema.safeParse(tooLong).success).toBe(false);
+  });
+
+  it('accepts exactly 50 characters', () => {
+    const max = 'a'.repeat(50);
+    expect(accountDisplayNameSchema.parse(max)).toBe(max);
+  });
+
+  it('rejects HTML-like characters that could enable injection', () => {
+    expect(accountDisplayNameSchema.safeParse('<script>').success).toBe(false);
+    expect(accountDisplayNameSchema.safeParse('Belfius>').success).toBe(false);
+    expect(accountDisplayNameSchema.safeParse('<Belfius').success).toBe(false);
+  });
+
+  it('accepts accented characters and ampersands', () => {
+    expect(accountDisplayNameSchema.parse('Épargne & Provisions')).toBe('Épargne & Provisions');
+  });
+
+  it('accepts emoji (no HTML restriction beyond < / >)', () => {
+    expect(accountDisplayNameSchema.parse('Belfius 🏦')).toBe('Belfius 🏦');
+  });
+});
+
+describe('accountRenameByTypeSchema', () => {
+  it('accepts a well-formed payload', () => {
+    const result = accountRenameByTypeSchema.safeParse({
+      accountType: 'income_bills',
+      displayName: 'Belfius',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an unknown account_type', () => {
+    expect(
+      accountRenameByTypeSchema.safeParse({
+        accountType: 'principal',
+        displayName: 'Belfius',
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects empty displayName', () => {
+    expect(
+      accountRenameByTypeSchema.safeParse({
+        accountType: 'income_bills',
+        displayName: '   ',
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects displayName containing < or >', () => {
+    expect(
+      accountRenameByTypeSchema.safeParse({
+        accountType: 'income_bills',
+        displayName: '<img onerror=...>',
+      }).success,
+    ).toBe(false);
+  });
+
+  it('exposes field-level error path on accountType', () => {
+    const result = accountRenameByTypeSchema.safeParse({
+      accountType: 'unknown',
+      displayName: 'Belfius',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const flat = result.error.flatten();
+      expect(flat.fieldErrors.accountType).toBeDefined();
+    }
+  });
+});


### PR DESCRIPTION
## Pourquoi

Première PR **avec UI** de la Voie D Dashboard cockpit. Construit sur PR-D1 (#94 mergée) pour consommer `accounts.account_type` + `accounts.display_name` et produire les 3 cards comptes typés (Bloc 1 du document canonique) avec **renommage inline** via Server Action.

Handoff source : `cowork-handoffs/2026-05-03-2030-pr-d2-header-account-cards.md` (vault Athenaeum).

ADRs porteurs : [ADR-008](docs/adr/ADR-008-account-naming-and-typing.md) (account_type / display_name), pattern useOptimistic inspiré de [ADR-010](docs/adr/ADR-010-live-decrement-quotidien.md).

## Quoi

### UI

| Composant | Rôle |
|---|---|
| `src/components/features/AccountCard.tsx` | **Server Component** — visuel par `account_type`, format balance, sub-label i18n |
| `src/components/features/AccountCardEditableTitle.tsx` | **Client Component** — `useOptimistic` + `useTransition` pour rename inline (sub-100ms perçu) |

Visual mapping locked par la spec :

| `account_type` | Icône Lucide | Couleur |
|---|---|---|
| `income_bills` | `Wallet` | `text-blue-500` |
| `provisions` | `PiggyBank` | `text-emerald-500` |
| `daily_card` | `CreditCard` | `text-purple-500` |

UX rename : click titre → `<input>` autofocus + select-all → Enter ou blur = save (Server Action) / Esc = cancel sans appel serveur. Toast d'erreur via `sonner` si validation client (HTML chars) ou serveur (RLS, network) échoue.

### Server Action

`renameAccountByTypeAction` (additive, fichier existant `src/lib/actions/accounts.ts`) :

- Identifie le compte via `(workspace_id, account_type)` — la table `public.accounts` n'a **pas** de colonne `id`, le UNIQUE INDEX `(workspace_id, account_type)` ajouté en PR-D1 garantit l'unicité.
- Validation Zod (`accountRenameByTypeSchema` = enum + 1..50 chars + regex `^[^<>]*$`).
- Rate-limit `mutation` (30 req/min/user via Upstash).
- Audit log `AuditEvent.ACCOUNT_RENAMED` (nouveau).
- `revalidateAccountPaths()` invalide `/[locale]/app` + `/[locale]/app/accounts`.

### Data layer

`src/lib/data/workspace-snapshot.ts` étend la query `accounts` pour charger `account_type` + `display_name` aux côtés de `kind`/`label` (additif, zéro casse). Le type `AccountSnapshot` expose les 5 champs.

### Page

`src/app/[locale]/app/page.tsx` remplace le grid 3 cards génériques (lignes 280-302 pré-PR-D2) par un loop sur `ACCOUNT_TYPE_ORDER = ['income_bills', 'provisions', 'daily_card']` qui rend les nouvelles `<AccountCard />`. Le reste de `page.tsx` (KPI cards, plan du mois, expenses section) reste inchangé.

### i18n (5 locales, parité 5/5)

FR-BE et EN authored, NL/DE/ES stubbés en EN (acceptable per scope) :

```
app.accounts.rename.{placeholder, inputLabel, editLabel, errorInvalid}
errors.account.type.invalid
errors.account.displayName.{required, tooLong, invalidChars}
```

### Tests

| Niveau | Fichier | Cas |
|---|---|---|
| Vitest schema | `tests/schemas/account.test.ts` | 18 cas (account_type vs kind legacy, displayName edge lengths, HTML injection blocked, accents/emoji acceptés) |
| Vitest RTL component | `src/components/features/__tests__/AccountCardEditableTitle.test.tsx` | 10 cas (render button, switch input on click, Esc revert, Enter calls Server Action, no-op when unchanged, HTML rejected client-side, server error → toast, aria-label correctness) |
| Playwright E2E | `e2e/dashboard-account-rename.spec.ts` | 2 scénarios (rename Compte Principal → Belfius persists across reload + DB roundtrip ; Esc cancels without persisting) |

568 tests verts au total (28 nouveaux). Coverage sur `lib/schemas/account.ts` au-dessus des seuils.

## Décisions notables

1. **`accountType` plutôt que `accountId` pour identifier la row** — la table `accounts` n'a pas d'`id`, la PK est `(workspace_id, kind)` et l'index unique PR-D1 est `(workspace_id, account_type)`. Le handoff mentionne `accountId`, j'ai pivoté vers `accountType` (équivalent fonctionnel, zéro migration). À documenter en amendement ADR-008.
2. **Conservation `kind`/`label`** — dette tech à nettoyer en PR-D-final. `getWorkspaceSnapshot` charge maintenant les 5 colonnes ; `AccountsClient.tsx`, `accounts.ts` action existante (`renameAccountAction` legacy via `kind`+`label`) restent intacts.
3. **Pattern useOptimistic** — réutilise l'idiome ADR-010 (Quotidien live decrement) appliqué au rename. Server Action serialisée via `useTransition`. `useEffect` re-sync supprimé (le draft est local au mode edit ; ESLint `react-hooks/set-state-in-effect` aurait flag).
4. **`data-account-type` attribute** sur `<Card>` — facilite les sélecteurs E2E sans coupler aux i18n labels.

## Hors scope strict

- ❌ Pas de sélecteur mois `< Mai 2026 >` (= PR-D3)
- ❌ Pas de Bloc 2 Capacité d'Épargne Réelle / Effort Lissé (= PR-D3)
- ❌ Pas de touche au `Header.tsx` existant (le fix logo issue #95 reste séparé)
- ❌ Pas de refonte visuelle globale (= PR-D-final)
- ❌ Pas de suppression `kind`/`label` (dette tech post-migration consommateurs)

## Quality gates

- `npm run lint` → 0 erreur (3 warnings préexistants hors scope)
- `npm run lint:use-server` → ✓ All "use server" files contain only async exports
- `npm run typecheck` → 0 erreur
- `npm run test` → 568/568 pass (28 nouveaux)
- `npm run build` → ✓ Compiled successfully

## Test plan

- [x] Lint + typecheck + tests verts (en local)
- [x] Build prod réussi
- [ ] CI Lint + Typecheck + Unit Tests
- [ ] CI Security audit
- [ ] CI Playwright E2E
- [ ] Vercel Preview deployment SUCCESS
- [ ] Sourcery silent on dernier commit
- [ ] @thierry smoke test live : ouvrir Dashboard → click "Compte Principal" → tape "Belfius" → Enter → refresh → vérifier persistance

## Amendements ADR-008 à proposer post-merge (non bloquant)

- Ajouter section "Identifier les comptes côté Server Actions" qui documente que `(workspace_id, account_type)` est l'identifiant canonique (la table n'a pas d'`id`).
- Ajouter section "Pattern useOptimistic + useTransition" comme référence pour les futures interactions inline (PR-D4 toggle paye, PR-D5 add expense).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduire des cartes de compte de tableau de bord typées avec renommage en ligne, basées sur un nouveau modèle de type de compte canonique et sur les données, la validation, l’audit et les tests associés.

Nouvelles fonctionnalités :
- Afficher trois cartes de compte cockpit typées sur le tableau de bord, pilotées par des types de compte canoniques et des libellés localisés.
- Autoriser le renommage en ligne des cartes de compte avec mises à jour optimistes de l’UI et persistance côté serveur via une nouvelle action de renommage par type de compte.

Améliorations :
- Étendre le schéma de compte et le snapshot d’espace de travail pour exposer les types de compte canoniques et les noms d’affichage définis par l’utilisateur, en plus des champs hérités.
- Ajouter une journalisation d’audit pour les événements de renommage de compte et connecter le rendu du tableau de bord au nouveau classement des types de compte canoniques.

Documentation :
- Mettre à jour les catalogues de messages localisés pour couvrir l’UX de renommage de compte et les erreurs de validation dans tous les paramètres régionaux pris en charge.

Tests :
- Ajouter des tests de schéma Vitest pour la validation du type de compte et du nom d’affichage, y compris les cas limites et le blocage des injections HTML.
- Ajouter des tests RTL pour le comportement du titre de carte de compte éditable et l’étiquetage en matière d’accessibilité.
- Ajouter une couverture E2E Playwright pour la persistance du renommage de compte et les flux d’annulation sur le tableau de bord.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce typed dashboard account cards with inline renaming powered by a new canonical account type model and supporting data, validation, audit, and tests.

New Features:
- Render three typed cockpit account cards on the dashboard driven by canonical account types and localized labels.
- Allow inline renaming of account cards with optimistic UI updates and server-side persistence via a new rename-by-account-type action.

Enhancements:
- Extend the account schema and workspace snapshot to expose canonical account types and user-defined display names alongside legacy fields.
- Add audit logging for account rename events and wire dashboard rendering to the new canonical account type ordering.

Documentation:
- Update localized message catalogs to cover account rename UX and validation errors across supported locales.

Tests:
- Add Vitest schema tests for account type and display name validation, including edge cases and HTML injection blocking.
- Add RTL tests for the editable account card title behaviour and accessibility labelling.
- Add Playwright E2E coverage for account renaming persistence and cancel flows on the dashboard.

</details>