### PR TITLE
fix(supabase): subquery in CHECK constraint blocks migration 2 push

### DIFF
--- a/supabase/migrations/20260503000002_pr_d1_charges_enrichments.sql
+++ b/supabase/migrations/20260503000002_pr_d1_charges_enrichments.sql
@@ -27,8 +27,10 @@ alter table public.charges
 
 -- -------------------------------------------------------------------------
 -- 2. Constraint: every entry of payment_months must be in 1..12
---    Postgres has no native check on array elements, so we use a CHECK
---    expression that asserts MIN >= 1 AND MAX <= 12 over the array.
+--    Postgres interdit les subqueries dans les CHECK constraints (SQLSTATE 0A000),
+--    on utilise donc l'opérateur `<@` (contained by) qui est immutable et
+--    accepté en CHECK : tous les éléments du tableau doivent être dans
+--    l'ensemble [1,2,...,12].
 -- -------------------------------------------------------------------------
 do $$
 begin
@@ -42,7 +44,7 @@ begin
         array_length(payment_months, 1) is null
         or (
           array_length(payment_months, 1) between 1 and 12
-          and (select bool_and(m between 1 and 12) from unnest(payment_months) as m)
+          and payment_months <@ array[1,2,3,4,5,6,7,8,9,10,11,12]::smallint[]
         )
       );
   end if;


### PR DESCRIPTION
## Bug fix
La migration 2 PR-D1 (\20260503000002_pr_d1_charges_enrichments.sql\) utilise une subquery \(select bool_and(m between 1 and 12) from unnest(payment_months) as m)\ dans une CHECK constraint. Postgres interdit cela : \ERROR: cannot use subquery in check constraint (SQLSTATE 0A000)\.

## Fix
Remplacer par l'opérateur \<@\ (contained by) qui est immutable et accepté en CHECK :
\\\sql
payment_months <@ array[1,2,3,4,5,6,7,8,9,10,11,12]::smallint[]
\\\

## Contexte
Détecté empiriquement lors du \supabase db push --linked\ post-merge PR #94 (PR-D1) le 3 mai 2026. Migration 1 OK, migration 2 plante, migrations 3/4 pas exécutées.

Migration idempotente (DO bloc avec \if not exists pg_constraint\) → safe à re-tenter post-merge.

🤖 Generated with @cowork

## Summary by Sourcery

Corrections de bugs :
- S'assurer que la contrainte CHECK `payment_months` utilise l'opérateur de contenance de tableau au lieu d'une sous-requête, ce qui résout la restriction de PostgreSQL sur l'utilisation de sous-requêtes dans les contraintes CHECK.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure the payment_months CHECK constraint uses the array containment operator instead of a subquery, resolving PostgreSQL's restriction on subqueries in CHECK constraints.

</details>