### PR TITLE
chore(ci): fix Lighthouse timeout via GitHub Deployments API (PR-QA-1c-0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,10 @@ jobs:
         run: |
           set -e
           for i in $(seq 1 60); do
+            # Reset on each iteration so the log line below cannot show a
+            # stale value from a previous loop when this iteration finds no
+            # deployment yet (Sourcery feedback, PR #110).
+            state=""
             deployment_id=$(curl -sf \
               -H "Authorization: Bearer $GH_TOKEN" \
               -H "Accept: application/vnd.github+json" \
@@ -127,7 +131,7 @@ jobs:
                 "https://api.github.com/repos/$REPO/deployments/$deployment_id/statuses?per_page=1" \
                 | jq -r '.[0].state // empty') || true
               if [ "$state" = "success" ]; then
-                echo "Production deploy READY for $COMMIT_SHA (deployment id=$deployment_id)"
+                echo "Production deploy succeeded for $COMMIT_SHA (deployment id=$deployment_id)"
                 exit 0
               fi
               if [ "$state" = "failure" ] || [ "$state" = "error" ]; then
@@ -135,10 +139,10 @@ jobs:
                 exit 1
               fi
             fi
-            echo "Waiting for Vercel production deploy ($i/60, current state=${state:-pending})…"
+            echo "Waiting for production deploy ($i/60, current state=${state:-pending})…"
             sleep 10
           done
-          echo "Timeout: no READY production deploy for $COMMIT_SHA" >&2
+          echo "Timeout: no production deployment reached state=success for $COMMIT_SHA" >&2
           exit 1
       - name: Run Lighthouse against canonical production URL
         # The deployment-specific *.vercel.app hostname is gated by Vercel SSO

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,23 +100,42 @@ jobs:
           cache: npm
       - run: npm ci
       - name: Wait for Vercel production deploy
+        # Polls the GitHub Deployments API rather than the Vercel API directly.
+        # Rationale (PR-QA-1c-0, 4 mai 2026): the previous Vercel-API filter
+        # `meta.githubCommitSha == $sha AND target == 'production'` consistently
+        # missed the deploy even after Vercel reported it as success — likely a
+        # field-naming or target-naming mismatch on Vercel's side. GitHub
+        # Deployments API exposes the same data (Vercel pushes to it) and is
+        # accessible with the workflow's GITHUB_TOKEN, no extra secrets needed.
+        # The deployment status `success` corresponds to Vercel `readyState=READY`.
         env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMIT_SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
         run: |
           set -e
           for i in $(seq 1 60); do
-            payload=$(curl -sf -H "Authorization: Bearer $VERCEL_TOKEN" \
-              "https://api.vercel.com/v6/deployments?projectId=$VERCEL_PROJECT_ID&teamId=$VERCEL_TEAM_ID&target=production&limit=10") || true
-            ready=$(echo "$payload" | jq -r --arg sha "$COMMIT_SHA" \
-              '.deployments[]? | select(.meta.githubCommitSha == $sha and .readyState == "READY") | .url' | head -n1)
-            if [ -n "$ready" ] && [ "$ready" != "null" ]; then
-              echo "Production deploy READY for $COMMIT_SHA: https://$ready"
-              exit 0
+            deployment_id=$(curl -sf \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$REPO/deployments?ref=$COMMIT_SHA&environment=Production&per_page=1" \
+              | jq -r '.[0].id // empty') || true
+            if [ -n "$deployment_id" ]; then
+              state=$(curl -sf \
+                -H "Authorization: Bearer $GH_TOKEN" \
+                -H "Accept: application/vnd.github+json" \
+                "https://api.github.com/repos/$REPO/deployments/$deployment_id/statuses?per_page=1" \
+                | jq -r '.[0].state // empty') || true
+              if [ "$state" = "success" ]; then
+                echo "Production deploy READY for $COMMIT_SHA (deployment id=$deployment_id)"
+                exit 0
+              fi
+              if [ "$state" = "failure" ] || [ "$state" = "error" ]; then
+                echo "Production deploy FAILED for $COMMIT_SHA (state=$state)" >&2
+                exit 1
+              fi
             fi
-            echo "Waiting for Vercel production deploy ($i/60)…"
+            echo "Waiting for Vercel production deploy ($i/60, current state=${state:-pending})…"
             sleep 10
           done
           echo "Timeout: no READY production deploy for $COMMIT_SHA" >&2


### PR DESCRIPTION
Closes #109

## Contexte

Sprint Mobile Recovery 2026-05-04 — insertion @cowork. Le job Lighthouse CI sur main timeout depuis (au moins) le merge PR-QA-1b (commit 48ba7798) avec le message :

\`\`\`
Timeout: no READY production deploy for <SHA>
\`\`\`

Cette PR sera bloquante dès que PR-QA-1c-1 touchera \`src/\` (le job Lighthouse n'est plus SKIPPED). On la fixe MAINTENANT avant de lancer la séquence fix bugs.

## Cause racine

Le step \"Wait for Vercel production deploy\" interrogeait l'API Vercel directement avec ce filtre :

\`\`\`bash
.deployments[]? | select(.meta.githubCommitSha == \$sha
                          and .readyState == \"READY\"
                          and target == \"production\")
\`\`\`

Vercel a bien créé le production deploy (id 4568902227, state=success à 10:20:22, target_url=https://ankora-...vercel.app) — confirmé via GitHub Deployments API. Mais le filtre Vercel-API ne matche jamais. Cause exacte non diagnostiquable depuis l'extérieur sans \`VERCEL_TOKEN\` local (probablement field-naming ou semantics \`target\` différent côté Vercel API entre la docs et la réalité).

## Fix

Switch du poll **Vercel API → GitHub Deployments API**. Avantages :

- Pas de \`VERCEL_TOKEN\` requis pour ce step (le \`GITHUB_TOKEN\` natif du workflow suffit)
- Données identiques (Vercel push vers GitHub Deployments)
- Plus robuste (un standard GitHub vs un standard Vercel-spécifique)
- Bonus : exit fail-fast sur \`state=failure|error\` (manquant avant)

Logique de polling identique : 60 itérations × 10s = 10 min window.

## Validation locale (sans VERCEL_TOKEN)

\`\`\`bash
$ gh api \"repos/thierryvm/ankora/deployments?ref=48ba7798...&environment=Production\"
[{\"id\": 4568902227, \"environment\": \"Production\", \"sha\": \"48ba7798...\"}]

$ gh api \"repos/thierryvm/ankora/deployments/4568902227/statuses\"
[{\"state\": \"success\", \"target_url\": \"https://ankora-...vercel.app\"}]
\`\`\`

→ La nouvelle requête trouve le deploy ready instantanément.

## Validation post-merge (le paradoxe)

Le job Lighthouse a \`if: github.event_name == 'push' && github.ref == 'refs/heads/main'\`, donc il ne tourne PAS sur cette PR — il sera SKIPPED. Validation réelle = observer le push sur main post-merge :

- ✅ Lighthouse vert dans les ~2-3 min (vs 10 min timeout précédemment)
- → fermer #109 quand observé

Si malgré le fix Lighthouse reste rouge, hot-fix à prévoir (rollback minimal vers logique précédente).

## DoD Ankora 5/5

- [x] Lint + Typecheck + Tests : devraient passer (zéro fichier touché en \`src/\`)
- [x] Sourcery : pas de point sensible attendu (workflow YAML simple)
- [x] Pas de conflit main
- [x] Rapport final livré (vault Athenaeum)
- [ ] Lighthouse vert : **paradoxe assumé** par @cowork — validation post-merge

## Hors scope

- ❌ Aucun fix bug UI mobile (= PR-QA-1c-1 à c-7 à venir)
- ❌ Aucune optimisation perf bundle (= PR séparée future)
- ❌ Aucun touche aux 12 agents
- ❌ Aucun touche aux tests Vitest/Playwright
- ❌ Aucun touche aux secrets repo (VERCEL_TOKEN/TEAM_ID/PROJECT_ID gardés au cas où d'autres workflows les utilisent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Améliorations :
- Remplacer l’interrogation directe de l’API Vercel par l’API GitHub Deployments afin de détecter l’état de préparation en production en utilisant le `GITHUB_TOKEN` du workflow, et gérer explicitement les états de succès, d’échec et d’erreur.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Replace direct Vercel API polling with GitHub Deployments API to detect production readiness using the workflow GITHUB_TOKEN and handle success, failure, and error states explicitly.

</details>