### PR TITLE
fix(legal): correct publisher identity Thierry Van Mele -> Vanmeeteren (5 locales)

### DIFF
--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -386,7 +386,7 @@
       "title": "Datenschutzerklärung",
       "s1": {
         "heading": "1. Verantwortlicher",
-        "body": "Ankora, herausgegeben von Thierry Van Mele (Belgien). Kontakt: <mail>thierryvm@gmail.com</mail>."
+        "body": "Ankora, herausgegeben von Thierry Vanmeeteren (Belgien). Kontakt: <mail>thierryvm@gmail.com</mail>."
       },
       "s2": {
         "heading": "2. Erhobene Daten",

--- a/messages/en.json
+++ b/messages/en.json
@@ -386,7 +386,7 @@
       "title": "Privacy policy",
       "s1": {
         "heading": "1. Data controller",
-        "body": "Ankora, published by Thierry Van Mele (Belgium). Contact: <mail>thierryvm@gmail.com</mail>."
+        "body": "Ankora, published by Thierry Vanmeeteren (Belgium). Contact: <mail>thierryvm@gmail.com</mail>."
       },
       "s2": {
         "heading": "2. Data collected",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -386,7 +386,7 @@
       "title": "Política de privacidad",
       "s1": {
         "heading": "1. Responsable del tratamiento",
-        "body": "Ankora, editado por Thierry Van Mele (Bélgica). Contacto: <mail>thierryvm@gmail.com</mail>."
+        "body": "Ankora, editado por Thierry Vanmeeteren (Bélgica). Contacto: <mail>thierryvm@gmail.com</mail>."
       },
       "s2": {
         "heading": "2. Datos recogidos",

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -386,7 +386,7 @@
       "title": "Politique de confidentialité",
       "s1": {
         "heading": "1. Responsable de traitement",
-        "body": "Ankora, édité par Thierry Van Mele (Belgique). Contact : <mail>thierryvm@gmail.com</mail>."
+        "body": "Ankora, édité par Thierry Vanmeeteren (Belgique). Contact : <mail>thierryvm@gmail.com</mail>."
       },
       "s2": {
         "heading": "2. Données collectées",

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -386,7 +386,7 @@
       "title": "Privacybeleid",
       "s1": {
         "heading": "1. Verwerkingsverantwoordelijke",
-        "body": "Ankora, uitgegeven door Thierry Van Mele (België). Contact: <mail>thierryvm@gmail.com</mail>."
+        "body": "Ankora, uitgegeven door Thierry Vanmeeteren (België). Contact: <mail>thierryvm@gmail.com</mail>."
       },
       "s2": {
         "heading": "2. Verzamelde gegevens",


### PR DESCRIPTION
## Contexte

P0 bug identifié par @cowork dans audit pages légales 6 mai 2026.

\messages/*.json legal.privacy.s1.body\ contenait \Thierry Van Mele\ au lieu de \Thierry Vanmeeteren\.

## Fix

Correction \Van Mele -> Vanmeeteren\ appliquée aux 5 locales :
- fr-BE
- en
- nl-BE
- es-ES
- de-DE

Parité garantie via grep automatique post-fix.

## Conformité RGPD

L'identité du \Responsable de traitement\ (page Privacy section 1) DOIT être exacte selon RGPD art. 13. Une fausse identité expose à sanctions APD belge. Fix CRITIQUE pre-launch v1.0.

## Refs

- ADR P0 #103 historique fix Vanmansart -> vanmeeteren (sujet similaire avril 2026)
- Audit pages légales @cowork 6 mai 2026 (handoff Obsidian Ankora)
- Issue #116 BUG-iOS-011 (non lié)

## DoD

- [x] 5 locales fixées
- [x] Parité grep validée
- [ ] CI verte
- [ ] Validation @thierry post-merge sur prod

## Summary by Sourcery

Corrections de bugs :
- Correction de l’orthographe du nom de l’éditeur dans la section sur la politique de confidentialité pour les fichiers de messages fr-BE, en, nl-BE, es-ES et de-DE.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the misspelled publisher name in the privacy policy section for fr-BE, en, nl-BE, es-ES, and de-DE message files.

</details>