### PR TITLE
docs(infra): Supabase breaking changes 2026 prep — CONVENTIONS + ROADMAP (THI-206)

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -81,22 +81,49 @@ Source : [Supabase changelog 45329](https://supabase.com/changelog/45329-breakin
 
 ```sql
 create table if not exists public.<nom> (
-  -- colonnes
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references public.workspaces (id) on delete cascade,
+  created_at timestamptz not null default now()
+  -- ... autres colonnes
 );
 
 -- 1. RLS obligatoire
 alter table public.<nom> enable row level security;
--- ... policies ...
+
+-- Exemple pattern Ankora — workspace-scoped (à adapter selon l'agrégat)
+create policy "<nom>_select_own"
+  on public.<nom> for select
+  using (
+    workspace_id in (
+      select workspace_id
+      from public.workspace_members
+      where user_id = auth.uid()
+    )
+  );
+
+create policy "<nom>_insert_own"
+  on public.<nom> for insert
+  with check (
+    workspace_id in (
+      select workspace_id
+      from public.workspace_members
+      where user_id = auth.uid()
+    )
+  );
+
+-- (update / delete : mêmes patterns avec `using` + `with check`)
 
 -- 2. GRANT explicite (NOUVEAU — était implicite avant le 30/10/2026)
 grant select, insert, update, delete on table public.<nom>
   to anon, authenticated;
 ```
 
-**Exceptions valides** (pas de GRANT volontaire) :
+> ⚠️ **Toujours expliciter au moins une `policy` par opération CRUD nécessaire.** RLS activé sans policies = table fermée à tout le monde (sauf `service_role` qui bypass RLS via `bypassrls`). Le pattern `workspace_members` ci-dessus est le canon Ankora — toute déviation doit être justifiée dans la migration.
 
-- Tables audit log write-only (service_role uniquement)
-- Tables internes non exposées au client
+**Exceptions valides** (pas de GRANT volontaire à `anon` / `authenticated`) :
+
+- Tables audit log write-only (accès via `service_role` uniquement, jamais exposées à PostgREST)
+- Tables internes au domaine (queues, snapshots, projections) non exposées au client
 
 ### Pattern REVOKE FROM PUBLIC — fonctions privées
 
@@ -108,6 +135,22 @@ revoke execute on function public.<fn>() from public;
 ```
 
 Sans ce `REVOKE FROM PUBLIC`, la fonction reste exécutable même après un `REVOKE` ciblé. Source empirique : Terminal Learning migration 015 (16 mai 2026).
+
+#### Impact sur `service_role` et rôles custom
+
+`REVOKE EXECUTE ... FROM PUBLIC` retire le droit pour **tous les rôles** PostgreSQL, y compris `service_role` (qui hérite implicitement de `PUBLIC` même s'il bypass RLS sur les tables). Conséquence : un job interne, une Edge Function, un cron `pg_cron`, ou un script de migration qui exécutait la fonction via `service_role` **cassera silencieusement** après le REVOKE.
+
+Pattern correct quand la fonction reste nécessaire côté serveur :
+
+```sql
+-- Ordre obligatoire : REVOKE d'abord, GRANT ciblé ensuite
+revoke execute on function public.<fn>() from public;
+grant execute on function public.<fn>() to service_role;
+-- Si rôles custom (ex. `cron_runner`, `migration_runner`) :
+-- grant execute on function public.<fn>() to cron_runner;
+```
+
+À documenter dans le commentaire SQL de la fonction si elle a des consommateurs internes — sinon le `REVOKE FROM PUBLIC` d'une prochaine migration pourrait casser une Edge Function dont personne ne se souvient.
 
 ### Recommandation V2 — schema `api` dédié
 

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -70,3 +70,50 @@ Exemples :
 - Anglais pour code, commentaires, commits, docs techniques
 - **Interdit** : "placement", "investissement", "conseil financier" — contraire à la contrainte FSMA
 - **Ton** : direct, rassurant, factuel. Pas de fausse familiarité, pas de jargon.
+
+## Migrations Supabase — conventions post-30 octobre 2026
+
+À partir du **30 octobre 2026**, Supabase n'exposera plus automatiquement les tables du schema `public` via PostgREST / GraphQL. Toute table créée sans GRANT explicite renverra **404 silencieux** côté client (comportement "table inexistante").
+
+Source : [Supabase changelog 45329](https://supabase.com/changelog/45329-breaking-change-tables-not-exposed-to-data-and-graphql-api-automatically).
+
+### Template migration obligatoire
+
+```sql
+create table if not exists public.<nom> (
+  -- colonnes
+);
+
+-- 1. RLS obligatoire
+alter table public.<nom> enable row level security;
+-- ... policies ...
+
+-- 2. GRANT explicite (NOUVEAU — était implicite avant le 30/10/2026)
+grant select, insert, update, delete on table public.<nom>
+  to anon, authenticated;
+```
+
+**Exceptions valides** (pas de GRANT volontaire) :
+
+- Tables audit log write-only (service_role uniquement)
+- Tables internes non exposées au client
+
+### Pattern REVOKE FROM PUBLIC — fonctions privées
+
+`REVOKE FROM anon, authenticated` ne suffit pas pour fermer une fonction PostgREST. Les rôles `anon` et `authenticated` héritent du grant par défaut PostgreSQL via le rôle `PUBLIC` — `has_function_privilege('anon', ...)` retourne toujours `true`.
+
+```sql
+-- Pour toute fonction qui ne doit PAS être exposée à PostgREST :
+revoke execute on function public.<fn>() from public;
+```
+
+Sans ce `REVOKE FROM PUBLIC`, la fonction reste exécutable même après un `REVOKE` ciblé. Source empirique : Terminal Learning migration 015 (16 mai 2026).
+
+### Recommandation V2 — schema `api` dédié
+
+Long terme, envisager un schema `api` distinct pour les tables réellement exposées au client (plus propre que `public` qui mélange tables exposées, fonctions internes, vues, etc.). À cadrer dans un ADR dédié si la dette s'aggrave.
+
+### Refs
+
+- Linear ticket [THI-206](https://linear.app/thierryvm/issue/THI-206) — PR-INFRA-4 (deadline 30 octobre 2026)
+- Obsidian learning : `90_Meta/learnings/2026-05-16-supabase-breaking-changes-2026-cross-project.md`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -249,7 +249,7 @@ Mettre à jour le template migration Ankora pour intégrer `GRANT explicite` (Su
 - `@supabase/supabase-js` : `^2.103.3` (dans la fenêtre 2.101–2.105 stable)
 - `vercel.json` runtime : défaut Vercel (Node 24+)
 
-Convention canonique documentée dans [`docs/CONVENTIONS.md`](./CONVENTIONS.md#migrations-supabase--conventions-post-30-octobre-2026). Premier usage sur la prochaine migration créée — pas de ré-écriture rétroactive des migrations existantes (RLS + grants implicites conservés pour les tables d'avant la deadline).
+Convention canonique documentée dans [`docs/CONVENTIONS.md`](./CONVENTIONS.md#migrations-supabase--conventions-post-30-octobre-2026). Premier usage sur la prochaine migration créée — pas de réécriture rétroactive des migrations existantes (RLS + grants implicites conservés pour les tables d'avant la deadline).
 
 **Refs** :
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -234,6 +234,30 @@ L'audit dashboard-ux PR-D5 a confirmé que 6 des 8 sections du cockpit v3 (cible
 
 ---
 
+## Backlog infrastructure / Tech debt
+
+### PR-INFRA-4 — Migration template GRANT explicite + REVOKE FROM PUBLIC
+
+**Linear** : [THI-206](https://linear.app/thierryvm/issue/THI-206) · **Priorité** : Medium · **Deadline** : 30 octobre 2026
+
+Mettre à jour le template migration Ankora pour intégrer `GRANT explicite` (Supabase breaking change 30/10/2026 — tables non exposées par défaut sans grant) et le pattern empirique `REVOKE FROM PUBLIC` pour fermer les fonctions PostgREST privées.
+
+**Audit Ankora 2026-05-17** (post-merge PR-D5) — infra à jour, action limitée au template :
+
+- Postgres : **17.6** ✅ (deadline force-upgrade 1er juillet caduque pour Ankora)
+- Node CI 4 workflows + `engines` : **24** ✅ (deadline 30 juin caduque)
+- `@supabase/supabase-js` : `^2.103.3` (dans la fenêtre 2.101–2.105 stable)
+- `vercel.json` runtime : défaut Vercel (Node 24+)
+
+Convention canonique documentée dans [`docs/CONVENTIONS.md`](./CONVENTIONS.md#migrations-supabase--conventions-post-30-octobre-2026). Premier usage sur la prochaine migration créée — pas de ré-écriture rétroactive des migrations existantes (RLS + grants implicites conservés pour les tables d'avant la deadline).
+
+**Refs** :
+
+- Obsidian learning : `90_Meta/learnings/2026-05-16-supabase-breaking-changes-2026-cross-project.md`
+- Supabase changelog : <https://supabase.com/changelog/45329-breaking-change-tables-not-exposed-to-data-and-graphql-api-automatically>
+
+---
+
 ## Phase 0 — Bootstrap (terminée)
 
 - [x] Choix du nom + vérification domaines


### PR DESCRIPTION
## Summary

Documentation-only PR pour préparer Ankora aux **3 breaking changes Supabase 2026** remontés par le briefing cross-projet @cowork (source : Terminal Learning 16/05/2026).

**Audit factuel 2026-05-17** (post-merge PR-D5) → infra Ankora déjà à jour, **seul le pattern migration template reste pertinent** :

| Item | Valeur | Deadline | Status |
|------|--------|----------|--------|
| Postgres | **17.6** ✅ | 1er juillet 2026 | Caduc — déjà sur 17 |
| Node CI (4 workflows) + `engines` | **24** ✅ | 30 juin 2026 | Caduc — > Node 22 requis |
| `@supabase/supabase-js` | `^2.103.3` | — | Dans la fenêtre 2.101–2.105 stable |
| `vercel.json` runtime | défaut | — | Node 24+ |

**Décision posture** : challenge appliqué — pas créé les 3 tickets prévus dans le briefing (2 caducs), seulement **THI-206** (PR-INFRA-4, deadline 30 octobre 2026) pour le template migration. Validé @cowork option A.

## Changes

- **`docs/CONVENTIONS.md`** : nouvelle section "Migrations Supabase — conventions post-30 octobre 2026" (template GRANT explicite + pattern empirique REVOKE FROM PUBLIC + recommandation V2 schema `api`)
- **`docs/ROADMAP.md`** : nouvelle section "Backlog infrastructure / Tech debt" avec PR-INFRA-4 + audit factuel 2026-05-17 + refs Linear THI-206 + learning Obsidian

## Garde-fous respectés

- ✅ Aucune migration DB exécutée
- ✅ Aucune dépendance ajoutée (budget 0 €)
- ✅ Pas de touche au code prod (docs only)
- ✅ Branch protection main respectée (PR au lieu de push direct)

## Refs

- Linear : [THI-206](https://linear.app/thierryvm/issue/THI-206)
- Obsidian learning : `90_Meta/learnings/2026-05-16-supabase-breaking-changes-2026-cross-project.md`
- Supabase changelog : <https://supabase.com/changelog/45329-breaking-change-tables-not-exposed-to-data-and-graphql-api-automatically>

## Test plan

- [ ] CI lint + typecheck + tests verts (rien ne touche le code)
- [ ] Sourcery review silent sur le dernier commit
- [ ] `docs/CONVENTIONS.md` rendu correct dans la preview GitHub
- [ ] `docs/ROADMAP.md` rendu correct dans la preview GitHub
- [ ] Pas de conflit avec main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documenter les conventions de migration et d’infrastructure Supabase en préparation des changements majeurs prévus en 2026, sans modifier le code d’exécution ni l’infrastructure.

Documentation :
- Ajouter des conventions pour les migrations Supabase après le 30 octobre 2026, incluant des exigences explicites de `GRANT`, des modèles de `REVOKE` pour les fonctions privées, ainsi qu’une recommandation pour un schéma dédié `api`.
- Étendre la feuille de route avec un élément de backlog infrastructure/tech debt (PR-INFRA-4 / THI-206) décrivant la mise à jour prévue du modèle de migration et consignant l’audit d’infrastructure lié à Supabase du 2026-05-17.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document Supabase migration and infrastructure conventions in preparation for 2026 breaking changes, without modifying runtime code or infrastructure.

Documentation:
- Add conventions for Supabase migrations after 30 October 2026, including explicit GRANT requirements, REVOKE patterns for private functions, and a recommendation for a dedicated `api` schema.
- Extend the roadmap with an infrastructure/tech-debt backlog item (PR-INFRA-4 / THI-206) describing the planned migration template update and recording the 2026-05-17 Supabase-related infra audit.

</details>