### PR TITLE
fix(dashboard): UX polish — logo click + rename affordance (#95, #98)

### DIFF
--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -698,7 +698,8 @@
         "placeholder": "E.g. Belfius, Revolut, ING…",
         "inputLabel": "New account name",
         "editLabel": "Rename account \"{name}\"",
-        "errorInvalid": "Invalid name (1 to 50 characters, no < or >)."
+        "errorInvalid": "Invalid name (1 to 50 characters, no < or >).",
+        "tooltip": "Click to rename"
       }
     },
     "expenses": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -698,7 +698,8 @@
         "placeholder": "E.g. Belfius, Revolut, ING…",
         "inputLabel": "New account name",
         "editLabel": "Rename account \"{name}\"",
-        "errorInvalid": "Invalid name (1 to 50 characters, no < or >)."
+        "errorInvalid": "Invalid name (1 to 50 characters, no < or >).",
+        "tooltip": "Click to rename"
       }
     },
     "expenses": {

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -698,7 +698,8 @@
         "placeholder": "E.g. Belfius, Revolut, ING…",
         "inputLabel": "New account name",
         "editLabel": "Rename account \"{name}\"",
-        "errorInvalid": "Invalid name (1 to 50 characters, no < or >)."
+        "errorInvalid": "Invalid name (1 to 50 characters, no < or >).",
+        "tooltip": "Click to rename"
       }
     },
     "expenses": {

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -698,7 +698,8 @@
         "placeholder": "Ex: Belfius, Revolut, ING…",
         "inputLabel": "Nouveau nom du compte",
         "editLabel": "Renommer le compte « {name} »",
-        "errorInvalid": "Nom invalide (1 à 50 caractères, sans < ou >)."
+        "errorInvalid": "Nom invalide (1 à 50 caractères, sans < ou >).",
+        "tooltip": "Cliquer pour renommer"
       }
     },
     "expenses": {

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -698,7 +698,8 @@
         "placeholder": "E.g. Belfius, Revolut, ING…",
         "inputLabel": "New account name",
         "editLabel": "Rename account \"{name}\"",
-        "errorInvalid": "Invalid name (1 to 50 characters, no < or >)."
+        "errorInvalid": "Invalid name (1 to 50 characters, no < or >).",
+        "tooltip": "Click to rename"
       }
     },
     "expenses": {

--- a/src/components/features/AccountCardEditableTitle.tsx
+++ b/src/components/features/AccountCardEditableTitle.tsx
@@ -135,7 +135,7 @@ export function AccountCardEditableTitle({ accountType, displayName, subLabel }:
         type="button"
         onClick={enterEdit}
         title={t('tooltip')}
-        className="group hover:bg-muted/50 focus-visible:bg-muted/50 -mx-1 -my-0.5 flex cursor-text items-center gap-1.5 rounded-md px-1 py-0.5 text-left text-base font-semibold tracking-tight transition-colors hover:underline hover:decoration-zinc-500 hover:decoration-dotted hover:underline-offset-4 focus-visible:outline-none"
+        className="group hover:bg-muted/50 focus-visible:bg-muted/50 -mx-1 -my-0.5 flex cursor-pointer items-center gap-1.5 rounded-md px-1 py-0.5 text-left text-base font-semibold tracking-tight transition-colors hover:underline hover:decoration-zinc-500 hover:decoration-dotted hover:underline-offset-4 focus-visible:outline-none"
         aria-label={t('editLabel', { name: optimisticName })}
         disabled={isPending}
       >

--- a/src/components/features/AccountCardEditableTitle.tsx
+++ b/src/components/features/AccountCardEditableTitle.tsx
@@ -134,13 +134,14 @@ export function AccountCardEditableTitle({ accountType, displayName, subLabel }:
       <button
         type="button"
         onClick={enterEdit}
-        className="group hover:bg-muted/50 focus-visible:bg-muted/50 -mx-1 -my-0.5 flex items-center gap-1.5 rounded-md px-1 py-0.5 text-left text-base font-semibold tracking-tight transition-colors focus-visible:outline-none"
+        title={t('tooltip')}
+        className="group hover:bg-muted/50 focus-visible:bg-muted/50 -mx-1 -my-0.5 flex cursor-text items-center gap-1.5 rounded-md px-1 py-0.5 text-left text-base font-semibold tracking-tight transition-colors hover:underline hover:decoration-zinc-500 hover:decoration-dotted hover:underline-offset-4 focus-visible:outline-none"
         aria-label={t('editLabel', { name: optimisticName })}
         disabled={isPending}
       >
         <span className="truncate">{optimisticName}</span>
         <Edit2
-          className="h-3.5 w-3.5 shrink-0 opacity-0 transition-opacity group-hover:opacity-50 focus-visible:opacity-50"
+          className="h-3.5 w-3.5 shrink-0 opacity-30 transition-opacity group-hover:opacity-70 focus-visible:opacity-70"
           aria-hidden
           strokeWidth={1.5}
         />

--- a/src/components/features/__tests__/AccountCardEditableTitle.test.tsx
+++ b/src/components/features/__tests__/AccountCardEditableTitle.test.tsx
@@ -140,14 +140,14 @@ describe('<AccountCardEditableTitle />', () => {
     expect(button).toHaveAttribute('title', 'Cliquer pour renommer');
   });
 
-  it('keeps the pencil discreetly visible at rest (issue #98 affordance)', () => {
+  it('keeps the pencil discreetly visible at rest, emphasised on hover and keyboard focus (issue #98 affordance)', () => {
     renderWithIntl(<AccountCardEditableTitle {...baseProps} />);
     const button = screen.getByRole('button', { name: /Renommer le compte/i });
     // The Edit2 icon is the only <svg> child of the button.
     const icon = button.querySelector('svg');
     expect(icon).not.toBeNull();
-    // opacity-30 baseline + group-hover:opacity-70 emphasis.
-    expect(icon!.getAttribute('class')).toContain('opacity-30');
-    expect(icon!.getAttribute('class')).toContain('group-hover:opacity-70');
+    // opacity-30 at rest, opacity-70 on either pointer hover OR keyboard
+    // focus — the latter is critical for keyboard-only discoverability.
+    expect(icon).toHaveClass('opacity-30', 'group-hover:opacity-70', 'focus-visible:opacity-70');
   });
 });

--- a/src/components/features/__tests__/AccountCardEditableTitle.test.tsx
+++ b/src/components/features/__tests__/AccountCardEditableTitle.test.tsx
@@ -133,4 +133,21 @@ describe('<AccountCardEditableTitle />', () => {
     const button = screen.getByRole('button', { name: 'Renommer le compte « Compte Principal »' });
     expect(button).toBeInTheDocument();
   });
+
+  it('exposes a tooltip via the title attribute (issue #98)', () => {
+    renderWithIntl(<AccountCardEditableTitle {...baseProps} />);
+    const button = screen.getByRole('button', { name: /Renommer le compte/i });
+    expect(button).toHaveAttribute('title', 'Cliquer pour renommer');
+  });
+
+  it('keeps the pencil discreetly visible at rest (issue #98 affordance)', () => {
+    renderWithIntl(<AccountCardEditableTitle {...baseProps} />);
+    const button = screen.getByRole('button', { name: /Renommer le compte/i });
+    // The Edit2 icon is the only <svg> child of the button.
+    const icon = button.querySelector('svg');
+    expect(icon).not.toBeNull();
+    // opacity-30 baseline + group-hover:opacity-70 emphasis.
+    expect(icon!.getAttribute('class')).toContain('opacity-30');
+    expect(icon!.getAttribute('class')).toContain('group-hover:opacity-70');
+  });
 });

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -24,7 +24,7 @@ export async function Header({ variant = 'marketing', isAuthenticated = false }:
         <Link
           href="/"
           aria-label={t('homeAria')}
-          className="focus-visible:ring-brand-600 flex shrink-0 items-center gap-2 rounded-md transition-transform duration-150 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none active:scale-95"
+          className="focus-visible:ring-brand-600 flex shrink-0 items-center gap-2 rounded-md transition-transform duration-150 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-safe:active:scale-95"
         >
           <AnkoraLogo className="h-8 w-auto" />
         </Link>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -15,10 +15,16 @@ export async function Header({ variant = 'marketing', isAuthenticated = false }:
   return (
     <header className="border-border bg-background/80 sticky top-0 z-40 border-b backdrop-blur">
       <div className="mx-auto flex h-16 max-w-6xl items-center justify-between gap-2 px-4 md:px-6">
+        {/*
+         * The logo always points to the public landing (`/`), aligned with
+         * MktNav.tsx — clicking it from `/app` is now a deliberate
+         * navigation, which avoids the no-op + title-flash described in
+         * issue #95. The tactile press animation reinforces the click.
+         */}
         <Link
-          href={isAuthenticated ? '/app' : '/'}
+          href="/"
           aria-label={t('homeAria')}
-          className="focus-visible:ring-brand-600 flex shrink-0 items-center gap-2 rounded-md focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+          className="focus-visible:ring-brand-600 flex shrink-0 items-center gap-2 rounded-md transition-transform duration-150 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none active:scale-95"
         >
           <AnkoraLogo className="h-8 w-auto" />
         </Link>

--- a/src/components/layout/__tests__/Header.test.tsx
+++ b/src/components/layout/__tests__/Header.test.tsx
@@ -86,10 +86,11 @@ describe('<Header />', () => {
     expect(screen.getByLabelText('Accueil Ankora')).toHaveAttribute('href', '/');
   });
 
-  it('home link has the active:scale-95 tactile press animation (issue #95)', async () => {
+  it('home link has the tactile press animation, gated on motion-safe (issue #95)', async () => {
     await renderHeader({ variant: 'app', isAuthenticated: true });
     const link = screen.getByLabelText('Accueil Ankora');
-    expect(link.className).toContain('active:scale-95');
-    expect(link.className).toContain('transition-transform');
+    // The full animation set: transition-transform + duration-150 +
+    // motion-safe:active:scale-95 (the latter respects prefers-reduced-motion).
+    expect(link).toHaveClass('transition-transform', 'duration-150', 'motion-safe:active:scale-95');
   });
 });

--- a/src/components/layout/__tests__/Header.test.tsx
+++ b/src/components/layout/__tests__/Header.test.tsx
@@ -74,12 +74,22 @@ describe('<Header />', () => {
     expect(screen.getByRole('link', { name: 'Paramètres' })).toBeInTheDocument();
   });
 
-  it('home link points to / when unauthenticated, /app when authenticated', async () => {
+  it('home link always points to / regardless of auth state (issue #95)', async () => {
+    // Per issue #95, the logo always navigates to the public landing for
+    // consistency with MktNav.tsx. Clicking from /app is a deliberate
+    // "go home" action and avoids the title-flash no-op described in #95.
     const { unmount } = await renderHeader({ variant: 'marketing', isAuthenticated: false });
     expect(screen.getByLabelText('Accueil Ankora')).toHaveAttribute('href', '/');
     unmount();
 
     await renderHeader({ variant: 'marketing', isAuthenticated: true });
-    expect(screen.getByLabelText('Accueil Ankora')).toHaveAttribute('href', '/app');
+    expect(screen.getByLabelText('Accueil Ankora')).toHaveAttribute('href', '/');
+  });
+
+  it('home link has the active:scale-95 tactile press animation (issue #95)', async () => {
+    await renderHeader({ variant: 'app', isAuthenticated: true });
+    const link = screen.getByLabelText('Accueil Ankora');
+    expect(link.className).toContain('active:scale-95');
+    expect(link.className).toContain('transition-transform');
   });
 });


### PR DESCRIPTION
## Pourquoi

Mini-PR cosmétique bundlant 2 dettes UX P3 détectées empiriquement par @thierry pendant le smoke test PR-D2 sur prod (3 mai 2026 soir).

Closes #95
Closes #98

## Quoi

### Issue #95 — Logo Ankora click feedback

`src/components/layout/Header.tsx` :

- **`href` toujours `"/"`** (au lieu de la condition `isAuthenticated ? '/app' : '/'`). Aligne le comportement avec `MktNav.tsx` et élimine le no-op + title-flash quand l'utilisateur est déjà sur `/app`. Le logo devient un point de retour explicite vers la landing publique.
- **Animation tactile `active:scale-95 transition-transform duration-150`** sur le `<Link>` pour un feedback de press visible.

### Issue #98 — Affordance rename inline cards comptes

`src/components/features/AccountCardEditableTitle.tsx` :

- **Pencil Edit2 visible discrètement au repos** : `opacity-30 group-hover:opacity-70` (était `opacity-0 group-hover:opacity-50`). La feature de renommage devient découvrable sans hover initial.
- **Titre éditable avec affordance text** : `cursor-text` + dotted-underline au hover (`hover:underline hover:decoration-zinc-500 hover:decoration-dotted hover:underline-offset-4`).
- **Tooltip natif** via `title` attribute ("Cliquer pour renommer" / "Click to rename") qui s'affiche au survol.

### i18n

Nouvelle clé en 5 locales (parité 5/5) :

```
app.accounts.rename.tooltip
```

FR-BE et EN authored, NL/DE/ES stubbés en EN per scope.

### Tests

- `src/components/layout/__tests__/Header.test.tsx` :
  - Test `home link points to / when unauthenticated, /app when authenticated` mis à jour pour valider `href="/"` dans les **2 cas auth states** (cohérent avec le fix #95).
  - Nouveau test : assertion sur la présence des classes `active:scale-95` + `transition-transform`.
- `src/components/features/__tests__/AccountCardEditableTitle.test.tsx` :
  - Nouveau test : `title` attribute exposé avec la valeur traduite "Cliquer pour renommer".
  - Nouveau test : pencil baseline `opacity-30` + `group-hover:opacity-70`.

571 tests verts (3 nouveaux). Lint + typecheck + build green.

## Hors scope strict

- ❌ Aucune touche à `AccountCard.tsx` (Server Component reste tel quel)
- ❌ Aucune touche aux Server Actions
- ❌ Aucune migration ou modification data model
- ❌ Aucun autre fix UX

## Quality gates

- `npm run lint` → 0 erreur (3 warnings préexistants)
- `npm run lint:use-server` → ✓ All "use server" files contain only async exports
- `npm run typecheck` → 0 erreur
- `npm run test` → 571/571 pass (3 nouveaux)
- `npm run build` → ✓ Compiled successfully

## Test plan

- [x] Lint + typecheck + tests + build verts en local
- [ ] CI Lint + Typecheck + Unit Tests
- [ ] CI Security audit
- [ ] CI Playwright E2E
- [ ] Vercel Preview deployment SUCCESS
- [ ] Sourcery silent on dernier commit
- [ ] @thierry smoke test live :
  - Sur `/app`, cliquer le logo → navigation vers `/` (pas de title-flash)
  - Cliquer plus longuement sur le logo → effet tactile `active:scale-95`
  - Sur `/app`, hover sur une card compte → pencil Edit2 légèrement visible (opacity ≈30%) puis emphasized (≈70%) au hover
  - Survoler le titre éditable → curseur `cursor-text` + tooltip "Cliquer pour renommer" apparaît + underline pointillée

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Peaufiner l’UX du tableau de bord autour de la navigation via le logo de l’en‑tête et de l’ergonomie de renommage de la carte de compte.

Nouvelles fonctionnalités :
- Exposer une info-bulle de renommage en ligne et un indice visuel sur les cartes de compte afin de rendre l’action de renommage plus facile à découvrir.

Améliorations :
- Mettre à jour le logo de l’en-tête pour qu’il redirige toujours vers la page d’accueil publique et ajouter une animation de pression tactile pour une navigation vers l’accueil cohérente et explicite.
- Ajuster le style du titre éditable de la carte de compte afin que l’icône de crayon reste subtilement visible et que le texte du titre indique la possibilité de cliquer pour renommer via le curseur et les états de soulignement.
- Ajouter une nouvelle clé i18n pour l’info-bulle de renommage dans toutes les langues prises en charge.

Tests :
- Étendre les tests de l’en-tête pour couvrir la nouvelle URL cible du logo et les classes d’animation de pression tactile.
- Ajouter des tests pour le titre éditable de la carte de compte concernant le texte de l’info-bulle et le comportement mis à jour de visibilité de l’icône de crayon.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Polish dashboard UX around the header logo navigation and account card rename affordance.

New Features:
- Expose an inline rename tooltip and visual affordance on account cards to make the rename action more discoverable.

Enhancements:
- Update the header logo to always navigate to the public landing page and add a tactile press animation for consistent, explicit home navigation.
- Adjust the account card editable title styling so the pencil icon remains subtly visible and the title text indicates click-to-rename via cursor and underline states.
- Add a new i18n key for the rename tooltip across all supported locales.

Tests:
- Extend header tests to cover the new logo target URL and tactile press animation classes.
- Add account card editable title tests for the tooltip text and updated pencil icon visibility behavior.

</details>