### PR TITLE
feat(cockpit): Effort Lissé + Capacité Réelle hero radar (PR-D3)

### DIFF
--- a/e2e/dashboard-cockpit-bloc2.spec.ts
+++ b/e2e/dashboard-cockpit-bloc2.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from './helpers/test';
+import { adminClientOrNull, deleteSeededUser, seedOnboardedUser } from './helpers/seed';
+
+const admin = adminClientOrNull();
+
+test.describe('PR-D3 — Bloc 2 hero radar (Effort Lissé + Capacité Réelle)', () => {
+  test.skip(!admin, 'Needs real Supabase (NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY).');
+
+  test('renders both hero cards on the dashboard for an authenticated user', async ({ page }) => {
+    if (!admin) return;
+    const user = await seedOnboardedUser(admin, [
+      { label: 'Loyer', amount: 900, frequency: 'monthly', dueMonth: 1, paidFrom: 'principal' },
+    ]);
+    // Configure income + daily allowance so the cards have non-trivial inputs.
+    await admin
+      .from('workspaces')
+      .update({ monthly_income: 2500, vie_courante_monthly_transfer: 500 })
+      .eq('id', user.workspaceId);
+
+    try {
+      await page.goto('/login');
+      await page.getByLabel('Email').fill(user.email);
+      await page.getByLabel('Mot de passe').fill(user.password);
+      await page.getByRole('button', { name: /^se connecter$/i }).click();
+      await page.waitForURL(/\/app\b/, { timeout: 15_000 });
+
+      await expect(page.getByTestId('effort-financier-card')).toBeVisible();
+      await expect(page.getByTestId('capacite-epargne-card')).toBeVisible();
+      // 2500 - 900 - 500 = 1100 → positive
+      const card = page.getByTestId('capacite-epargne-card');
+      await expect(card).toHaveAttribute('data-positive', 'true');
+    } finally {
+      await deleteSeededUser(admin, user.userId);
+    }
+  });
+
+  test('renders the negative variant in rose when charges exceed income', async ({ page }) => {
+    if (!admin) return;
+    const user = await seedOnboardedUser(admin, [
+      { label: 'Big bill', amount: 1500, frequency: 'monthly', dueMonth: 1, paidFrom: 'principal' },
+    ]);
+    await admin
+      .from('workspaces')
+      .update({ monthly_income: 1000, vie_courante_monthly_transfer: 0 })
+      .eq('id', user.workspaceId);
+
+    try {
+      await page.goto('/login');
+      await page.getByLabel('Email').fill(user.email);
+      await page.getByLabel('Mot de passe').fill(user.password);
+      await page.getByRole('button', { name: /^se connecter$/i }).click();
+      await page.waitForURL(/\/app\b/, { timeout: 15_000 });
+
+      const card = page.getByTestId('capacite-epargne-card');
+      await expect(card).toBeVisible();
+      await expect(card).toHaveAttribute('data-positive', 'false');
+      const value = page.getByTestId('capacite-epargne-value');
+      // The value class string must include the rose accent.
+      const className = await value.getAttribute('class');
+      expect(className ?? '').toMatch(/rose/);
+    } finally {
+      await deleteSeededUser(admin, user.userId);
+    }
+  });
+
+  test('renders the mini-CTA on daily_card when vie_courante_monthly_transfer is null', async ({
+    page,
+  }) => {
+    if (!admin) return;
+    const user = await seedOnboardedUser(admin, [
+      { label: 'Loyer', amount: 800, frequency: 'monthly', dueMonth: 1, paidFrom: 'principal' },
+    ]);
+    // Income only — daily allowance left null on purpose.
+    await admin
+      .from('workspaces')
+      .update({ monthly_income: 2000, vie_courante_monthly_transfer: null })
+      .eq('id', user.workspaceId);
+
+    try {
+      await page.goto('/login');
+      await page.getByLabel('Email').fill(user.email);
+      await page.getByLabel('Mot de passe').fill(user.password);
+      await page.getByRole('button', { name: /^se connecter$/i }).click();
+      await page.waitForURL(/\/app\b/, { timeout: 15_000 });
+
+      // The CTA links to /app/accounts so the user can finish the cockpit
+      // setup. Anchored to the daily_card row via the AccountCard data-attr.
+      const dailyCard = page.locator('[data-account-type="daily_card"]');
+      await expect(dailyCard).toBeVisible();
+      const cta = dailyCard.getByRole('link', { name: /régler le plafond quotidien/i });
+      await expect(cta).toBeVisible();
+      await expect(cta).toHaveAttribute('href', /\/app\/accounts/);
+    } finally {
+      await deleteSeededUser(admin, user.userId);
+    }
+  });
+
+  test('Bloc 2 stays visible on iPhone viewport (mobile-first)', async ({ page }) => {
+    if (!admin) return;
+    const user = await seedOnboardedUser(admin, [
+      { label: 'Loyer', amount: 700, frequency: 'monthly', dueMonth: 1, paidFrom: 'principal' },
+    ]);
+    await admin
+      .from('workspaces')
+      .update({ monthly_income: 2500, vie_courante_monthly_transfer: 400 })
+      .eq('id', user.workspaceId);
+
+    await page.setViewportSize({ width: 375, height: 667 });
+    try {
+      await page.goto('/login');
+      await page.getByLabel('Email').fill(user.email);
+      await page.getByLabel('Mot de passe').fill(user.password);
+      await page.getByRole('button', { name: /^se connecter$/i }).click();
+      await page.waitForURL(/\/app\b/, { timeout: 15_000 });
+
+      await expect(page.getByTestId('effort-financier-card')).toBeVisible();
+      await expect(page.getByTestId('capacite-epargne-card')).toBeVisible();
+    } finally {
+      await deleteSeededUser(admin, user.userId);
+    }
+  });
+});

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -900,6 +900,21 @@
       }
     }
   },
+  "dashboard": {
+    "effort": {
+      "title": "Geglätteter finanzieller Aufwand",
+      "charges_fixes": "Fixe Ausgaben",
+      "provisions": "Rückstellungen"
+    },
+    "capacite": {
+      "title": "Reale Sparkapazität",
+      "message_positive": "Das bleibt dir wirklich jeden Monat — keine Überraschungen.",
+      "message_negative": "Achtung: dein gesamter Lebensstil übersteigt dein Einkommen."
+    },
+    "daily": {
+      "cta_set_plafond": "Tägliches Limit festlegen"
+    }
+  },
   "glossary": {
     "title": "Glossary",
     "subtitle": "15 essential terms for understanding your budgeting and personal finances.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -900,6 +900,21 @@
       }
     }
   },
+  "dashboard": {
+    "effort": {
+      "title": "Smoothed financial effort",
+      "charges_fixes": "Fixed charges",
+      "provisions": "Provisions"
+    },
+    "capacite": {
+      "title": "Real saving capacity",
+      "message_positive": "This is your true monthly leftover — no surprises.",
+      "message_negative": "Heads up: your overall lifestyle exceeds your income."
+    },
+    "daily": {
+      "cta_set_plafond": "Set my daily allowance"
+    }
+  },
   "glossary": {
     "title": "Glossary",
     "subtitle": "15 essential terms for understanding your budgeting and personal finances.",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -900,6 +900,21 @@
       }
     }
   },
+  "dashboard": {
+    "effort": {
+      "title": "Esfuerzo financiero suavizado",
+      "charges_fixes": "Gastos fijos",
+      "provisions": "Provisiones"
+    },
+    "capacite": {
+      "title": "Capacidad real de ahorro",
+      "message_positive": "Esto es lo que realmente te queda cada mes, sin sorpresas.",
+      "message_negative": "Cuidado: tu nivel de vida global supera tus ingresos."
+    },
+    "daily": {
+      "cta_set_plafond": "Configurar el límite diario"
+    }
+  },
   "glossary": {
     "title": "Glossary",
     "subtitle": "15 essential terms for understanding your budgeting and personal finances.",

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -900,6 +900,21 @@
       }
     }
   },
+  "dashboard": {
+    "effort": {
+      "title": "Effort financier lissé",
+      "charges_fixes": "Charges fixes",
+      "provisions": "Provisions"
+    },
+    "capacite": {
+      "title": "Capacité d'épargne réelle",
+      "message_positive": "C'est ton vrai reste à vivre chaque mois, sans surprise.",
+      "message_negative": "Attention, ton train de vie global dépasse tes revenus."
+    },
+    "daily": {
+      "cta_set_plafond": "Régler le plafond quotidien"
+    }
+  },
   "glossary": {
     "title": "Glossaire",
     "subtitle": "15 termes essentiels pour comprendre ta gestion budgétaire et tes finances personnelles.",

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -900,6 +900,21 @@
       }
     }
   },
+  "dashboard": {
+    "effort": {
+      "title": "Vereffende financiële inspanning",
+      "charges_fixes": "Vaste kosten",
+      "provisions": "Voorzieningen"
+    },
+    "capacite": {
+      "title": "Werkelijke spaarcapaciteit",
+      "message_positive": "Dit is wat je elke maand echt overhoudt, zonder verrassingen.",
+      "message_negative": "Let op: je totale levensstijl overschrijdt je inkomen."
+    },
+    "daily": {
+      "cta_set_plafond": "Dagelijks plafond instellen"
+    }
+  },
   "glossary": {
     "title": "Woordenboek",
     "subtitle": "15 essentiële termen voor het begrijpen van je budgetbeheer en persoonlijke financiën.",

--- a/src/app/[locale]/app/page.tsx
+++ b/src/app/[locale]/app/page.tsx
@@ -14,8 +14,10 @@ import { Link } from '@/i18n/navigation';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { AccountCard } from '@/components/features/AccountCard';
+import { EffortFinancierCard } from '@/components/dashboard/EffortFinancierCard';
+import { CapaciteEpargneCard } from '@/components/dashboard/CapaciteEpargneCard';
 import { Budget, Expenses, Provision, Transfer, money } from '@/lib/domain';
-import { getWorkspaceSnapshot } from '@/lib/data/workspace-snapshot';
+import { getWorkspaceSnapshot, toCockpitCharges } from '@/lib/data/workspace-snapshot';
 import type { AccountType } from '@/lib/schemas/account';
 import type { Locale } from '@/i18n/routing';
 import { formatCurrency, formatDate, formatMonth } from '@/lib/i18n/formatters';
@@ -87,6 +89,15 @@ export default async function DashboardPage() {
     snapshot.monthlyIncome === null || snapshot.vieCouranteMonthlyTransfer === null;
   const accountByType = new Map(snapshot.accounts.map((a) => [a.accountType, a]));
 
+  // PR-D3 — Bloc 2 hero radar inputs.
+  const cockpitCharges = toCockpitCharges(snapshot.charges);
+  // Daily allowance not yet configured: surface the inline CTA on the
+  // daily_card row so the user can complete the cockpit setup without
+  // hunting through Settings.
+  const dailyPlafondMissing =
+    snapshot.vieCouranteMonthlyTransfer === null || snapshot.vieCouranteMonthlyTransfer === 0;
+  const tDaily = await getTranslations('dashboard.daily');
+
   return (
     <div className="flex flex-col gap-8">
       <header>
@@ -95,6 +106,26 @@ export default async function DashboardPage() {
           {t('headerTitle', { month: monthLabel })}
         </h1>
       </header>
+
+      {/*
+        PR-D3 — Bloc 2 hero radar (Voie D 3/8).
+        Always visible (even on an empty workspace, where Effort = 0 and
+        Capacité = revenus - plafond) so the user always sees the canonical
+        cockpit narrative. The Capacité card is the differentiating KPI;
+        the Effort card sits beside it as the breakdown that justifies it.
+      */}
+      <section
+        aria-label={t('headerTitle', { month: monthLabel })}
+        className="grid gap-4 md:grid-cols-2"
+      >
+        <EffortFinancierCard charges={cockpitCharges} locale={locale} />
+        <CapaciteEpargneCard
+          revenus={monthlyIncome}
+          charges={cockpitCharges}
+          plafondQuotidien={vieCouranteTransferAmount}
+          locale={locale}
+        />
+      </section>
 
       {!hasCharges ? (
         <Card>
@@ -282,6 +313,15 @@ export default async function DashboardPage() {
             {ACCOUNT_TYPE_ORDER.map((accountType) => {
               const account = accountByType.get(accountType);
               if (!account) return null;
+              const extraHint =
+                accountType === 'daily_card' && dailyPlafondMissing ? (
+                  <Link
+                    href="/app/accounts"
+                    className="text-muted-foreground hover:text-brand-700 text-xs hover:underline"
+                  >
+                    {tDaily('cta_set_plafond')}
+                  </Link>
+                ) : undefined;
               return (
                 <AccountCard
                   key={accountType}
@@ -289,6 +329,7 @@ export default async function DashboardPage() {
                   displayName={account.displayName}
                   balance={account.balance}
                   locale={locale}
+                  extraHint={extraHint}
                 />
               );
             })}

--- a/src/components/dashboard/CapaciteEpargneCard.tsx
+++ b/src/components/dashboard/CapaciteEpargneCard.tsx
@@ -1,0 +1,100 @@
+import Decimal from 'decimal.js';
+import { AlertCircle, CheckCircle2 } from 'lucide-react';
+import { getTranslations } from 'next-intl/server';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { capaciteEpargneReelle } from '@/lib/domain/cockpit';
+import type { CockpitCharge } from '@/lib/domain/cockpit/types';
+import { formatCurrency } from '@/lib/i18n/formatters';
+import type { Locale } from '@/i18n/routing';
+
+type Props = {
+  revenus: Decimal;
+  charges: readonly CockpitCharge[];
+  plafondQuotidien: Decimal;
+  locale: Locale;
+};
+
+/**
+ * Capacité d'Épargne Réelle — radar card #2 of cockpit Bloc 2 (ADR-009).
+ *
+ * THE differentiating KPI: `revenus - effortFinancierLisse - plafondQuotidien`.
+ * Stable mois-après-mois (the lissage absorbs the volatility of periodic
+ * bills) and honest about whether the user's lifestyle fits inside their
+ * income on a true annual basis. No competitor (Monarch, YNAB, Lunch Money,
+ * Linxo, Bankin') ships this calculation.
+ *
+ * Visual semantics:
+ *  - emerald accent + CheckCircle2 + positive message when capacité ≥ 0
+ *  - rose accent + AlertCircle + warning message when capacité < 0
+ *  - decorative glow blob bottom-right matching the state colour
+ *
+ * Server Component (math + i18n only).
+ */
+export async function CapaciteEpargneCard({ revenus, charges, plafondQuotidien, locale }: Props) {
+  const t = await getTranslations('dashboard.capacite');
+  const result = capaciteEpargneReelle({ revenus, charges, plafondQuotidien });
+  const fmt = (value: Parameters<typeof formatCurrency>[0]) => formatCurrency(value, locale);
+
+  const accent = result.isPositive
+    ? {
+        ringColor: 'ring-emerald-500/15',
+        iconColor: 'text-emerald-500',
+        valueColor: 'text-emerald-600 dark:text-emerald-400',
+        glowColor: 'bg-emerald-500/20',
+        gradientFrom: 'from-emerald-500/8',
+        Icon: CheckCircle2,
+        message: t('message_positive'),
+      }
+    : {
+        ringColor: 'ring-rose-500/15',
+        iconColor: 'text-rose-500',
+        valueColor: 'text-rose-600 dark:text-rose-400',
+        glowColor: 'bg-rose-500/20',
+        gradientFrom: 'from-rose-500/8',
+        Icon: AlertCircle,
+        message: t('message_negative'),
+      };
+
+  // Force "+12,34 €" prefix on positive values so the affirmative framing is
+  // unambiguous; the formatter omits the sign for non-negative numbers by
+  // default. Zero stays unsigned (still positive per `isPositive`).
+  const formatted = fmt(result.capacite);
+  const signed = result.capacite.gt(0) ? `+${formatted}` : formatted;
+
+  return (
+    <Card
+      className={`relative overflow-hidden ring-1 ring-inset ${accent.ringColor}`}
+      data-testid="capacite-epargne-card"
+      data-positive={result.isPositive ? 'true' : 'false'}
+    >
+      <div
+        aria-hidden
+        className={`pointer-events-none absolute inset-0 bg-gradient-to-br ${accent.gradientFrom} to-transparent`}
+      />
+      <div
+        aria-hidden
+        className={`pointer-events-none absolute -right-16 -bottom-16 h-48 w-48 rounded-full ${accent.glowColor} opacity-70 blur-3xl`}
+      />
+      <CardHeader className="relative flex flex-row items-start justify-between gap-3 pb-2">
+        <div className="min-w-0">
+          <CardTitle className="text-muted-foreground text-sm font-medium">{t('title')}</CardTitle>
+        </div>
+        <accent.Icon
+          aria-hidden
+          strokeWidth={1.5}
+          className={`h-6 w-6 shrink-0 ${accent.iconColor}`}
+        />
+      </CardHeader>
+      <CardContent className="relative">
+        <p
+          className={`text-4xl font-bold tracking-tight tabular-nums ${accent.valueColor}`}
+          data-testid="capacite-epargne-value"
+        >
+          {signed}
+        </p>
+        <p className="text-muted-foreground mt-3 text-sm leading-relaxed">{accent.message}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/EffortFinancierCard.tsx
+++ b/src/components/dashboard/EffortFinancierCard.tsx
@@ -1,0 +1,77 @@
+import { ShieldCheck } from 'lucide-react';
+import { getTranslations } from 'next-intl/server';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  effortFinancierLisse,
+  provisionsMensuellesLissees,
+  totalChargesMensuelles,
+} from '@/lib/domain/cockpit';
+import type { CockpitCharge } from '@/lib/domain/cockpit/types';
+import { formatCurrency } from '@/lib/i18n/formatters';
+import type { Locale } from '@/i18n/routing';
+
+type Props = {
+  charges: readonly CockpitCharge[];
+  locale: Locale;
+};
+
+/**
+ * Effort Financier Lissé — radar card #1 of cockpit Bloc 2 (ADR-009).
+ *
+ * Big number = `totalChargesMensuelles + provisionsMensuellesLissees`. The
+ * breakdown reveals the two contributors so the user can recognise that
+ * a "calm month" with no annual bill due is not a green light to spend
+ * the apparent surplus — the lissage already earmarked it.
+ *
+ * Visually: subtle navy gradient + brass shield top-right + tabular numerics.
+ * Server Component (zero hydration cost — pure math + i18n).
+ */
+export async function EffortFinancierCard({ charges, locale }: Props) {
+  const t = await getTranslations('dashboard.effort');
+  const fixedCharges = totalChargesMensuelles(charges);
+  const provisions = provisionsMensuellesLissees(charges);
+  const total = effortFinancierLisse(charges);
+  const fmt = (value: Parameters<typeof formatCurrency>[0]) => formatCurrency(value, locale);
+
+  return (
+    <Card
+      className="relative overflow-hidden ring-1 ring-blue-500/15 ring-inset"
+      data-testid="effort-financier-card"
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 bg-gradient-to-br from-blue-500/8 to-transparent"
+      />
+      <CardHeader className="relative flex flex-row items-start justify-between gap-3 pb-2">
+        <div className="min-w-0">
+          <CardTitle className="text-muted-foreground text-sm font-medium">{t('title')}</CardTitle>
+        </div>
+        <ShieldCheck aria-hidden strokeWidth={1.5} className="h-6 w-6 shrink-0 text-blue-500" />
+      </CardHeader>
+      <CardContent className="relative">
+        <p
+          className="text-foreground text-4xl font-bold tracking-tight tabular-nums"
+          data-testid="effort-financier-total"
+        >
+          {fmt(total)}
+        </p>
+        <dl className="mt-4 grid grid-cols-2 gap-3 text-xs">
+          <div>
+            <dt className="text-muted-foreground">{t('charges_fixes')}</dt>
+            <dd className="text-foreground mt-0.5 font-semibold tabular-nums">
+              {fmt(fixedCharges)}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">{t('provisions')}</dt>
+            <dd className="text-foreground mt-0.5 font-semibold tabular-nums">
+              {provisions.gt(0) ? '+' : ''}
+              {fmt(provisions)}
+            </dd>
+          </div>
+        </dl>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/__tests__/CapaciteEpargneCard.test.tsx
+++ b/src/components/dashboard/__tests__/CapaciteEpargneCard.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Decimal from 'decimal.js';
+
+import messages from '../../../../messages/fr-BE.json';
+import type { CockpitCharge } from '@/lib/domain/cockpit/types';
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: async (namespace: string) => {
+    const ns =
+      (messages as Record<string, Record<string, unknown>>)[namespace.split('.')[0] ?? ''] ?? {};
+    const sub = namespace
+      .split('.')
+      .slice(1)
+      .reduce<unknown>((acc, key) => {
+        if (typeof acc === 'object' && acc !== null && key in acc) {
+          return (acc as Record<string, unknown>)[key];
+        }
+        return undefined;
+      }, ns);
+    return (key: string) => {
+      const node = sub;
+      if (typeof node === 'object' && node !== null && key in node) {
+        const value = (node as Record<string, unknown>)[key];
+        return typeof value === 'string' ? value : key;
+      }
+      return key;
+    };
+  },
+}));
+
+import { CapaciteEpargneCard } from '../CapaciteEpargneCard';
+
+const charge = (over: Partial<CockpitCharge>): CockpitCharge => ({
+  id: over.id ?? `c-${Math.random().toString(36).slice(2)}`,
+  label: 'Test',
+  amount: new Decimal(0),
+  frequency: 'monthly',
+  paymentMonths: [1],
+  paymentDay: 1,
+  isActive: true,
+  ...over,
+});
+
+const renderCard = async (input: {
+  revenus: Decimal;
+  charges: CockpitCharge[];
+  plafondQuotidien: Decimal;
+}) => {
+  const ui = await CapaciteEpargneCard({ ...input, locale: 'fr-BE' });
+  return render(ui);
+};
+
+describe('<CapaciteEpargneCard /> (PR-D3 Bloc 2 radar #2 — KPI hero)', () => {
+  it('renders the FR title from the dashboard.capacite namespace', async () => {
+    await renderCard({
+      revenus: new Decimal(2000),
+      charges: [],
+      plafondQuotidien: new Decimal(0),
+    });
+    expect(screen.getByText(messages.dashboard.capacite.title)).toBeInTheDocument();
+  });
+
+  it('renders the positive variant with emerald colour and prefix +', async () => {
+    await renderCard({
+      revenus: new Decimal(2500),
+      charges: [charge({ amount: new Decimal(1500), frequency: 'monthly' })],
+      plafondQuotidien: new Decimal(500),
+    });
+    const card = screen.getByTestId('capacite-epargne-card');
+    expect(card.getAttribute('data-positive')).toBe('true');
+    const value = screen.getByTestId('capacite-epargne-value');
+    expect(value.textContent ?? '').toMatch(/^\+/);
+    expect(value.className).toContain('emerald');
+    expect(screen.getByText(messages.dashboard.capacite.message_positive)).toBeInTheDocument();
+  });
+
+  it('renders the negative variant with rose colour and warning message', async () => {
+    await renderCard({
+      revenus: new Decimal(1000),
+      charges: [charge({ amount: new Decimal(1500), frequency: 'monthly' })],
+      plafondQuotidien: new Decimal(0),
+    });
+    const card = screen.getByTestId('capacite-epargne-card');
+    expect(card.getAttribute('data-positive')).toBe('false');
+    const value = screen.getByTestId('capacite-epargne-value');
+    expect(value.className).toContain('rose');
+    expect(screen.getByText(messages.dashboard.capacite.message_negative)).toBeInTheDocument();
+  });
+
+  it('treats capacité = 0 as positive (≥ 0 contract)', async () => {
+    await renderCard({
+      revenus: new Decimal(1000),
+      charges: [],
+      plafondQuotidien: new Decimal(1000),
+    });
+    const card = screen.getByTestId('capacite-epargne-card');
+    expect(card.getAttribute('data-positive')).toBe('true');
+    // Zero stays unsigned (no leading "+")
+    const value = screen.getByTestId('capacite-epargne-value');
+    expect(value.textContent ?? '').not.toMatch(/^\+/);
+  });
+
+  it('handles revenus = 0 with massive negative output', async () => {
+    await renderCard({
+      revenus: new Decimal(0),
+      charges: [charge({ amount: new Decimal(100), frequency: 'monthly' })],
+      plafondQuotidien: new Decimal(50),
+    });
+    const card = screen.getByTestId('capacite-epargne-card');
+    expect(card.getAttribute('data-positive')).toBe('false');
+    const value = screen.getByTestId('capacite-epargne-value');
+    expect(value.textContent ?? '').toMatch(/-150/);
+  });
+
+  it('keeps decimal precision across many lissed charges', async () => {
+    // 12 × Dashlane (53 € annual) = 12 × 4.4166… = 53 exactly.
+    const charges = Array.from({ length: 12 }, () =>
+      charge({ amount: new Decimal(53), frequency: 'annual', paymentMonths: [4] }),
+    );
+    await renderCard({
+      revenus: new Decimal(0),
+      charges,
+      plafondQuotidien: new Decimal(0),
+    });
+    const value = screen.getByTestId('capacite-epargne-value');
+    expect(value.textContent ?? '').toMatch(/-53[,.]00/);
+  });
+
+  it('handles the @thierry mixed-frequency fixture (negative case)', async () => {
+    const charges = [
+      charge({ amount: new Decimal(1500), frequency: 'monthly' }),
+      charge({ amount: new Decimal(53), frequency: 'annual', paymentMonths: [4] }),
+      charge({ amount: new Decimal(45), frequency: 'quarterly', paymentMonths: [1, 4, 7, 10] }),
+      charge({ amount: new Decimal(300), frequency: 'annual', paymentMonths: [6] }),
+      charge({ amount: new Decimal(120), frequency: 'annual', paymentMonths: [3] }),
+      charge({ amount: new Decimal(55), frequency: 'annual', paymentMonths: [3] }),
+      charge({ amount: new Decimal(600), frequency: 'semiannual', paymentMonths: [2, 8] }),
+    ];
+    await renderCard({
+      revenus: new Decimal(2000),
+      charges,
+      plafondQuotidien: new Decimal(500),
+    });
+    // capacité = 2000 - 1659 - 500 = -159
+    const card = screen.getByTestId('capacite-epargne-card');
+    expect(card.getAttribute('data-positive')).toBe('false');
+    const value = screen.getByTestId('capacite-epargne-value');
+    expect(value.textContent ?? '').toMatch(/-159/);
+  });
+});
+
+describe('dashboard.capacite — i18n parity (5 locales)', () => {
+  it.each(['fr-BE', 'en', 'de-DE', 'es-ES', 'nl-BE'] as const)(
+    'locale %s exposes title + message_positive + message_negative',
+    async (locale) => {
+      const m = (await import(`../../../../messages/${locale}.json`)).default as {
+        dashboard: {
+          capacite: {
+            title?: string;
+            message_positive?: string;
+            message_negative?: string;
+          };
+        };
+      };
+      expect(m.dashboard.capacite.title).toBeTypeOf('string');
+      expect((m.dashboard.capacite.title ?? '').length).toBeGreaterThan(0);
+      expect(m.dashboard.capacite.message_positive).toBeTypeOf('string');
+      expect(m.dashboard.capacite.message_negative).toBeTypeOf('string');
+    },
+  );
+});

--- a/src/components/dashboard/__tests__/EffortFinancierCard.test.tsx
+++ b/src/components/dashboard/__tests__/EffortFinancierCard.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Decimal from 'decimal.js';
+
+import messages from '../../../../messages/fr-BE.json';
+import type { CockpitCharge } from '@/lib/domain/cockpit/types';
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: async (namespace: string) => {
+    const ns =
+      (messages as Record<string, Record<string, unknown>>)[namespace.split('.')[0] ?? ''] ?? {};
+    const sub = namespace
+      .split('.')
+      .slice(1)
+      .reduce<unknown>((acc, key) => {
+        if (typeof acc === 'object' && acc !== null && key in acc) {
+          return (acc as Record<string, unknown>)[key];
+        }
+        return undefined;
+      }, ns);
+    return (key: string) => {
+      const node = sub;
+      if (typeof node === 'object' && node !== null && key in node) {
+        const value = (node as Record<string, unknown>)[key];
+        return typeof value === 'string' ? value : key;
+      }
+      return key;
+    };
+  },
+}));
+
+import { EffortFinancierCard } from '../EffortFinancierCard';
+
+const charge = (over: Partial<CockpitCharge>): CockpitCharge => ({
+  id: over.id ?? `c-${Math.random().toString(36).slice(2)}`,
+  label: 'Test',
+  amount: new Decimal(0),
+  frequency: 'monthly',
+  paymentMonths: [1],
+  paymentDay: 1,
+  isActive: true,
+  ...over,
+});
+
+const renderCard = async (charges: CockpitCharge[]) => {
+  const ui = await EffortFinancierCard({ charges, locale: 'fr-BE' });
+  return render(ui);
+};
+
+describe('<EffortFinancierCard /> (PR-D3 Bloc 2 radar #1)', () => {
+  it('renders the FR title and an empty-state total of 0', async () => {
+    await renderCard([]);
+    expect(screen.getByText(messages.dashboard.effort.title)).toBeInTheDocument();
+    const total = screen.getByTestId('effort-financier-total');
+    expect(total.textContent ?? '').toMatch(/0[,.]00/);
+  });
+
+  it('sums monthly charges into the fixed-charges breakdown only', async () => {
+    await renderCard([
+      charge({ amount: new Decimal(900), frequency: 'monthly' }),
+      charge({ amount: new Decimal(60), frequency: 'monthly' }),
+    ]);
+    const total = screen.getByTestId('effort-financier-total');
+    expect(total.textContent ?? '').toMatch(/960/);
+  });
+
+  it('lisses an annual charge across 12 months in the provisions row', async () => {
+    await renderCard([
+      charge({ amount: new Decimal(1200), frequency: 'annual', paymentMonths: [3] }),
+    ]);
+    const total = screen.getByTestId('effort-financier-total');
+    // 1200 / 12 = 100
+    expect(total.textContent ?? '').toMatch(/100/);
+  });
+
+  it('combines monthly + provisions into the headline total', async () => {
+    await renderCard([
+      charge({ amount: new Decimal(1500), frequency: 'monthly' }),
+      charge({ amount: new Decimal(1200), frequency: 'annual', paymentMonths: [3] }),
+      charge({ amount: new Decimal(45), frequency: 'quarterly', paymentMonths: [1, 4, 7, 10] }),
+    ]);
+    // 1500 + 100 + 15 = 1615
+    const total = screen.getByTestId('effort-financier-total');
+    expect(total.textContent ?? '').toMatch(/1\s?615/);
+  });
+
+  it('ignores inactive charges (cockpit math contract)', async () => {
+    await renderCard([
+      charge({ amount: new Decimal(900), frequency: 'monthly' }),
+      charge({ amount: new Decimal(800), frequency: 'monthly', isActive: false }),
+    ]);
+    const total = screen.getByTestId('effort-financier-total');
+    expect(total.textContent ?? '').toMatch(/900/);
+  });
+});
+
+describe('errors.dashboard.effort — i18n parity (5 locales)', () => {
+  it.each(['fr-BE', 'en', 'de-DE', 'es-ES', 'nl-BE'] as const)(
+    'locale %s exposes title/charges_fixes/provisions',
+    async (locale) => {
+      const m = (await import(`../../../../messages/${locale}.json`)).default as {
+        dashboard: { effort: { title?: string; charges_fixes?: string; provisions?: string } };
+      };
+      expect(m.dashboard.effort.title).toBeTypeOf('string');
+      expect((m.dashboard.effort.title ?? '').length).toBeGreaterThan(0);
+      expect(m.dashboard.effort.charges_fixes).toBeTypeOf('string');
+      expect(m.dashboard.effort.provisions).toBeTypeOf('string');
+    },
+  );
+});

--- a/src/components/features/AccountCard.tsx
+++ b/src/components/features/AccountCard.tsx
@@ -14,6 +14,12 @@ type AccountCardProps = {
   displayName: string;
   balance: number;
   locale: Locale;
+  /**
+   * Optional inline hint rendered below the balance — used by the dashboard
+   * to surface the "Set my daily allowance" CTA on the `daily_card` row when
+   * `vie_courante_monthly_transfer` is unset (PR-D3 mini-CTA).
+   */
+  extraHint?: React.ReactNode;
 };
 
 const TYPE_VISUAL: Record<
@@ -47,7 +53,13 @@ const TYPE_VISUAL: Record<
  * Visual semantics per account_type are locked by the canonical spec
  * `dashboard-cockpit-vraie-vision-2026-05-03.md` (Bloc 1).
  */
-export async function AccountCard({ accountType, displayName, balance, locale }: AccountCardProps) {
+export async function AccountCard({
+  accountType,
+  displayName,
+  balance,
+  locale,
+  extraHint,
+}: AccountCardProps) {
   const t = await getTranslations('app.accounts');
   const visual = TYPE_VISUAL[accountType];
   const Icon = visual.icon;
@@ -76,6 +88,7 @@ export async function AccountCard({ accountType, displayName, balance, locale }:
         >
           {balanceLabel}
         </p>
+        {extraHint ? <div className="mt-2">{extraHint}</div> : null}
       </CardContent>
     </Card>
   );

--- a/src/lib/data/workspace-snapshot.ts
+++ b/src/lib/data/workspace-snapshot.ts
@@ -9,7 +9,29 @@ import {
   type ChargePaidFrom,
   type Expense,
 } from '@/lib/domain/types';
-import type { AccountType } from '@/lib/domain/cockpit/types';
+import type { AccountType, CockpitCharge } from '@/lib/domain/cockpit/types';
+
+/**
+ * Adapter from the legacy `Charge` shape (still consumed by Bloc 1 KPI helpers
+ * via `Budget.*` / `Transfer.*`) to the cockpit-flavoured `CockpitCharge` that
+ * `effortFinancierLisse()` and `capaciteEpargneReelle()` expect (PR-D1).
+ *
+ * The cockpit math used by PR-D3 only reads `amount`, `frequency`, and
+ * `isActive`; `paymentMonths` and `paymentDay` are stubbed from the legacy
+ * `dueMonth`. PR-D4+ will read the canonical `payment_months[]` / `payment_day`
+ * columns directly from the snapshot once the SELECT is extended.
+ */
+export function toCockpitCharges(charges: readonly Charge[]): readonly CockpitCharge[] {
+  return charges.map((c) => ({
+    id: c.id,
+    label: c.label,
+    amount: c.amount,
+    frequency: c.frequency,
+    paymentMonths: [c.dueMonth] as readonly number[],
+    paymentDay: 1,
+    isActive: c.isActive,
+  }));
+}
 
 /**
  * Canonical timezone for month-boundary calculations on the dashboard.


### PR DESCRIPTION
## Summary

Voie D Dashboard Cockpit complet, sub-PR **3/8**. Wires the two ADR-009 KPI cards into the dashboard so the user sees the canonical cockpit narrative above the existing Bloc 1 KPIs:

| Effort Financier Lissé | Capacité d'Épargne Réelle |
| --- | --- |
| `Σ charges mensuelles + Σ provisions lissées` | `revenus − effortLissé − plafondQuotidien` |

The Capacité card is **the differentiating KPI** — no competitor (Monarch, YNAB, Lunch Money, Linxo, Bankin') ships this lissé annual calculation. Stable mois-après-mois because the lissage absorbs the volatility of periodic bills.

## Architecture

- **`src/components/dashboard/EffortFinancierCard.tsx`** (RSC) — big number + 2-cell breakdown (charges fixes / provisions). Subtle blue gradient + Shield top-right. Reads `totalChargesMensuelles`, `provisionsMensuellesLissees`, `effortFinancierLisse` from PR-D1's cockpit module.
- **`src/components/dashboard/CapaciteEpargneCard.tsx`** (RSC, hero) — emerald (≥ 0) or rose (< 0) accent with matching glow blob, contextual message, and `+12,34 €` prefix on positives. Zero stays unsigned (still positive per `isPositive`).
- **`toCockpitCharges()`** in [src/lib/data/workspace-snapshot.ts](src/lib/data/workspace-snapshot.ts) — adapter `Charge → CockpitCharge`. Stubs `paymentMonths` / `paymentDay` (cockpit math only reads `amount` + `frequency` + `isActive`); PR-D4 will swap in the canonical `payment_months[]` columns once the SELECT is extended.
- **`plafondQuotidien` source resolved** (Phase 2 audit flag): re-uses the existing `workspaces.vie_courante_monthly_transfer` column. **Zero migration**.
- **Mini-CTA "Régler le plafond quotidien"** surfaced inline on the `daily_card` row of Bloc 1 when `vie_courante_monthly_transfer` is null/0. AccountCard grew an optional `extraHint?: React.ReactNode` slot — narrow API addition.
- **Bloc 2 always visible** (even on empty workspace: Effort = 0, Capacité = revenus − plafond).

## i18n

New top-level `dashboard` namespace in **5 locales** (fr-BE, en, de-DE, es-ES, nl-BE) with full key parity:

```
dashboard.effort.{title, charges_fixes, provisions}
dashboard.capacite.{title, message_positive, message_negative}
dashboard.daily.cta_set_plafond
```

No FR placeholders.

## Tests

- **22 Vitest cases** across 2 new files:
  - `EffortFinancierCard.test.tsx` (5 cases) — empty state, monthly-only, annual lissage, mix, inactive ignored, + 5-locale parity.
  - `CapaciteEpargneCard.test.tsx` (7 cases) — title, positive variant emerald + `+` prefix, negative variant rose, capacité = 0 unsigned, revenus = 0, decimal precision over 12 lissed charges, **@thierry mixed-frequency fixture (-159 €)**, + 5-locale parity.
- **4 E2E cases** in `e2e/dashboard-cockpit-bloc2.spec.ts` — both cards visible after login, negative variant rose, mini-CTA when plafond null, Bloc 2 visible on iPhone viewport. Skipped automatically without real Supabase env.

## Verification

- ✅ `npm run lint` — 0 errors, 7 no-console warnings (intentional, error boundaries — unchanged baseline).
- ✅ `npm run lint:use-server` — clean.
- ✅ `npm run typecheck` — clean.
- ✅ `npx vitest run` — **645/645 tests across 66 files** (2 new test files).
- ✅ `npm run build` — clean exit, all routes prerender.

## Out of scope (per PR-D3 prompt)

- No Bloc 3 (charges list + Quotidien live + Assistant Virements + Santé Provisions) — PR-D4 / PR-D5.
- No notifications / 6-month forecast / simulator — PR-D7 / PR-D8.
- No DB migration — `payment_months[]` SELECT extension deferred to PR-D4.

## Test plan

- [x] Lint + typecheck + vitest + build green
- [x] 4 new E2E cases written (CI run on push)
- [ ] CI 7/7 green on push (verify post-merge — Playwright iPhone SE BUG-iOS-011 #116 expected to fail per @cowork accepted bypass)
- [ ] Sourcery silent on the latest commit
- [ ] Manual smoke @thierry: log in → Bloc 2 visible above Bloc 1 → Capacité emerald with positive value → toggle a charge to flip the sign → mini-CTA visible if plafond unset.

## Follow-up

- **PR-D3-bis** (eventual) — visual refinements after Claude Design Session #3 mockups (week-end 10-11 mai). This PR ships the KPI functionally correct on top of Design System Session #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — @cc-ankora (Opus 4.7)