### PR TITLE
fix(footer): make Ankora logo clickable matching Header pattern

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -11,7 +11,13 @@ export async function Footer() {
     <footer className="border-border bg-card border-t">
       <div className="mx-auto flex max-w-6xl flex-col items-start justify-between gap-6 px-4 py-10 md:flex-row md:items-center md:px-6">
         <div className="flex items-center gap-2">
-          <AnkoraLogo className="h-7 w-auto" />
+          <Link
+            href="/"
+            aria-label={tCommon('homeAria')}
+            className="focus-visible:ring-brand-600 flex shrink-0 items-center rounded-md transition-transform duration-150 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-safe:active:scale-95"
+          >
+            <AnkoraLogo className="h-7 w-auto" />
+          </Link>
           <span className="text-muted-foreground text-sm">
             {t('copyrightNotice', { year: new Date().getFullYear() })}
           </span>


### PR DESCRIPTION
Le logo Ankora dans le Footer etait inerte alors que celui du Header est cliquable. Pattern UX universel manquant signale par @thierry. Wrapper AnkoraLogo dans Link href='/' avec aria-label tCommon('homeAria') reuse + meme pattern visuel que Header.

## Summary by Sourcery

Nouvelles fonctionnalités :
- Ajout d’un lien cliquable vers la page d’accueil autour du logo Ankora dans le pied de page afin de s’aligner sur le modèle d’interaction de l’en-tête.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Add a clickable home link around the Ankora logo in the footer to align with the header interaction pattern.

</details>