### PR TITLE
feat(consent): RGPD-compliant granular cookies management (PR-LEGAL-1)

### DIFF
--- a/e2e/cookies-consent.spec.ts
+++ b/e2e/cookies-consent.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect, type Page } from '@playwright/test';
+
+const STORAGE_KEY = 'ankora.consent.v1';
+const REOPEN_KEY = 'ankora.consent.reopen';
+
+const clearConsentStorage = async (page: Page) => {
+  await page.addInitScript(
+    ([k1, k2]: [string, string]) => {
+      window.localStorage.removeItem(k1);
+      window.localStorage.removeItem(k2);
+    },
+    [STORAGE_KEY, REOPEN_KEY] as [string, string],
+  );
+};
+
+test.describe('PR-LEGAL-1 — cookies consent flow', () => {
+  test('first visit shows the banner with three actions', async ({ page }) => {
+    await clearConsentStorage(page);
+    await page.goto('/');
+    await expect(page.getByRole('button', { name: 'Essentiels uniquement' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Personnaliser' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Tout accepter' })).toBeVisible();
+  });
+
+  test('Accept all dismisses the banner and persists analytics + marketing in localStorage', async ({
+    page,
+  }) => {
+    await clearConsentStorage(page);
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Tout accepter' }).click();
+    await expect(page.getByRole('button', { name: 'Tout accepter' })).not.toBeVisible();
+    const stored = await page.evaluate((key) => window.localStorage.getItem(key), STORAGE_KEY);
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored as string) as { analytics: boolean; marketing: boolean };
+    expect(parsed.analytics).toBe(true);
+    expect(parsed.marketing).toBe(true);
+  });
+
+  test('Customize → analytics on, marketing off → save persists granular choice', async ({
+    page,
+  }) => {
+    await clearConsentStorage(page);
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Personnaliser' }).click();
+    await page.getByRole('checkbox', { name: "Analyse d'usage" }).check();
+    await page.getByRole('button', { name: 'Enregistrer mes préférences' }).click();
+    await expect(page.getByRole('button', { name: 'Tout accepter' })).not.toBeVisible();
+    const stored = await page.evaluate((key) => window.localStorage.getItem(key), STORAGE_KEY);
+    const parsed = JSON.parse(stored as string) as { analytics: boolean; marketing: boolean };
+    expect(parsed.analytics).toBe(true);
+    expect(parsed.marketing).toBe(false);
+  });
+
+  test('Footer "Modifier mes préférences cookies" reopens the banner from any page', async ({
+    page,
+  }) => {
+    // Start with an existing decision so the banner is dismissed initially.
+    await page.addInitScript(
+      ([k]: [string]) => {
+        window.localStorage.setItem(
+          k,
+          JSON.stringify({
+            version: '1.0.0',
+            analytics: true,
+            marketing: false,
+            decidedAt: '2026-01-01T00:00:00.000Z',
+          }),
+        );
+      },
+      [STORAGE_KEY] as [string],
+    );
+    await page.goto('/');
+    // Banner not visible because a decision already exists.
+    await expect(page.getByRole('button', { name: 'Tout accepter' })).not.toBeVisible();
+
+    // Click the footer reopen button.
+    await page.getByRole('button', { name: 'Modifier mes préférences cookies' }).click();
+    await expect(page.getByRole('button', { name: 'Tout accepter' })).toBeVisible();
+  });
+});

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -462,11 +462,16 @@
       "manageHeading": "Deine Präferenzen verwalten",
       "manageBody1": "Du kannst deine Einwilligungen jederzeit unter <b>Einstellungen → Datenschutz</b> ändern oder indem du im Footer auf „Cookies verwalten“ klickst.",
       "manageBody2": "Das Ablehnen nicht-essenzieller Cookies beeinträchtigt das Erlebnis nicht: Ankora bleibt voll funktionsfähig.",
+      "manageMethodsHeading": "Wie verwalte ich meine Cookies",
+      "manageMethod1": "Beim ersten Besuch bietet das Banner drei Optionen: nur essenzielle, anpassen oder alle akzeptieren.",
+      "manageMethod2": "Eingeloggt kannst du in Einstellungen → Cookies & Datenschutz jede Kategorie umschalten.",
+      "manageMethod3": "Auf jeder Seite öffnet der Link \"Cookie-Einstellungen verwalten\" in der Fußzeile das Banner erneut.",
+      "withdrawalHeading": "Widerruf der Einwilligung",
+      "withdrawalBody": "Gemäß DSGVO (Art. 7(3)) ist der Widerruf der Einwilligung genauso einfach wie deren Erteilung. Drei gleichwertige Methoden: 1) Einstellungen → Cookies & Datenschutz → \"Meine Wahl zurücksetzen\". 2) Fußzeile → \"Cookie-Einstellungen verwalten\". 3) E-Mail an thierryvm@gmail.com mit Betreff \"Cookie-Einwilligung widerrufen\".",
       "lifetimeHeading": "Lebensdauer",
       "lifetimeItem1": "Session: Ende der Navigation",
       "lifetimeItem2": "Präferenzen: 12 Monate",
       "lifetimeItem3": "Analytics: 6 Monate (falls akzeptiert)",
-      "draft": "Diese Cookie-Richtlinienseite wird derzeit erstellt.",
       "contact": "Bei Fragen kontaktiere uns: thierryvm@gmail.com",
       "backHome": "Zurück zur Startseite"
     }
@@ -480,9 +485,22 @@
   },
   "consent": {
     "title": "Cookies und Datenschutz",
-    "body": "Wir verwenden nur essenzielle Cookies, um dich anzumelden. Analyse-Cookies sind standardmäßig deaktiviert — du kannst sie aktivieren, wenn du uns helfen möchtest, Ankora zu verbessern. Du kannst deine Meinung jederzeit über <link>die Cookie-Richtlinie</link> ändern.",
+    "body": "Wir verwenden nur essenzielle Cookies, um dich anzumelden. Analyse- und Marketing-Cookies sind standardmäßig deaktiviert — du kannst sie aktivieren, wenn du uns helfen möchtest, Ankora zu verbessern. Du kannst deine Meinung jederzeit über <link>die Cookie-Richtlinie</link> ändern.",
     "essentialOnly": "Nur essenziell",
-    "acceptAnalytics": "Analysen akzeptieren"
+    "acceptAll": "Alle akzeptieren",
+    "customize": {
+      "button": "Anpassen",
+      "save": "Meine Einstellungen speichern",
+      "cancel": "Abbrechen",
+      "legend": "Cookie-Kategorien",
+      "essentialLabel": "Essenziell",
+      "essentialBadge": "(immer aktiv)",
+      "essentialDescription": "Sitzung, Sicherheit, Sprach- und Theme-Einstellungen. Für die Funktion von Ankora notwendig.",
+      "analyticsLabel": "Nutzungsanalyse",
+      "analyticsDescription": "Anonyme Statistiken, um zu verstehen, welche Seiten am meisten helfen. Keine personenbezogenen Daten.",
+      "marketingLabel": "Marketing",
+      "marketingDescription": "Reserviert für zukünftige Kampagnen. Phase 1 von Ankora: keine Marketing-Cookies aktiv."
+    }
   },
   "footer": {
     "copyright": "© {year} — Alle Rechte vorbehalten",
@@ -490,7 +508,8 @@
     "privacy": "Datenschutz",
     "cookies": "Cookies verwalten",
     "faq": "FAQ",
-    "copyrightNotice": "© {year} Ankora™. Alle Rechte vorbehalten."
+    "copyrightNotice": "© {year} Ankora™. Alle Rechte vorbehalten.",
+    "cookiePreferences": "Cookie-Einstellungen verwalten"
   },
   "auth": {
     "login": {
@@ -775,6 +794,23 @@
         "submit": "Mein Konto löschen",
         "submitting": "Planen…",
         "toastScheduled": "Löschung geplant — du hast 30 Tage zum Widerrufen"
+      },
+      "cookies": {
+        "title": "Cookies & Datenschutz",
+        "description": "Wähle aus, welchen Cookie-Kategorien du zustimmst. Deine Wahl wird mit unserem Server synchronisiert (DSGVO-Audit) und kann jederzeit geändert werden.",
+        "essentialLabel": "Essenziell",
+        "essentialBadge": "(immer aktiv)",
+        "essentialDescription": "Sitzung, Sicherheit, Sprach- und Theme-Einstellungen. Für die Funktion von Ankora notwendig.",
+        "analyticsLabel": "Nutzungsanalyse",
+        "analyticsDescription": "Anonyme Statistiken, um zu verstehen, welche Seiten am meisten helfen. Keine personenbezogenen Daten.",
+        "marketingLabel": "Marketing",
+        "marketingDescription": "Reserviert für zukünftige Kampagnen. Phase 1 von Ankora: keine Marketing-Cookies aktiv.",
+        "resetButton": "Meine Wahl zurücksetzen",
+        "resetHint": "Dies löscht deine Entscheidung und zeigt das Banner beim nächsten Laden erneut an.",
+        "noDecisionHint": "Du hast auf diesem Gerät noch keine Wahl getroffen. Das Banner erscheint bei deinem nächsten Besuch.",
+        "toastSaved": "Cookie-Einstellungen gespeichert.",
+        "toastReset": "Wahl zurückgesetzt. Das Banner erscheint erneut.",
+        "toastError": "Deine Wahl konnte nicht gespeichert werden. Versuche es erneut."
       }
     },
     "simulator": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -462,11 +462,16 @@
       "manageHeading": "Manage your preferences",
       "manageBody1": "You can change your consents at any time in <b>Settings → Privacy</b> or by clicking \"Manage cookies\" in the footer.",
       "manageBody2": "Declining non-essential cookies does not degrade the experience: Ankora remains fully functional.",
+      "manageMethodsHeading": "How to manage my cookies",
+      "manageMethod1": "On first visit, the banner offers three choices: essential only, customize, or accept all.",
+      "manageMethod2": "When logged in, Settings → Cookies & privacy lets you toggle each category.",
+      "manageMethod3": "From any page, the \"Manage cookie preferences\" link in the footer reopens the banner.",
+      "withdrawalHeading": "Withdrawing consent",
+      "withdrawalBody": "Under GDPR (art. 7(3)), withdrawing consent is as easy as giving it. Three equivalent methods: 1) Settings → Cookies & privacy → \"Reset my choice\". 2) Footer → \"Manage cookie preferences\". 3) Email thierryvm@gmail.com with subject \"Cookies consent withdrawal\".",
       "lifetimeHeading": "Lifetime",
       "lifetimeItem1": "Session: end of browsing",
       "lifetimeItem2": "Preferences: 12 months",
       "lifetimeItem3": "Analytics: 6 months (if accepted)",
-      "draft": "This cookie policy page is being drafted.",
       "contact": "For any questions, contact us: thierryvm@gmail.com",
       "backHome": "Back to home"
     }
@@ -480,9 +485,22 @@
   },
   "consent": {
     "title": "Cookies and privacy",
-    "body": "We only use essential cookies to log you in. Analytics cookies are off by default — you can turn them on if you want to help us improve Ankora. You can change your mind at any time via <link>the cookie policy</link>.",
+    "body": "We only use essential cookies to log you in. Analytics and marketing cookies are off by default — you can turn them on if you want to help us improve Ankora. You can change your mind at any time via <link>the cookie policy</link>.",
     "essentialOnly": "Essential only",
-    "acceptAnalytics": "Accept analytics"
+    "acceptAll": "Accept all",
+    "customize": {
+      "button": "Customize",
+      "save": "Save my preferences",
+      "cancel": "Cancel",
+      "legend": "Cookie categories",
+      "essentialLabel": "Essential",
+      "essentialBadge": "(always on)",
+      "essentialDescription": "Session, security, language and theme preferences. Required for Ankora to work.",
+      "analyticsLabel": "Usage analytics",
+      "analyticsDescription": "Anonymous stats to understand which pages help most. No personal data.",
+      "marketingLabel": "Marketing",
+      "marketingDescription": "Reserved for future campaigns. Phase 1 of Ankora: no marketing cookies active."
+    }
   },
   "footer": {
     "copyright": "© {year} — All rights reserved",
@@ -490,7 +508,8 @@
     "privacy": "Privacy",
     "cookies": "Manage cookies",
     "faq": "FAQ",
-    "copyrightNotice": "© {year} Ankora™. All rights reserved."
+    "copyrightNotice": "© {year} Ankora™. All rights reserved.",
+    "cookiePreferences": "Manage cookie preferences"
   },
   "auth": {
     "login": {
@@ -775,6 +794,23 @@
         "submit": "Delete my account",
         "submitting": "Scheduling…",
         "toastScheduled": "Deletion scheduled — you have 30 days to cancel"
+      },
+      "cookies": {
+        "title": "Cookies & privacy",
+        "description": "Choose which cookie categories you accept. Your choice is synced with our server (GDPR audit) and you can change it at any time.",
+        "essentialLabel": "Essential",
+        "essentialBadge": "(always on)",
+        "essentialDescription": "Session, security, language and theme preferences. Required for Ankora to work.",
+        "analyticsLabel": "Usage analytics",
+        "analyticsDescription": "Anonymous stats to understand which pages help most. No personal data.",
+        "marketingLabel": "Marketing",
+        "marketingDescription": "Reserved for future campaigns. Phase 1 of Ankora: no marketing cookies active.",
+        "resetButton": "Reset my choice",
+        "resetHint": "This clears your decision and re-prompts the banner on the next page load.",
+        "noDecisionHint": "You haven't made a choice on this device yet. The banner will show on your next visit.",
+        "toastSaved": "Cookie preferences saved.",
+        "toastReset": "Choice reset. The banner will reappear.",
+        "toastError": "Could not save your choice. Try again."
       }
     },
     "simulator": {

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -462,11 +462,16 @@
       "manageHeading": "Gestionar tus preferencias",
       "manageBody1": "Puedes modificar tus consentimientos en cualquier momento desde <b>Ajustes → Privacidad</b> o pulsando «Gestionar cookies» en el pie de página.",
       "manageBody2": "Rechazar los cookies no esenciales no degrada la experiencia: Ankora sigue siendo totalmente funcional.",
+      "manageMethodsHeading": "Cómo gestionar mis cookies",
+      "manageMethod1": "En la primera visita, el banner ofrece tres opciones: solo esenciales, personalizar o aceptar todo.",
+      "manageMethod2": "Una vez identificado, en Ajustes → Cookies y privacidad puedes activar/desactivar cada categoría.",
+      "manageMethod3": "Desde cualquier página, el enlace \"Gestionar preferencias de cookies\" en el pie de página reabre el banner.",
+      "withdrawalHeading": "Retirada del consentimiento",
+      "withdrawalBody": "Según el RGPD (art. 7(3)), retirar el consentimiento es tan fácil como darlo. Tres métodos equivalentes: 1) Ajustes → Cookies y privacidad → \"Restablecer mi elección\". 2) Pie de página → \"Gestionar preferencias de cookies\". 3) Correo a thierryvm@gmail.com con el asunto \"Retirada del consentimiento de cookies\".",
       "lifetimeHeading": "Duración",
       "lifetimeItem1": "Sesión: fin de la navegación",
       "lifetimeItem2": "Preferencias: 12 meses",
       "lifetimeItem3": "Analíticas: 6 meses (si se aceptan)",
-      "draft": "Esta página de política de cookies está en proceso de redacción.",
       "contact": "Para cualquier pregunta, contáctanos: thierryvm@gmail.com",
       "backHome": "Volver al inicio"
     }
@@ -480,9 +485,22 @@
   },
   "consent": {
     "title": "Cookies y privacidad",
-    "body": "Solo usamos los cookies esenciales para conectarte. Los cookies de análisis están desactivados por defecto — puedes activarlos si quieres ayudarnos a mejorar Ankora. Puedes cambiar de opinión en cualquier momento desde <link>la política de cookies</link>.",
+    "body": "Solo usamos los cookies esenciales para conectarte. Los cookies de análisis y marketing están desactivados por defecto — puedes activarlos si quieres ayudarnos a mejorar Ankora. Puedes cambiar de opinión en cualquier momento desde <link>la política de cookies</link>.",
     "essentialOnly": "Solo esenciales",
-    "acceptAnalytics": "Aceptar los análisis"
+    "acceptAll": "Aceptar todo",
+    "customize": {
+      "button": "Personalizar",
+      "save": "Guardar mis preferencias",
+      "cancel": "Cancelar",
+      "legend": "Categorías de cookies",
+      "essentialLabel": "Esenciales",
+      "essentialBadge": "(siempre activos)",
+      "essentialDescription": "Sesión, seguridad, preferencias de idioma y tema. Necesarios para que Ankora funcione.",
+      "analyticsLabel": "Análisis de uso",
+      "analyticsDescription": "Estadísticas anónimas para entender qué páginas ayudan más. Sin datos personales.",
+      "marketingLabel": "Marketing",
+      "marketingDescription": "Reservados para futuras campañas. Fase 1 de Ankora: ningún cookie de marketing activo."
+    }
   },
   "footer": {
     "copyright": "© {year} — Todos los derechos reservados",
@@ -490,7 +508,8 @@
     "privacy": "Privacidad",
     "cookies": "Gestionar cookies",
     "faq": "FAQ",
-    "copyrightNotice": "© {year} Ankora™. Todos los derechos reservados."
+    "copyrightNotice": "© {year} Ankora™. Todos los derechos reservados.",
+    "cookiePreferences": "Gestionar preferencias de cookies"
   },
   "auth": {
     "login": {
@@ -775,6 +794,23 @@
         "submit": "Eliminar mi cuenta",
         "submitting": "Programando…",
         "toastScheduled": "Eliminación programada — tienes 30 días para cancelar"
+      },
+      "cookies": {
+        "title": "Cookies y privacidad",
+        "description": "Elige qué categorías de cookies aceptas. Tu elección se sincroniza con nuestro servidor (auditoría RGPD) y puedes modificarla en cualquier momento.",
+        "essentialLabel": "Esenciales",
+        "essentialBadge": "(siempre activos)",
+        "essentialDescription": "Sesión, seguridad, preferencias de idioma y tema. Necesarios para que Ankora funcione.",
+        "analyticsLabel": "Análisis de uso",
+        "analyticsDescription": "Estadísticas anónimas para entender qué páginas ayudan más. Sin datos personales.",
+        "marketingLabel": "Marketing",
+        "marketingDescription": "Reservados para futuras campañas. Fase 1 de Ankora: ningún cookie de marketing activo.",
+        "resetButton": "Restablecer mi elección",
+        "resetHint": "Esto borra tu decisión y muestra de nuevo el banner en la próxima carga.",
+        "noDecisionHint": "Aún no has elegido en este dispositivo. El banner aparecerá en tu próxima visita.",
+        "toastSaved": "Preferencias de cookies guardadas.",
+        "toastReset": "Elección restablecida. El banner reaparecerá.",
+        "toastError": "No se ha podido guardar tu elección. Inténtalo de nuevo."
       }
     },
     "simulator": {

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -462,11 +462,16 @@
       "manageHeading": "Gérer tes préférences",
       "manageBody1": "Tu peux modifier tes consentements à tout moment dans <b>Paramètres → Confidentialité</b> ou en cliquant sur « Gérer les cookies » dans le pied de page.",
       "manageBody2": "Refuser les cookies non essentiels ne dégrade pas l'expérience : Ankora reste entièrement fonctionnel.",
+      "manageMethodsHeading": "Comment gérer mes cookies",
+      "manageMethod1": "À la première visite, le bandeau te propose trois choix : essentiels uniquement, personnaliser, ou tout accepter.",
+      "manageMethod2": "Connecté, dans Paramètres → Cookies & confidentialité, tu peux activer/désactiver chaque catégorie.",
+      "manageMethod3": "Depuis n'importe quelle page, le lien « Modifier mes préférences cookies » dans le pied de page rouvre le bandeau.",
+      "withdrawalHeading": "Retrait du consentement",
+      "withdrawalBody": "Conformément au RGPD (art. 7(3)), retirer ton consentement est aussi simple que de le donner. Trois méthodes équivalentes : 1) Paramètres → Cookies & confidentialité → bouton « Réinitialiser mon choix ». 2) Pied de page → « Modifier mes préférences cookies ». 3) Email à thierryvm@gmail.com avec l'objet « Retrait consentement cookies ».",
       "lifetimeHeading": "Durée de vie",
       "lifetimeItem1": "Session : fin de navigation",
       "lifetimeItem2": "Préférences : 12 mois",
       "lifetimeItem3": "Analytics : 6 mois (si acceptés)",
-      "draft": "Cette page de politique cookies est en cours de rédaction.",
       "contact": "Pour toute question, contacte-nous : thierryvm@gmail.com",
       "backHome": "Retour à l'accueil"
     }
@@ -480,9 +485,22 @@
   },
   "consent": {
     "title": "Cookies et vie privée",
-    "body": "On utilise uniquement les cookies essentiels pour te connecter. Les cookies d'analyse sont désactivés par défaut — tu peux les activer si tu veux nous aider à améliorer Ankora. Tu peux changer d'avis à tout moment via <link>la politique cookies</link>.",
+    "body": "On utilise uniquement les cookies essentiels pour te connecter. Les cookies d'analyse et marketing sont désactivés par défaut — tu peux les activer si tu veux nous aider à améliorer Ankora. Tu peux changer d'avis à tout moment via <link>la politique cookies</link>.",
     "essentialOnly": "Essentiels uniquement",
-    "acceptAnalytics": "Accepter les analyses"
+    "acceptAll": "Tout accepter",
+    "customize": {
+      "button": "Personnaliser",
+      "save": "Enregistrer mes préférences",
+      "cancel": "Annuler",
+      "legend": "Catégories de cookies",
+      "essentialLabel": "Essentiels",
+      "essentialBadge": "(toujours actifs)",
+      "essentialDescription": "Session, sécurité, préférence de langue et de thème. Indispensables au fonctionnement d'Ankora.",
+      "analyticsLabel": "Analyse d'usage",
+      "analyticsDescription": "Statistiques anonymisées pour comprendre quelles pages aident le plus. Aucune donnée personnelle.",
+      "marketingLabel": "Marketing",
+      "marketingDescription": "Réservés à de futures campagnes. Phase 1 d'Ankora : aucun cookie marketing actif."
+    }
   },
   "footer": {
     "copyright": "© {year} — Tous droits réservés",
@@ -490,7 +508,8 @@
     "privacy": "Confidentialité",
     "cookies": "Gérer les cookies",
     "faq": "FAQ",
-    "copyrightNotice": "© {year} Ankora™. Tous droits réservés."
+    "copyrightNotice": "© {year} Ankora™. Tous droits réservés.",
+    "cookiePreferences": "Modifier mes préférences cookies"
   },
   "auth": {
     "login": {
@@ -775,6 +794,23 @@
         "submit": "Supprimer mon compte",
         "submitting": "Programmation…",
         "toastScheduled": "Suppression programmée — tu as 30 jours pour annuler"
+      },
+      "cookies": {
+        "title": "Cookies & confidentialité",
+        "description": "Choisis quelles catégories de cookies tu acceptes. Ton choix est synchronisé avec notre serveur (audit RGPD) et tu peux le modifier à tout moment.",
+        "essentialLabel": "Essentiels",
+        "essentialBadge": "(toujours actifs)",
+        "essentialDescription": "Session, sécurité, préférence de langue et de thème. Indispensables au fonctionnement d'Ankora.",
+        "analyticsLabel": "Analyse d'usage",
+        "analyticsDescription": "Statistiques anonymisées pour comprendre quelles pages aident le plus. Aucune donnée personnelle.",
+        "marketingLabel": "Marketing",
+        "marketingDescription": "Réservés à de futures campagnes. Phase 1 d'Ankora : aucun cookie marketing actif.",
+        "resetButton": "Réinitialiser mon choix",
+        "resetHint": "Le bouton supprime ta décision et te repropose le bandeau au prochain chargement.",
+        "noDecisionHint": "Tu n'as pas encore choisi sur cet appareil. Le bandeau s'affichera à ta prochaine visite.",
+        "toastSaved": "Préférences cookies enregistrées.",
+        "toastReset": "Choix réinitialisé. Le bandeau réapparaîtra.",
+        "toastError": "Impossible d'enregistrer ton choix. Réessaie."
       }
     },
     "simulator": {

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -462,11 +462,16 @@
       "manageHeading": "Je voorkeuren beheren",
       "manageBody1": "Je kunt je toestemmingen op elk moment wijzigen in <b>Instellingen → Privacy</b> of door op « Cookies beheren » te klikken in de voettekst.",
       "manageBody2": "Niet-essentiële cookies weigeren heeft geen invloed op de ervaring: Ankora blijft volledig functioneel.",
+      "manageMethodsHeading": "Hoe mijn cookies beheren",
+      "manageMethod1": "Bij het eerste bezoek biedt het banner drie keuzes: enkel essentiële, aanpassen of alles aanvaarden.",
+      "manageMethod2": "Aangemeld kun je in Instellingen → Cookies & privacy elke categorie in- of uitschakelen.",
+      "manageMethod3": "Op elke pagina opent de link \"Cookievoorkeuren beheren\" in de voettekst het banner opnieuw.",
+      "withdrawalHeading": "Toestemming intrekken",
+      "withdrawalBody": "Volgens de AVG (art. 7(3)) is toestemming intrekken even eenvoudig als ze geven. Drie gelijkwaardige methoden: 1) Instellingen → Cookies & privacy → \"Mijn keuze opnieuw instellen\". 2) Voettekst → \"Cookievoorkeuren beheren\". 3) E-mail naar thierryvm@gmail.com met onderwerp \"Cookietoestemming intrekken\".",
       "lifetimeHeading": "Levensduur",
       "lifetimeItem1": "Sessie: einde van de navigatie",
       "lifetimeItem2": "Voorkeuren: 12 maanden",
       "lifetimeItem3": "Analytics: 6 maanden (indien aanvaard)",
-      "draft": "Deze pagina met het cookiebeleid wordt momenteel opgesteld.",
       "contact": "Voor elke vraag, contacteer ons: thierryvm@gmail.com",
       "backHome": "Terug naar de startpagina"
     }
@@ -480,9 +485,22 @@
   },
   "consent": {
     "title": "Cookies en privacy",
-    "body": "We gebruiken enkel essentiële cookies om je te laten inloggen. Analytische cookies zijn standaard uitgeschakeld — je kunt ze activeren als je ons wil helpen Ankora te verbeteren. Je kunt op elk moment van gedacht veranderen via <link>het cookiebeleid</link>.",
+    "body": "We gebruiken enkel essentiële cookies om je te laten inloggen. Analytische en marketingcookies zijn standaard uitgeschakeld — je kunt ze activeren als je ons wil helpen Ankora te verbeteren. Je kunt op elk moment van gedacht veranderen via <link>het cookiebeleid</link>.",
     "essentialOnly": "Enkel essentiële",
-    "acceptAnalytics": "Analyses aanvaarden"
+    "acceptAll": "Alles aanvaarden",
+    "customize": {
+      "button": "Aanpassen",
+      "save": "Mijn voorkeuren opslaan",
+      "cancel": "Annuleren",
+      "legend": "Cookie-categorieën",
+      "essentialLabel": "Essentiële",
+      "essentialBadge": "(altijd actief)",
+      "essentialDescription": "Sessie, beveiliging, taal- en thema-voorkeuren. Vereist om Ankora te laten werken.",
+      "analyticsLabel": "Gebruiksanalyse",
+      "analyticsDescription": "Anonieme statistieken om te begrijpen welke pagina's het meest helpen. Geen persoonsgegevens.",
+      "marketingLabel": "Marketing",
+      "marketingDescription": "Voorbehouden voor toekomstige campagnes. Fase 1 van Ankora: geen marketingcookies actief."
+    }
   },
   "footer": {
     "copyright": "© {year} — Alle rechten voorbehouden",
@@ -490,7 +508,8 @@
     "privacy": "Privacy",
     "cookies": "Cookies beheren",
     "faq": "FAQ",
-    "copyrightNotice": "© {year} Ankora™. Alle rechten voorbehouden."
+    "copyrightNotice": "© {year} Ankora™. Alle rechten voorbehouden.",
+    "cookiePreferences": "Cookievoorkeuren beheren"
   },
   "auth": {
     "login": {
@@ -775,6 +794,23 @@
         "submit": "Mijn account verwijderen",
         "submitting": "Inplannen…",
         "toastScheduled": "Verwijdering ingepland — je hebt 30 dagen om te annuleren"
+      },
+      "cookies": {
+        "title": "Cookies & privacy",
+        "description": "Kies welke cookie-categorieën je aanvaardt. Je keuze wordt gesynchroniseerd met onze server (GDPR-audit) en je kunt die op elk moment wijzigen.",
+        "essentialLabel": "Essentiële",
+        "essentialBadge": "(altijd actief)",
+        "essentialDescription": "Sessie, beveiliging, taal- en thema-voorkeuren. Vereist om Ankora te laten werken.",
+        "analyticsLabel": "Gebruiksanalyse",
+        "analyticsDescription": "Anonieme statistieken om te begrijpen welke pagina's het meest helpen. Geen persoonsgegevens.",
+        "marketingLabel": "Marketing",
+        "marketingDescription": "Voorbehouden voor toekomstige campagnes. Fase 1 van Ankora: geen marketingcookies actief.",
+        "resetButton": "Mijn keuze opnieuw instellen",
+        "resetHint": "Dit verwijdert je beslissing en toont het banner opnieuw bij de volgende laadbeurt.",
+        "noDecisionHint": "Je hebt op dit apparaat nog geen keuze gemaakt. Het banner verschijnt bij je volgende bezoek.",
+        "toastSaved": "Cookievoorkeuren opgeslagen.",
+        "toastReset": "Keuze opnieuw ingesteld. Het banner verschijnt opnieuw.",
+        "toastError": "Kon je keuze niet opslaan. Probeer opnieuw."
       }
     },
     "simulator": {

--- a/src/app/[locale]/(public)/legal/cookies/page.tsx
+++ b/src/app/[locale]/(public)/legal/cookies/page.tsx
@@ -52,6 +52,16 @@ export default async function CookiesPage() {
           <p>{t.rich('manageBody1', { b: strong })}</p>
           <p>{t('manageBody2')}</p>
 
+          <h2>{t('manageMethodsHeading')}</h2>
+          <ol>
+            <li>{t('manageMethod1')}</li>
+            <li>{t('manageMethod2')}</li>
+            <li>{t('manageMethod3')}</li>
+          </ol>
+
+          <h2>{t('withdrawalHeading')}</h2>
+          <p>{t('withdrawalBody')}</p>
+
           <h2>{t('lifetimeHeading')}</h2>
           <ul>
             <li>{t('lifetimeItem1')}</li>

--- a/src/app/[locale]/app/settings/CookiesPreferencesSection.tsx
+++ b/src/app/[locale]/app/settings/CookiesPreferencesSection.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useEffect, useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { toast } from '@/components/ui/toast';
+import { reopenConsentBanner, CONSENT_VERSION } from '@/components/gdpr/ConsentBanner';
+import { recordCookieConsentAction } from '@/lib/actions/consent';
+import type { CookieConsentSnapshot } from '@/lib/actions/consent-types';
+
+const STORAGE_KEY = 'ankora.consent.v1';
+
+type LocalConsent = {
+  version: string;
+  analytics: boolean;
+  marketing: boolean;
+  decidedAt: string;
+};
+
+function readLocal(): LocalConsent | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as LocalConsent;
+    if (parsed.version !== CONSENT_VERSION) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeLocal(state: LocalConsent): void {
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+function clearLocal(): void {
+  window.localStorage.removeItem(STORAGE_KEY);
+}
+
+type Props = {
+  /**
+   * Server-fetched snapshot from `getCookieConsentAction()`. May be `null` if
+   * the user hasn't decided yet on this device, in which case we surface the
+   * "no choice yet" state and ask them to use the banner.
+   */
+  initialServerSnapshot: CookieConsentSnapshot | null;
+};
+
+export function CookiesPreferencesSection({ initialServerSnapshot }: Props) {
+  const t = useTranslations('app.settings.cookies');
+  const [analytics, setAnalytics] = useState<boolean>(initialServerSnapshot?.analytics ?? false);
+  const [marketing, setMarketing] = useState<boolean>(initialServerSnapshot?.marketing ?? false);
+  const [hasDecided, setHasDecided] = useState<boolean>(initialServerSnapshot !== null);
+  const [pending, startTransition] = useTransition();
+
+  // On mount, hydrate from localStorage if it has a fresher decision than the
+  // server snapshot — the user may have toggled while logged out and we want
+  // the UI to reflect their actual current local state.
+  //
+  // The eslint rule against synchronous setState-in-effect is intentionally
+  // disabled here: localStorage is an external system unavailable during SSR,
+  // so the read MUST happen after mount. The conditional means we only set
+  // state when the local decision is genuinely newer than the server one,
+  // which prevents the cascading-render anti-pattern the rule guards against.
+  useEffect(() => {
+    const local = readLocal();
+    if (!local) return;
+    if (!initialServerSnapshot || local.decidedAt > (initialServerSnapshot.decidedAt ?? '')) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setAnalytics(local.analytics);
+
+      setMarketing(local.marketing);
+
+      setHasDecided(true);
+    }
+  }, [initialServerSnapshot]);
+
+  const save = (nextAnalytics: boolean, nextMarketing: boolean) => {
+    writeLocal({
+      version: CONSENT_VERSION,
+      analytics: nextAnalytics,
+      marketing: nextMarketing,
+      decidedAt: new Date().toISOString(),
+    });
+    setAnalytics(nextAnalytics);
+    setMarketing(nextMarketing);
+    setHasDecided(true);
+    startTransition(async () => {
+      const res = await recordCookieConsentAction({
+        analytics: nextAnalytics,
+        marketing: nextMarketing,
+      });
+      if (res.ok) toast.success(t('toastSaved'));
+      else toast.error(t('toastError'));
+    });
+  };
+
+  const reset = () => {
+    clearLocal();
+    setAnalytics(false);
+    setMarketing(false);
+    setHasDecided(false);
+    reopenConsentBanner();
+    startTransition(async () => {
+      await recordCookieConsentAction({ analytics: false, marketing: false });
+      toast.success(t('toastReset'));
+    });
+  };
+
+  return (
+    <Card id="cookies-preferences">
+      <CardHeader>
+        <CardTitle>{t('title')}</CardTitle>
+        <CardDescription>{t('description')}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-5">
+        <div className="border-border flex items-start gap-3 rounded-md border p-4">
+          <input
+            type="checkbox"
+            checked
+            disabled
+            aria-label={t('essentialLabel')}
+            className="text-brand-700 mt-0.5 h-4 w-4"
+          />
+          <div className="flex-1">
+            <p className="text-sm font-medium">
+              {t('essentialLabel')}{' '}
+              <span className="text-muted-foreground text-xs font-normal">
+                {t('essentialBadge')}
+              </span>
+            </p>
+            <p className="text-muted-foreground mt-1 text-xs">{t('essentialDescription')}</p>
+          </div>
+        </div>
+
+        <div className="border-border flex items-start gap-3 rounded-md border p-4">
+          <input
+            id="analytics-toggle"
+            type="checkbox"
+            checked={analytics}
+            onChange={(e) => save(e.target.checked, marketing)}
+            disabled={pending}
+            aria-label={t('analyticsLabel')}
+            className="text-brand-700 focus-visible:ring-brand-600 mt-0.5 h-4 w-4 focus-visible:ring-2 focus-visible:outline-none"
+          />
+          <div className="flex-1">
+            <label htmlFor="analytics-toggle" className="text-sm font-medium">
+              {t('analyticsLabel')}
+            </label>
+            <p className="text-muted-foreground mt-1 text-xs">{t('analyticsDescription')}</p>
+          </div>
+        </div>
+
+        <div className="border-border flex items-start gap-3 rounded-md border p-4">
+          <input
+            id="marketing-toggle"
+            type="checkbox"
+            checked={marketing}
+            onChange={(e) => save(analytics, e.target.checked)}
+            disabled={pending}
+            aria-label={t('marketingLabel')}
+            className="text-brand-700 focus-visible:ring-brand-600 mt-0.5 h-4 w-4 focus-visible:ring-2 focus-visible:outline-none"
+          />
+          <div className="flex-1">
+            <label htmlFor="marketing-toggle" className="text-sm font-medium">
+              {t('marketingLabel')}
+            </label>
+            <p className="text-muted-foreground mt-1 text-xs">{t('marketingDescription')}</p>
+          </div>
+        </div>
+
+        <div className="border-border border-t pt-4">
+          <Button type="button" variant="outline" onClick={reset} disabled={pending}>
+            {t('resetButton')}
+          </Button>
+          <p className="text-muted-foreground mt-2 text-xs">
+            {hasDecided ? t('resetHint') : t('noDecisionHint')}
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/[locale]/app/settings/SettingsClient.tsx
+++ b/src/app/[locale]/app/settings/SettingsClient.tsx
@@ -38,14 +38,29 @@ type Props = {
   locale: string;
   factors: Factor[];
   deletion: Deletion;
+  /**
+   * Optional slot rendered between DataCard and DangerZone — used by the
+   * page-level Server Component to inject the CookiesPreferencesSection
+   * (which needs server-fetched consent state) without leaking that data
+   * fetch into this client tree.
+   */
+  cookiesSection?: React.ReactNode;
 };
 
-export function SettingsClient({ email, displayName, locale, factors, deletion }: Props) {
+export function SettingsClient({
+  email,
+  displayName,
+  locale,
+  factors,
+  deletion,
+  cookiesSection,
+}: Props) {
   return (
     <div className="flex flex-col gap-6">
       <ProfileCard email={email} displayName={displayName} locale={locale} />
       <MfaCard factors={factors} />
       <DataCard />
+      {cookiesSection}
       <DangerZone deletion={deletion} email={email} />
     </div>
   );

--- a/src/app/[locale]/app/settings/__tests__/CookiesPreferencesSection.test.tsx
+++ b/src/app/[locale]/app/settings/__tests__/CookiesPreferencesSection.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+
+import messages from '../../../../../../messages/fr-BE.json';
+
+const recordCookieConsentMock = vi.fn().mockResolvedValue({ ok: true, data: { persisted: true } });
+const reopenMock = vi.fn();
+
+vi.mock('@/lib/actions/consent', () => ({
+  recordCookieConsentAction: (...args: unknown[]) => recordCookieConsentMock(...args),
+}));
+
+vi.mock('@/components/gdpr/ConsentBanner', () => ({
+  reopenConsentBanner: () => reopenMock(),
+  CONSENT_VERSION: '1.0.0',
+}));
+
+vi.mock('@/components/ui/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { CookiesPreferencesSection } from '../CookiesPreferencesSection';
+
+const STORAGE_KEY = 'ankora.consent.v1';
+
+const wrapped = (
+  initial: React.ComponentProps<typeof CookiesPreferencesSection>['initialServerSnapshot'],
+) => (
+  <NextIntlClientProvider locale="fr-BE" messages={messages}>
+    <CookiesPreferencesSection initialServerSnapshot={initial} />
+  </NextIntlClientProvider>
+);
+
+describe('<CookiesPreferencesSection />', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    recordCookieConsentMock.mockClear();
+    reopenMock.mockClear();
+  });
+
+  it('renders the title, description and the three categories', () => {
+    render(wrapped(null));
+    // CardTitle renders as a <div>, not a heading — assert by visible text.
+    expect(screen.getByText(messages.app.settings.cookies.title)).toBeInTheDocument();
+    expect(screen.getAllByRole('checkbox')).toHaveLength(3);
+    expect(screen.getByLabelText(messages.app.settings.cookies.essentialLabel)).toBeDisabled();
+  });
+
+  it('reflects the server-fetched snapshot when one is provided', () => {
+    render(
+      wrapped({
+        analytics: true,
+        marketing: false,
+        version: '1.0.0',
+        decidedAt: '2026-01-01T00:00:00.000Z',
+      }),
+    );
+    const analyticsCheckbox = screen.getByLabelText(
+      messages.app.settings.cookies.analyticsLabel,
+    ) as HTMLInputElement;
+    const marketingCheckbox = screen.getByLabelText(
+      messages.app.settings.cookies.marketingLabel,
+    ) as HTMLInputElement;
+    expect(analyticsCheckbox.checked).toBe(true);
+    expect(marketingCheckbox.checked).toBe(false);
+  });
+
+  it('toggling analytics persists localStorage and calls the server action', async () => {
+    render(wrapped(null));
+    const checkbox = screen.getByLabelText(
+      messages.app.settings.cookies.analyticsLabel,
+    ) as HTMLInputElement;
+    fireEvent.click(checkbox);
+    await waitFor(() => {
+      expect(recordCookieConsentMock).toHaveBeenCalledWith({ analytics: true, marketing: false });
+      const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? 'null');
+      expect(stored).toMatchObject({ analytics: true, marketing: false });
+    });
+  });
+
+  it('reset button clears localStorage, calls reopenConsentBanner, and persists revocation server-side', async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: '1.0.0',
+        analytics: true,
+        marketing: true,
+        decidedAt: '2026-01-01T00:00:00.000Z',
+      }),
+    );
+    render(
+      wrapped({
+        analytics: true,
+        marketing: true,
+        version: '1.0.0',
+        decidedAt: '2026-01-01T00:00:00.000Z',
+      }),
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: messages.app.settings.cookies.resetButton }),
+    );
+    await waitFor(() => {
+      expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+      expect(reopenMock).toHaveBeenCalledTimes(1);
+      expect(recordCookieConsentMock).toHaveBeenCalledWith({ analytics: false, marketing: false });
+    });
+  });
+
+  it('hydrates from a fresher localStorage decision over a stale server snapshot', () => {
+    const fresh = '2026-12-31T23:59:59.000Z';
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: '1.0.0',
+        analytics: false,
+        marketing: true,
+        decidedAt: fresh,
+      }),
+    );
+    render(
+      wrapped({
+        analytics: true,
+        marketing: false,
+        version: '1.0.0',
+        decidedAt: '2026-01-01T00:00:00.000Z',
+      }),
+    );
+    const analytics = screen.getByLabelText(
+      messages.app.settings.cookies.analyticsLabel,
+    ) as HTMLInputElement;
+    const marketing = screen.getByLabelText(
+      messages.app.settings.cookies.marketingLabel,
+    ) as HTMLInputElement;
+    expect(analytics.checked).toBe(false);
+    expect(marketing.checked).toBe(true);
+  });
+});

--- a/src/app/[locale]/app/settings/page.tsx
+++ b/src/app/[locale]/app/settings/page.tsx
@@ -3,7 +3,9 @@ import { getTranslations } from 'next-intl/server';
 
 import { requireUser } from '@/lib/auth/require-user';
 import { createClient } from '@/lib/supabase/server';
+import { getCookieConsentAction } from '@/lib/actions/consent';
 import { SettingsClient } from './SettingsClient';
+import { CookiesPreferencesSection } from './CookiesPreferencesSection';
 
 type Factor = { id: string; friendlyName: string | null; status: string };
 type Deletion = { scheduledFor: string; status: string } | null;
@@ -18,7 +20,7 @@ export default async function SettingsPage() {
   const user = await requireUser();
   const supabase = await createClient();
 
-  const [profileRes, factorsRes, deletionRes] = await Promise.all([
+  const [profileRes, factorsRes, deletionRes, consentRes] = await Promise.all([
     supabase.from('users').select('display_name, locale, email').eq('id', user.id).maybeSingle(),
     supabase.auth.mfa.listFactors(),
     supabase
@@ -27,6 +29,7 @@ export default async function SettingsPage() {
       .eq('user_id', user.id)
       .eq('status', 'pending')
       .maybeSingle(),
+    getCookieConsentAction(),
   ]);
 
   const factors: Factor[] = (factorsRes.data?.totp ?? []).map((f) => ({
@@ -52,6 +55,11 @@ export default async function SettingsPage() {
         locale={profileRes.data?.locale ?? 'fr-BE'}
         factors={factors}
         deletion={deletion}
+        cookiesSection={
+          <CookiesPreferencesSection
+            initialServerSnapshot={consentRes.ok ? consentRes.data.snapshot : null}
+          />
+        }
       />
     </div>
   );

--- a/src/components/brand/BrandHomeLink.tsx
+++ b/src/components/brand/BrandHomeLink.tsx
@@ -1,0 +1,37 @@
+import { Link } from '@/i18n/navigation';
+import { AnkoraLogo } from '@/components/brand/AnkoraLogo';
+import { cn } from '@/lib/utils';
+
+type Props = {
+  /**
+   * Localised aria-label announced by assistive tech (e.g. "Accueil Ankora").
+   * The inner `<svg>` is intentionally `aria-hidden` so SR users hear this
+   * label exactly once — fixing the duplicate announcement that motivated
+   * the Sourcery review on PR #119.
+   */
+  ariaLabel: string;
+  /** Extra classes for the outer `<Link>` (rare — defaults to the canonical pattern). */
+  className?: string;
+  /** Sizing for the inner `<AnkoraLogo>` (e.g. `h-8 w-auto` in Header, `h-7 w-auto` in Footer). */
+  logoClassName?: string;
+};
+
+const LINK_CLASSES =
+  'focus-visible:ring-brand-600 flex shrink-0 items-center rounded-md transition-transform duration-150 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-safe:active:scale-95';
+
+/**
+ * Shared "home" link wrapping the Ankora wordmark. Used by both Header and
+ * Footer so the focus ring, press animation and a11y semantics never drift
+ * between the two surfaces.
+ *
+ * The logo SVG is rendered with `aria-hidden focusable={false}` because the
+ * surrounding `<Link>` already announces "Accueil Ankora" — anything else
+ * would have screen readers say "Ankora, Accueil Ankora" or similar.
+ */
+export function BrandHomeLink({ ariaLabel, className, logoClassName }: Props) {
+  return (
+    <Link href="/" aria-label={ariaLabel} className={cn(LINK_CLASSES, className)}>
+      <AnkoraLogo className={logoClassName} aria-hidden focusable={false} aria-label={undefined} />
+    </Link>
+  );
+}

--- a/src/components/brand/__tests__/BrandHomeLink.test.tsx
+++ b/src/components/brand/__tests__/BrandHomeLink.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+import { BrandHomeLink } from '../BrandHomeLink';
+
+describe('<BrandHomeLink />', () => {
+  it('wraps the Ankora wordmark in a link to / with the supplied aria-label', () => {
+    render(<BrandHomeLink ariaLabel="Accueil Ankora" />);
+    const link = screen.getByRole('link', { name: 'Accueil Ankora' });
+    expect(link).toHaveAttribute('href', '/');
+  });
+
+  it('hides the inner SVG from assistive tech to avoid duplicate announcements', () => {
+    const { container } = render(<BrandHomeLink ariaLabel="Home" />);
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    expect(svg?.getAttribute('aria-hidden')).toBe('true');
+    expect(svg?.getAttribute('focusable')).toBe('false');
+    // Critically: the SVG should NOT carry its own aria-label, otherwise
+    // SR users would hear "Ankora" + the parent link's aria-label.
+    expect(svg?.getAttribute('aria-label')).toBeNull();
+  });
+
+  it('forwards logoClassName to the AnkoraLogo for sizing per surface', () => {
+    const { container } = render(<BrandHomeLink ariaLabel="Home" logoClassName="h-7 w-auto" />);
+    const svg = container.querySelector('svg');
+    expect(svg?.className.baseVal ?? '').toContain('h-7');
+  });
+
+  it('applies the canonical focus + press animation classes', () => {
+    render(<BrandHomeLink ariaLabel="Home" />);
+    const link = screen.getByRole('link', { name: 'Home' });
+    expect(link.className).toContain('focus-visible:ring-brand-600');
+    expect(link.className).toContain('motion-safe:active:scale-95');
+    expect(link.className).toContain('transition-transform');
+  });
+
+  it('merges an optional className without losing the canonical pattern', () => {
+    render(<BrandHomeLink ariaLabel="Home" className="extra-class" />);
+    const link = screen.getByRole('link', { name: 'Home' });
+    expect(link.className).toContain('extra-class');
+    expect(link.className).toContain('focus-visible:ring-brand-600');
+  });
+});

--- a/src/components/gdpr/ConsentBanner.tsx
+++ b/src/components/gdpr/ConsentBanner.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { useState, useSyncExternalStore } from 'react';
+import { useState, useSyncExternalStore, useTransition } from 'react';
 import { useTranslations } from 'next-intl';
 
 import { Link } from '@/i18n/navigation';
+import { recordCookieConsentAction } from '@/lib/actions/consent';
 
 const STORAGE_KEY = 'ankora.consent.v1';
-const CONSENT_VERSION = '1.0.0';
+const REOPEN_FLAG_KEY = 'ankora.consent.reopen';
+export const CONSENT_VERSION = '1.0.0';
 
 type ConsentState = {
   version: string;
@@ -28,8 +30,19 @@ function readStored(): ConsentState | null {
   }
 }
 
+function isReopenRequested(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(REOPEN_FLAG_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
 function persist(state: ConsentState): void {
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  // Reopen flag is consumed: any successful decision dismisses the banner.
+  window.localStorage.removeItem(REOPEN_FLAG_KEY);
 }
 
 /**
@@ -37,19 +50,44 @@ function persist(state: ConsentState): void {
  * return a stable reference between invalidations — otherwise React loops.
  * We only recompute when subscribers are notified (persist or storage event).
  */
-let cachedSnapshot: ConsentState | null = null;
 let cachedInitialized = false;
 
-function getSnapshot(): ConsentState | null {
-  if (!cachedInitialized) {
-    cachedSnapshot = readStored();
-    cachedInitialized = true;
+type StoreSnapshot = {
+  stored: ConsentState | null;
+  reopen: boolean;
+};
+
+const SNAPSHOT_REF: { value: StoreSnapshot } = {
+  value: { stored: null, reopen: false },
+};
+
+function refreshSnapshot(): void {
+  const next: StoreSnapshot = {
+    stored: readStored(),
+    reopen: isReopenRequested(),
+  };
+  // Stable identity unless the relevant fields changed.
+  const prev = SNAPSHOT_REF.value;
+  if (
+    prev.stored?.version !== next.stored?.version ||
+    prev.stored?.analytics !== next.stored?.analytics ||
+    prev.stored?.marketing !== next.stored?.marketing ||
+    prev.reopen !== next.reopen
+  ) {
+    SNAPSHOT_REF.value = next;
   }
-  return cachedSnapshot;
 }
 
-function getServerSnapshot(): ConsentState | null {
-  return null;
+function getSnapshot(): StoreSnapshot {
+  if (!cachedInitialized) {
+    refreshSnapshot();
+    cachedInitialized = true;
+  }
+  return SNAPSHOT_REF.value;
+}
+
+function getServerSnapshot(): StoreSnapshot {
+  return { stored: null, reopen: false };
 }
 
 const STORAGE_LISTENERS = new Set<() => void>();
@@ -57,8 +95,8 @@ const STORAGE_LISTENERS = new Set<() => void>();
 function subscribe(cb: () => void) {
   STORAGE_LISTENERS.add(cb);
   const onStorage = (event: StorageEvent) => {
-    if (event.key === STORAGE_KEY) {
-      cachedSnapshot = readStored();
+    if (event.key === STORAGE_KEY || event.key === REOPEN_FLAG_KEY) {
+      refreshSnapshot();
       cb();
     }
   };
@@ -70,26 +108,69 @@ function subscribe(cb: () => void) {
 }
 
 function notify() {
-  cachedSnapshot = readStored();
+  refreshSnapshot();
   STORAGE_LISTENERS.forEach((cb) => cb());
+}
+
+/**
+ * Test-only escape hatch — forces the module-level snapshot cache to be
+ * recomputed from a fresh `localStorage` read on the next render. Vitest
+ * shares module state between test cases by default, so without this the
+ * banner would carry the consent decision of one test into the next.
+ *
+ * Not exported in any production import path (only `__tests__/` files
+ * call it). Kept inside the module so the cache implementation stays
+ * private.
+ */
+export function __resetConsentCacheForTests(): void {
+  cachedInitialized = false;
+  SNAPSHOT_REF.value = { stored: null, reopen: false };
+}
+
+/**
+ * Programmatically requests the banner to re-open. Called from the Settings
+ * "Reset choice" button and the Footer "Manage cookie preferences" link so
+ * the user can revisit their decision from anywhere.
+ *
+ * Implementation: clears the consent record AND sets a reopen flag. The flag
+ * is necessary because the version-cookie removal alone cannot distinguish
+ * "first visit" from "user-requested reopen" cleanly across SSR boundaries.
+ */
+export function reopenConsentBanner(): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.removeItem(STORAGE_KEY);
+  window.localStorage.setItem(REOPEN_FLAG_KEY, '1');
+  notify();
 }
 
 export function ConsentBanner() {
   const t = useTranslations('consent');
-  const stored = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  const snap = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
   const [dismissed, setDismissed] = useState(false);
+  const [customizing, setCustomizing] = useState(false);
+  const [analytics, setAnalytics] = useState(false);
+  const [marketing, setMarketing] = useState(false);
+  const [, startTransition] = useTransition();
 
-  if (dismissed || stored !== null) return null;
+  const hasDecided = snap.stored !== null;
+  const shouldShow = !dismissed && (!hasDecided || snap.reopen);
+  if (!shouldShow) return null;
 
-  const accept = (analytics: boolean, marketing: boolean) => {
+  const accept = (analyticsValue: boolean, marketingValue: boolean) => {
     persist({
       version: CONSENT_VERSION,
-      analytics,
-      marketing,
+      analytics: analyticsValue,
+      marketing: marketingValue,
       decidedAt: new Date().toISOString(),
     });
     setDismissed(true);
     notify();
+    startTransition(() => {
+      void recordCookieConsentAction({
+        analytics: analyticsValue,
+        marketing: marketingValue,
+      });
+    });
   };
 
   return (
@@ -111,22 +192,108 @@ export function ConsentBanner() {
           ),
         })}
       </p>
-      <div className="mt-4 flex flex-wrap gap-2">
-        <button
-          type="button"
-          onClick={() => accept(false, false)}
-          className="border-border hover:bg-brand-100 focus-visible:ring-brand-600 rounded-md border px-4 py-2 text-sm font-medium focus-visible:ring-2 focus-visible:outline-none"
-        >
-          {t('essentialOnly')}
-        </button>
-        <button
-          type="button"
-          onClick={() => accept(true, false)}
-          className="bg-brand-700 hover:bg-brand-800 focus-visible:ring-brand-600 rounded-md px-4 py-2 text-sm font-medium text-white focus-visible:ring-2 focus-visible:outline-none"
-        >
-          {t('acceptAnalytics')}
-        </button>
-      </div>
+
+      {customizing ? (
+        <div className="mt-4 flex flex-col gap-3">
+          <fieldset className="flex flex-col gap-3">
+            <legend className="sr-only">{t('customize.legend')}</legend>
+
+            <label className="border-border flex items-start gap-3 rounded-md border p-3">
+              <input
+                type="checkbox"
+                checked
+                disabled
+                aria-label={t('customize.essentialLabel')}
+                className="text-brand-700 mt-0.5 h-4 w-4"
+              />
+              <span className="flex-1">
+                <span className="block text-sm font-medium">
+                  {t('customize.essentialLabel')}{' '}
+                  <span className="text-muted-foreground text-xs font-normal">
+                    {t('customize.essentialBadge')}
+                  </span>
+                </span>
+                <span className="text-muted-foreground mt-1 block text-xs">
+                  {t('customize.essentialDescription')}
+                </span>
+              </span>
+            </label>
+
+            <label className="border-border flex items-start gap-3 rounded-md border p-3">
+              <input
+                type="checkbox"
+                checked={analytics}
+                onChange={(e) => setAnalytics(e.target.checked)}
+                aria-label={t('customize.analyticsLabel')}
+                className="text-brand-700 focus-visible:ring-brand-600 mt-0.5 h-4 w-4 focus-visible:ring-2 focus-visible:outline-none"
+              />
+              <span className="flex-1">
+                <span className="block text-sm font-medium">{t('customize.analyticsLabel')}</span>
+                <span className="text-muted-foreground mt-1 block text-xs">
+                  {t('customize.analyticsDescription')}
+                </span>
+              </span>
+            </label>
+
+            <label className="border-border flex items-start gap-3 rounded-md border p-3">
+              <input
+                type="checkbox"
+                checked={marketing}
+                onChange={(e) => setMarketing(e.target.checked)}
+                aria-label={t('customize.marketingLabel')}
+                className="text-brand-700 focus-visible:ring-brand-600 mt-0.5 h-4 w-4 focus-visible:ring-2 focus-visible:outline-none"
+              />
+              <span className="flex-1">
+                <span className="block text-sm font-medium">{t('customize.marketingLabel')}</span>
+                <span className="text-muted-foreground mt-1 block text-xs">
+                  {t('customize.marketingDescription')}
+                </span>
+              </span>
+            </label>
+          </fieldset>
+
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => accept(analytics, marketing)}
+              className="bg-brand-700 hover:bg-brand-800 focus-visible:ring-brand-600 rounded-md px-4 py-2 text-sm font-medium text-white focus-visible:ring-2 focus-visible:outline-none"
+            >
+              {t('customize.save')}
+            </button>
+            <button
+              type="button"
+              onClick={() => setCustomizing(false)}
+              className="border-border hover:bg-brand-100 focus-visible:ring-brand-600 rounded-md border px-4 py-2 text-sm font-medium focus-visible:ring-2 focus-visible:outline-none"
+            >
+              {t('customize.cancel')}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-4 flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => accept(false, false)}
+            className="border-border hover:bg-brand-100 focus-visible:ring-brand-600 rounded-md border px-4 py-2 text-sm font-medium focus-visible:ring-2 focus-visible:outline-none"
+          >
+            {t('essentialOnly')}
+          </button>
+          <button
+            type="button"
+            onClick={() => setCustomizing(true)}
+            className="border-border hover:bg-brand-100 focus-visible:ring-brand-600 rounded-md border px-4 py-2 text-sm font-medium focus-visible:ring-2 focus-visible:outline-none"
+          >
+            {t('customize.button')}
+          </button>
+          <button
+            type="button"
+            onClick={() => accept(true, true)}
+            className="bg-brand-700 hover:bg-brand-800 focus-visible:ring-brand-600 rounded-md px-4 py-2 text-sm font-medium text-white focus-visible:ring-2 focus-visible:outline-none"
+          >
+            {t('acceptAll')}
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/gdpr/__tests__/ConsentBanner.test.tsx
+++ b/src/components/gdpr/__tests__/ConsentBanner.test.tsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+
+import messages from '../../../../messages/fr-BE.json';
+
+const recordCookieConsentMock = vi.fn().mockResolvedValue({ ok: true, data: { persisted: false } });
+
+vi.mock('@/lib/actions/consent', () => ({
+  recordCookieConsentAction: (...args: unknown[]) => recordCookieConsentMock(...args),
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+import {
+  ConsentBanner,
+  reopenConsentBanner,
+  CONSENT_VERSION,
+  __resetConsentCacheForTests,
+} from '../ConsentBanner';
+
+const STORAGE_KEY = 'ankora.consent.v1';
+const REOPEN_KEY = 'ankora.consent.reopen';
+
+const wrapped = () => (
+  <NextIntlClientProvider locale="fr-BE" messages={messages}>
+    <ConsentBanner />
+  </NextIntlClientProvider>
+);
+
+const readStored = () => {
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  return raw ? JSON.parse(raw) : null;
+};
+
+describe('<ConsentBanner /> — extended (PR-LEGAL-1)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    recordCookieConsentMock.mockClear();
+    __resetConsentCacheForTests();
+  });
+
+  it('renders the three primary actions on first visit', () => {
+    render(wrapped());
+    expect(
+      screen.getByRole('button', { name: messages.consent.essentialOnly }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: messages.consent.customize.button }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: messages.consent.acceptAll })).toBeInTheDocument();
+  });
+
+  it('Accept all → analytics + marketing both true and banner dismissed', async () => {
+    render(wrapped());
+    fireEvent.click(screen.getByRole('button', { name: messages.consent.acceptAll }));
+    await waitFor(() => {
+      const stored = readStored();
+      expect(stored).toMatchObject({
+        version: CONSENT_VERSION,
+        analytics: true,
+        marketing: true,
+      });
+    });
+    expect(recordCookieConsentMock).toHaveBeenCalledWith({ analytics: true, marketing: true });
+    expect(
+      screen.queryByRole('button', { name: messages.consent.essentialOnly }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('Essential only → both analytics and marketing false', async () => {
+    render(wrapped());
+    fireEvent.click(screen.getByRole('button', { name: messages.consent.essentialOnly }));
+    await waitFor(() => {
+      expect(readStored()).toMatchObject({ analytics: false, marketing: false });
+    });
+    expect(recordCookieConsentMock).toHaveBeenCalledWith({ analytics: false, marketing: false });
+  });
+
+  it('Customize opens an inline panel with the three category toggles', () => {
+    render(wrapped());
+    fireEvent.click(screen.getByRole('button', { name: messages.consent.customize.button }));
+    expect(
+      screen.getByRole('checkbox', { name: messages.consent.customize.essentialLabel }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole('checkbox', { name: messages.consent.customize.analyticsLabel }),
+    ).toBeEnabled();
+    expect(
+      screen.getByRole('checkbox', { name: messages.consent.customize.marketingLabel }),
+    ).toBeEnabled();
+  });
+
+  it('Customize → toggle analytics only → save persists analytics=true marketing=false', async () => {
+    render(wrapped());
+    fireEvent.click(screen.getByRole('button', { name: messages.consent.customize.button }));
+    fireEvent.click(
+      screen.getByRole('checkbox', { name: messages.consent.customize.analyticsLabel }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: messages.consent.customize.save }));
+    await waitFor(() => {
+      expect(readStored()).toMatchObject({ analytics: true, marketing: false });
+    });
+    expect(recordCookieConsentMock).toHaveBeenCalledWith({ analytics: true, marketing: false });
+  });
+
+  it('does not render once a fresh decision is already in localStorage', () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: CONSENT_VERSION,
+        analytics: true,
+        marketing: false,
+        decidedAt: new Date().toISOString(),
+      }),
+    );
+    render(wrapped());
+    expect(
+      screen.queryByRole('button', { name: messages.consent.acceptAll }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('reopens when the reopen flag is set even if a decision exists', () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: CONSENT_VERSION,
+        analytics: true,
+        marketing: false,
+        decidedAt: new Date().toISOString(),
+      }),
+    );
+    window.localStorage.setItem(REOPEN_KEY, '1');
+    render(wrapped());
+    expect(screen.getByRole('button', { name: messages.consent.acceptAll })).toBeInTheDocument();
+  });
+
+  it('reopenConsentBanner() clears the decision and sets the reopen flag', () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: CONSENT_VERSION,
+        analytics: true,
+        marketing: false,
+        decidedAt: '2026-01-01T00:00:00.000Z',
+      }),
+    );
+    reopenConsentBanner();
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(window.localStorage.getItem(REOPEN_KEY)).toBe('1');
+  });
+});

--- a/src/components/layout/CookiePreferencesLink.tsx
+++ b/src/components/layout/CookiePreferencesLink.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import { reopenConsentBanner } from '@/components/gdpr/ConsentBanner';
+
+/**
+ * Footer link that reopens the cookie consent banner from any page so the
+ * user can revisit their decision (RGPD art. 7(3) — withdrawing consent
+ * must be as easy as giving it).
+ *
+ * Implementation note: rendered as a `<button>` (not `<a>`) because the
+ * action mutates client-side state (localStorage flag) rather than
+ * navigating. Styled to blend in with the surrounding footer links.
+ */
+export function CookiePreferencesLink() {
+  const t = useTranslations('footer');
+  return (
+    <button
+      type="button"
+      onClick={() => reopenConsentBanner()}
+      className="text-muted-foreground focus-visible:ring-brand-600 cursor-pointer rounded text-left text-sm hover:underline focus-visible:ring-2 focus-visible:outline-none"
+    >
+      {t('cookiePreferences')}
+    </button>
+  );
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,7 +1,8 @@
 import { getTranslations } from 'next-intl/server';
 
 import { Link } from '@/i18n/navigation';
-import { AnkoraLogo } from '@/components/brand/AnkoraLogo';
+import { BrandHomeLink } from '@/components/brand/BrandHomeLink';
+import { CookiePreferencesLink } from '@/components/layout/CookiePreferencesLink';
 
 export async function Footer() {
   const t = await getTranslations('footer');
@@ -11,13 +12,7 @@ export async function Footer() {
     <footer className="border-border bg-card border-t">
       <div className="mx-auto flex max-w-6xl flex-col items-start justify-between gap-6 px-4 py-10 md:flex-row md:items-center md:px-6">
         <div className="flex items-center gap-2">
-          <Link
-            href="/"
-            aria-label={tCommon('homeAria')}
-            className="focus-visible:ring-brand-600 flex shrink-0 items-center rounded-md transition-transform duration-150 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-safe:active:scale-95"
-          >
-            <AnkoraLogo className="h-7 w-auto" />
-          </Link>
+          <BrandHomeLink ariaLabel={tCommon('homeAria')} logoClassName="h-7 w-auto" />
           <span className="text-muted-foreground text-sm">
             {t('copyrightNotice', { year: new Date().getFullYear() })}
           </span>
@@ -35,6 +30,7 @@ export async function Footer() {
           <Link href="/faq" className="text-muted-foreground hover:underline">
             {t('faq')}
           </Link>
+          <CookiePreferencesLink />
         </nav>
       </div>
     </footer>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,6 @@
 import { getTranslations } from 'next-intl/server';
 import { Link } from '@/i18n/navigation';
-import { AnkoraLogo } from '@/components/brand/AnkoraLogo';
+import { BrandHomeLink } from '@/components/brand/BrandHomeLink';
 import { Button } from '@/components/ui/button';
 import { HeaderNav } from './HeaderNav';
 
@@ -20,14 +20,10 @@ export async function Header({ variant = 'marketing', isAuthenticated = false }:
          * MktNav.tsx — clicking it from `/app` is now a deliberate
          * navigation, which avoids the no-op + title-flash described in
          * issue #95. The tactile press animation reinforces the click.
+         * Shared with Footer via BrandHomeLink so a11y semantics and focus
+         * styling cannot drift between the two surfaces (Sourcery #119).
          */}
-        <Link
-          href="/"
-          aria-label={t('homeAria')}
-          className="focus-visible:ring-brand-600 flex shrink-0 items-center gap-2 rounded-md transition-transform duration-150 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-safe:active:scale-95"
-        >
-          <AnkoraLogo className="h-8 w-auto" />
-        </Link>
+        <BrandHomeLink ariaLabel={t('homeAria')} logoClassName="h-8 w-auto" />
 
         {variant === 'marketing' ? (
           <nav aria-label={t('nav.mainLabel')} className="hidden items-center gap-1 lg:flex">

--- a/src/components/layout/__tests__/Footer.test.tsx
+++ b/src/components/layout/__tests__/Footer.test.tsx
@@ -35,6 +35,29 @@ vi.mock('@/i18n/navigation', () => ({
   ),
 }));
 
+// CookiePreferencesLink is a Client Component using `useTranslations` from
+// `next-intl` (the client-side hook, distinct from the server `getTranslations`
+// already mocked above). Stub it locally so the Footer test stays focused on
+// the Server Component layout under test.
+vi.mock('next-intl', () => ({
+  useTranslations: (namespace: string) => (key: string) => {
+    const ns = (messages as Record<string, Record<string, unknown>>)[namespace] ?? {};
+    const value = ns[key];
+    return typeof value === 'string' ? value : key;
+  },
+}));
+
+// CookiePreferencesLink imports ConsentBanner which transitively imports the
+// `'use server'` consent action and the Supabase server client. Stub the
+// action so importing the Footer doesn't initialise the env-validated
+// Supabase client during the test run.
+vi.mock('@/lib/actions/consent', () => ({
+  recordCookieConsentAction: vi.fn().mockResolvedValue({ ok: true, data: { persisted: false } }),
+  getCookieConsentAction: vi.fn().mockResolvedValue({ ok: true, data: { snapshot: null } }),
+  resetCookieConsentAction: vi.fn().mockResolvedValue({ ok: true, data: { persisted: false } }),
+  COOKIE_CONSENT_VERSION: '1.0.0',
+}));
+
 import { Footer } from '../Footer';
 
 async function renderFooter() {
@@ -64,14 +87,26 @@ describe('<Footer />', () => {
     expect(screen.getByText((content) => content.includes(String(year)))).toBeInTheDocument();
   });
 
-  it('exposes the AnkoraLogo for brand recognition', async () => {
+  it('exposes the AnkoraLogo behind a single Accueil Ankora link (a11y, Sourcery #119 followup)', async () => {
     await renderFooter();
-    expect(screen.getByRole('img', { name: 'Ankora' })).toBeInTheDocument();
+    // Post-refactor: the SVG is aria-hidden so SR users hear the wrapping
+    // Link's aria-label exactly once. The brand mark itself is no longer
+    // a separate role=img landmark.
+    const homeLink = screen.getByLabelText(messages.common.homeAria);
+    expect(homeLink).toHaveAttribute('href', '/');
+    expect(screen.queryByRole('img', { name: 'Ankora' })).not.toBeInTheDocument();
   });
 
   it('uses an aria-labelled <nav> for the legal navigation', async () => {
     await renderFooter();
     const nav = screen.getByRole('navigation', { name: messages.common.nav.footerLabel });
     expect(nav).toBeInTheDocument();
+  });
+
+  it('exposes the cookie preferences re-open button (RGPD art. 7(3))', async () => {
+    await renderFooter();
+    expect(
+      screen.getByRole('button', { name: messages.footer.cookiePreferences }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/lib/actions/consent-types.ts
+++ b/src/lib/actions/consent-types.ts
@@ -1,0 +1,19 @@
+/**
+ * Pure types and constants for the cookie consent flow. Lives in its own
+ * file so `consent.ts` (which carries the `'use server'` directive) can
+ * stay strictly async-export-only as enforced by `scripts/lint-use-server.mjs`.
+ */
+
+export const COOKIE_CONSENT_VERSION = '1.0.0';
+
+export type CookieConsentInput = {
+  analytics: boolean;
+  marketing: boolean;
+};
+
+export type CookieConsentSnapshot = {
+  analytics: boolean;
+  marketing: boolean;
+  version: string | null;
+  decidedAt: string | null;
+};

--- a/src/lib/actions/consent.ts
+++ b/src/lib/actions/consent.ts
@@ -1,0 +1,132 @@
+'use server';
+
+import { headers } from 'next/headers';
+
+import { createClient } from '@/lib/supabase/server';
+import { recordConsent, getConsents, ConsentScope } from '@/lib/gdpr/consent';
+import { rateLimit } from '@/lib/security/rate-limit';
+import { log } from '@/lib/log';
+import type { ActionResult } from '@/lib/actions/types';
+import {
+  COOKIE_CONSENT_VERSION,
+  type CookieConsentInput,
+  type CookieConsentSnapshot,
+} from '@/lib/actions/consent-types';
+
+async function contextFromHeaders(): Promise<{ ip: string | null; userAgent: string | null }> {
+  const h = await headers();
+  const forwarded = h.get('x-forwarded-for');
+  const ip = forwarded?.split(',')[0]?.trim() ?? h.get('x-real-ip') ?? null;
+  return { ip, userAgent: h.get('user-agent') };
+}
+
+/**
+ * Records cookie consent decisions for the authenticated user. For unauthenticated
+ * visitors, returns `{ ok: true, persisted: false }` so the client can fall back
+ * to localStorage-only mode without erroring.
+ *
+ * RGPD art. 7 — consent must be specific, informed, and granular. We persist the
+ * analytics and marketing scopes independently so revocation of one does not
+ * cascade to the other.
+ */
+export async function recordCookieConsentAction(
+  input: CookieConsentInput,
+): Promise<ActionResult<{ persisted: boolean }>> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { ok: true, data: { persisted: false } };
+  }
+
+  const rl = await rateLimit('mutation', `consent:${user.id}`);
+  if (!rl.success) {
+    return { ok: false, errorCode: 'errors.session.rateLimited' };
+  }
+
+  const ctx = await contextFromHeaders();
+
+  try {
+    await recordConsent(
+      user.id,
+      ConsentScope.COOKIES_ANALYTICS,
+      input.analytics,
+      COOKIE_CONSENT_VERSION,
+      { ipAddress: ctx.ip, userAgent: ctx.userAgent },
+    );
+    await recordConsent(
+      user.id,
+      ConsentScope.COOKIES_MARKETING,
+      input.marketing,
+      COOKIE_CONSENT_VERSION,
+      { ipAddress: ctx.ip, userAgent: ctx.userAgent },
+    );
+  } catch (error) {
+    log.warn('Failed to persist cookie consent', {
+      userId: user.id,
+      error: error instanceof Error ? error.message : 'unknown',
+    });
+    return { ok: false, errorCode: 'errors.generic' };
+  }
+
+  return { ok: true, data: { persisted: true } };
+}
+
+/**
+ * Reads the current cookie consent snapshot for the authenticated user.
+ * Returns `null` for unauthenticated visitors — the client should rely on
+ * localStorage in that case.
+ */
+export async function getCookieConsentAction(): Promise<
+  ActionResult<{ snapshot: CookieConsentSnapshot | null }>
+> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { ok: true, data: { snapshot: null } };
+  }
+
+  try {
+    const records = await getConsents(user.id);
+    const analytics = records.find((r) => r.scope === ConsentScope.COOKIES_ANALYTICS);
+    const marketing = records.find((r) => r.scope === ConsentScope.COOKIES_MARKETING);
+
+    if (!analytics && !marketing) {
+      return { ok: true, data: { snapshot: null } };
+    }
+
+    return {
+      ok: true,
+      data: {
+        snapshot: {
+          analytics: analytics?.granted ?? false,
+          marketing: marketing?.granted ?? false,
+          version: analytics?.version ?? marketing?.version ?? null,
+          decidedAt: analytics?.grantedAt ?? analytics?.revokedAt ?? marketing?.grantedAt ?? null,
+        },
+      },
+    };
+  } catch (error) {
+    log.warn('Failed to read cookie consent', {
+      userId: user.id,
+      error: error instanceof Error ? error.message : 'unknown',
+    });
+    return { ok: false, errorCode: 'errors.generic' };
+  }
+}
+
+/**
+ * Resets cookie consent decisions for the authenticated user by recording
+ * `granted=false` on both analytics and marketing scopes. The client is then
+ * responsible for clearing its localStorage so the banner re-prompts.
+ *
+ * RGPD art. 7(3) — withdrawing consent must be as easy as giving it.
+ */
+export async function resetCookieConsentAction(): Promise<ActionResult<{ persisted: boolean }>> {
+  return recordCookieConsentAction({ analytics: false, marketing: false });
+}


### PR DESCRIPTION
## Summary

Closes the four GDPR gaps from @cowork's 2026-05-06 legal audit on cookie consent. Banner maison amélioré (decision @cowork: not Klaro!) — Phase 1 ships zero ad/marketing trackers, Belgian APD accepts any GDPR-compliant flow.

- **Granular 3-button banner**: Essential only / Customize / Accept all. Customize panel exposes analytics + marketing categories independently with descriptions.
- **Backend audit trail**: client decisions trigger `recordCookieConsentAction()` (new Server Action) which persists each scope (cookies.analytics, cookies.marketing) in the existing `user_consents` table with version, IP and User-Agent. Auth users get GDPR audit; visitors fall back to localStorage-only via the action's silent no-op path.
- **Settings → Cookies & privacy**: SSR-fetched snapshot via `getCookieConsentAction()`, hydrates from fresher localStorage on mount, per-category toggles, "Reset my choice" button that clears localStorage + records `granted=false` server-side + reopens banner.
- **Footer "Manage cookie preferences"**: reopens banner from any page (RGPD art. 7(3) — withdrawing consent must be as easy as giving it).
- **Legal page enrichment**: 3 new sections (manage methods, withdrawal, lifetimes). `legal.cookies.draft` placeholder removed across all 5 locales.

## i18n (5 locales, full parity, no FR placeholders)

`consent.acceptAll`, `consent.customize.*` (10 keys), `settings.cookies.*` (14 keys), `footer.cookiePreferences`, `legal.cookies.*` (6 new keys). Patched in lockstep.

## Bonus — Sourcery PR #119 follow-up (BrandHomeLink + a11y)

New `<BrandHomeLink>` shared by Header and Footer. Inner `<svg>` carries `aria-hidden focusable={false}`; the parent link's `aria-label="Accueil Ankora"` becomes the single SR announcement (fixes the duplicate readout flagged on PR #119). Focus ring + press animation classes centralised so they cannot drift between surfaces.

## Tests

- **5 new / extended Vitest files**: BrandHomeLink, ConsentBanner extended, CookiesPreferencesSection, Footer extended, plus the existing legal cookies page kept green. Cover accept-all / essential-only / customize-then-save flow, re-open flag honoured even with an existing decision, server-snapshot hydration with localStorage freshness override, reset clears localStorage + reopens banner + records revocation server-side, BrandHomeLink a11y semantics.
- **New `e2e/cookies-consent.spec.ts`** smoke covering: first-visit shows the three-button banner, accept-all dismisses + persists, customize saves a granular choice, footer button reopens the banner from any page.

## Verification

- ✅ `npm run lint` — 0 errors, 7 no-console warnings (intentional, error boundaries only).
- ✅ `npm run lint:use-server` — clean. (Pure types/constants moved to sibling `consent-types.ts` so the `'use server'` file stays strictly async-export-only.)
- ✅ `npm run typecheck` — clean.
- ✅ `npx vitest run` — 623/623 tests across 64 files (4 new test files vs main).
- ✅ `npm run build` — clean exit, all routes prerender.

## Out of scope (per @cowork direction)

- No Klaro! integration — re-evaluable in Phase 2 if Ankora adds 3rd-party marketing trackers.
- No TCF v2.2 (not applicable to Phase 1's tracker-free posture).
- No refactor of existing GDPR delete/export flows.

## Test plan

- [x] Lint + typecheck + vitest + build green
- [x] 4 new E2E cases written (CI run on push)
- [ ] CI 7/7 green on push (verify post-merge — Playwright iPhone SE BUG-iOS-011 #116 expected to fail per @cowork accepted bypass)
- [ ] Sourcery silent on the latest commit
- [ ] Manual smoke @thierry: incognito visit → 3-button banner → Accept all → banner gone → Settings shows toggles ON → Reset → banner back. Footer "Manage cookie preferences" reopens from any page.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — @cc-ankora (Opus 4.7)