### PR TITLE
feat(atoms): AnkButton/AnkCard rename + ADR-020 frontier (THI-189)

### DIFF
--- a/docs/adr/ADR-020-atoms-vs-ui-canonical-frontier.md
+++ b/docs/adr/ADR-020-atoms-vs-ui-canonical-frontier.md
@@ -1,0 +1,201 @@
+# ADR-020 — Frontière canonique `atoms/` (identité visuelle CD#3) vs `ui/` (infrastructure Radix)
+
+- **Statut** : Accepted
+- **Date** : 2026-05-18
+- **Accepté le** : 2026-05-18 par Thierry vanmeeteren (via délégation @cowork)
+- **Proposé par** : @cowork (orchestration) + @cc-ankora (diagnostic factuel)
+- **À accepter par** : Thierry vanmeeteren (Product Owner)
+- **Deciders** : Thierry vanmeeteren, @cowork, @cc-ankora
+- **Tags** : `architecture`, `design-system`, `components`, `frontier`
+- **Portée** : Phase 1 (MVP) — débloque PR-D6/D7 (Beta cockpit v3 — 6 sections restantes)
+- **Tracking Linear** : [THI-189](https://linear.app/thierryvm/issue/THI-189) (High priority)
+
+> **Glossaire des handles** (@cowork, @cc-design, @cc-ankora, @thierry) — voir source canonique : [`docs/design/trio-agents.md`](../design/trio-agents.md).
+
+---
+
+## Contexte & problème
+
+Le repo contient actuellement **deux dossiers de composants UI parallèles** dont la frontière n'est pas formellement documentée :
+
+| Dossier                 | Composants                                                                                                        | Origine                                               | Tests           | Barrel           | Convention nommage |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- | --------------- | ---------------- | ------------------ |
+| `src/components/atoms/` | 11 (Button, Card, Chip, Avatar, Drawer, ProgressBar, ColorPicker, IconPicker, Tabs, ThemeToggle, LangSwitcher)    | Claude Design Session #3 (mergée PR #147, 9 mai 2026) | 11 tests Vitest | ✅ `index.ts`    | PascalCase         |
+| `src/components/ui/`    | 13 (breadcrumb, button, card, dialog, eyebrow, form, glass, input, label, num, row, select, sheet, switch, toast) | shadcn legacy (présent depuis PR-3b PR #67)           | 9 tests Vitest  | ❌ pas de barrel | lowercase          |
+
+**Diagnostic factuel** (livré 2026-05-17 par @cc-ankora, `docs/audits/2026-05-17-thi-189-atoms-vs-ui-diagnostic.md`) :
+
+1. **Ce n'est PAS une fragmentation accidentelle** : le plan `docs/plans/PR-D4-PHASE2-A.md` ligne 18 documente explicitement « Cohabitation temporaire : `src/components/ui/button.tsx` (shadcn legacy) reste, `src/components/atoms/Button.tsx` nouveau Ankora CD#3. Cleanup en PR-D / PR-D5 ». Le cleanup n'a jamais été exécuté.
+2. **2 vrais doublons** sur 24 composants (~8 %) : `Button` et `Card`. APIs incompatibles : monolithique (atoms) vs composable Radix/cva (ui).
+3. **0 cross-import** (atoms n'importe pas ui, et vice versa) → bonne nouvelle architecturale, pas de couplage caché.
+4. **Distribution call-sites prod** :
+   - `ui/` = 38 call-sites prod (très intégré)
+   - `atoms/` = 14 call-sites (12 vitrine `/admin/_playground` + 2 prod réels : `AdminTopbar`, `LangSwitcherClient`)
+
+**Impact bloquant** : les 6 sections cockpit v3 restantes (THI-190 Health gauge, THI-192 Prochaines factures, THI-195 Simulateur drawer, THI-191/193/194) sont bloquées tant que la frontière atoms/ vs ui/ n'est pas claire. Sans règle, chaque section va fragmenter encore plus le DS.
+
+**Deadline critique** : 10 juin 2026 (Beta) — perte abonnement Pro Max x5 si non livré.
+
+---
+
+## Decision drivers
+
+| Driver                               | Pourquoi c'est décisif                                                                                                                                         |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Préserver le travail @cc-design CD#3 | 11 atoms CD#3 livrés 9 mai (PR #147) = identité visuelle Ankora figée. Jeter ce travail = perte design system canonique.                                       |
+| Préserver l'accessibilité Radix      | `ui/` repose sur Radix UI pour Dialog, Form, Select, Sheet, Switch, Toast = a11y best-in-class (focus trap, ARIA, keyboard nav). Réécrire = risque a11y élevé. |
+| Effort minimal vs deadline 10/06     | 24 jours restants. Toute solution > 2 jours d'effort prend trop de bande passante CC Ankora pour livrer Beta.                                                  |
+| Reviewability + maintenabilité       | La frontière doit être lisible pour CC Ankora futur + @thierry. Pas de règle implicite à reconstituer.                                                         |
+| Anti-régression future               | Sans règle ESLint, les nouvelles sections cockpit v3 vont créer encore des doublons.                                                                           |
+| Budget 0 €                           | Aucune dépendance payante ajoutée (lint custom = ESLint déjà présent).                                                                                         |
+
+---
+
+## Considered options
+
+### Option A — Tout migrer vers `ui/` (jeter `atoms/`)
+
+**Pour** :
+
+- Cohérence shadcn unique
+- Pattern connu communauté
+
+**Contre** :
+
+- ❌ **Perte du design Claude Design CD#3** (11 atoms livrés 9 mai)
+- ❌ Réécrire 11 composants pour reproduire l'identité visuelle CD#3 dans le pattern shadcn = 4-5 jours
+- ❌ Pattern AnkButton (variants `primary` / `secondary` / `ghost` / `destructive`) vs shadcn (variants `default` / `secondary` / `ghost` / `destructive` / `outline` / `link`) = mapping non-trivial
+
+**Effort** : 4-5 jours. **Risque** : Moyen (régression visuelle CD#3). **Rejet**.
+
+### Option B — Tout migrer vers `atoms/` (réécrire infra Radix)
+
+**Pour** :
+
+- Cohérence atoms unique
+- Pattern Ankora pur sans dépendance shadcn
+
+**Contre** :
+
+- ❌ **Réécrire Dialog, Form, Select, Sheet, Switch, Toast** sans Radix = risque a11y MAJEUR
+- ❌ Focus trap, ARIA, keyboard navigation à réimplémenter from scratch
+- ❌ Perte du pattern shadcn éprouvé communauté
+
+**Effort** : 10-15 jours. **Risque** : Élevé (a11y, deadline 10/06). **Rejet**.
+
+### Option C — Frontière fonctionnelle stricte + désambiguïsation ciblée ⭐
+
+**Principe** : reconnaître que `atoms/` et `ui/` ne sont pas en concurrence — ils ont des rôles **complémentaires** :
+
+- **`atoms/`** = **identité visuelle Ankora CD#3** (composants visuels purs, pas de Radix, look CD#3 verrouillé)
+- **`ui/`** = **infrastructure form/feedback Radix** (composants stateful avec a11y Radix : Dialog, Form, Select, Sheet, Switch, Toast)
+
+**Actions concrètes** :
+
+1. Renommer `atoms/Button.tsx` → `atoms/AnkButton.tsx` (+ export `AnkButton`)
+2. Renommer `atoms/Card.tsx` → `atoms/AnkCard.tsx` (+ export `AnkCard`)
+3. Update `atoms/index.ts` barrel pour exporter `AnkButton` / `AnkCard`
+4. Update tests Vitest existants (`__tests__/Button.test.tsx` → `AnkButton.test.tsx` + `__tests__/Card.test.tsx` → `AnkCard.test.tsx`)
+5. Update les 2 call-sites prod actuels (`AdminTopbar`, `LangSwitcherClient`) si ils importent les renommés (à vérifier — ils n'utilisent probablement pas Button/Card directement)
+6. Ajouter règle ESLint custom dans `eslint.config.mjs` : interdire `from '@/components/atoms/Button'` ou `from '@/components/atoms/Card'` (warn dev, error CI)
+7. Documenter cet ADR-020 comme référence pour CC Ankora + futurs développeurs
+
+**Pour** :
+
+- ✅ Préserve le work design CD#3 (atoms/) figé 9 mai 2026
+- ✅ Préserve l'infrastructure Radix de `ui/`
+- ✅ Effort minimal **0.5-1 jour** (renommage + lint + barrel + tests)
+- ✅ Risque faible (renommage mécanique + lint = 0 régression possible)
+- ✅ Débloque PR-D6/D7 immédiatement (frontière claire pour les 6 sections)
+- ✅ ADR documenté pour le futur (anti-régression)
+
+**Effort** : 0.5-1 jour. **Risque** : Faible. **Recommandé**.
+
+---
+
+## Decision
+
+**Option C retenue.**
+
+**Pattern d'usage canonique** :
+
+```typescript
+// ✅ Identité visuelle Ankora — composants visuels CD#3 purs
+import { AnkButton, AnkCard, Chip, ProgressBar, Avatar } from '@/components/atoms';
+
+// ✅ Infrastructure form/feedback Radix-based
+import { Dialog, DialogContent, DialogHeader } from '@/components/ui/dialog';
+import { Form, FormField, FormItem } from '@/components/ui/form';
+import { Select, SelectTrigger, SelectContent } from '@/components/ui/select';
+
+// ✅ Composition idiomatique — atoms dans ui-wrapper
+function HealthGaugeCard() {
+  return (
+    <Card>
+      {/* Card de ui/ (shadcn) — wrapper standard */}
+      <CardHeader>...</CardHeader>
+      <CardContent>
+        <ProgressBar value={75} tone="success" />
+        {/* ProgressBar de atoms/ — identité visuelle CD#3 */}
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+**Règle ESLint** (à ajouter dans `eslint.config.mjs`) :
+
+```javascript
+{
+  rules: {
+    'no-restricted-imports': ['error', {
+      patterns: [
+        {
+          group: ['@/components/atoms/Button', '@/components/atoms/Card'],
+          message: 'Use AnkButton or AnkCard from @/components/atoms instead (cf. ADR-020).',
+        },
+      ],
+    }],
+  },
+}
+```
+
+---
+
+## Conséquences positives
+
+- ✅ Débloque immédiatement PR-D6/D7 (6 sections cockpit v3 restantes pour Beta 10/06)
+- ✅ Préserve les deux investissements design (CD#3 atoms + Radix ui infrastructure)
+- ✅ Effort minimal (0.5-1 jour) compatible deadline Beta
+- ✅ Pattern réutilisable pour les composants futurs (chaque ajout va dans la « bonne » colonne selon son rôle)
+- ✅ Anti-régression via lint rule (les futures sections cockpit ne peuvent pas créer de doublon)
+
+## Conséquences négatives / risques
+
+- ⚠️ Convention nommage hybride (PascalCase atoms/ vs lowercase ui/) — accepté pour ne pas exploser le scope migration
+- ⚠️ Dépendance @radix-ui maintenue dans `ui/` (risque mineur : Radix est stable, communauté active)
+- ⚠️ 2 imports à connaître au lieu d'1 — mitigation : ADR-020 visible + lint rule + docs trio-agents.md
+
+## Plan de migration (à exécuter par @cc-ankora dans PR THI-189)
+
+Branche : `feat/thi-189-atoms-canonical-frontier`
+
+1. Renommer `atoms/Button.tsx` → `atoms/AnkButton.tsx` (+ export `AnkButton` au lieu de `Button`)
+2. Renommer `atoms/Card.tsx` → `atoms/AnkCard.tsx` (+ export `AnkCard` au lieu de `Card`)
+3. Update `atoms/index.ts` barrel
+4. Renommer + update tests `atoms/__tests__/Button.test.tsx` → `AnkButton.test.tsx` + `Card.test.tsx` → `AnkCard.test.tsx`
+5. Update `eslint.config.mjs` avec règle `no-restricted-imports` (cf. ci-dessus)
+6. Vérifier les 2 call-sites prod (`AdminTopbar`, `LangSwitcherClient`) — si ils importent Button/Card, update vers AnkButton/AnkCard
+7. Passer ce ADR-020 de Proposed → Accepted dans le même commit
+8. Lancer agents QA : `ui-auditor` + `test-runner`
+9. PR + review @thierry
+
+**Effort estimé** : 0.5-1 jour (renommage mécanique + lint + tests).
+
+## Refs
+
+- Diagnostic source : `docs/audits/2026-05-17-thi-189-atoms-vs-ui-diagnostic.md`
+- Plan migration interrompue documentée : `docs/plans/PR-D4-PHASE2-A.md` ligne 18
+- Linear THI-189 : <https://linear.app/thierryvm/issue/THI-189>
+- ADR-005 (PR-3a anticipée) — contexte design system socle
+- Pattern @cc-ankora « co-décideur, pas exécutant » (CLAUDE.md global)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,6 +16,19 @@ const eslintConfig = defineConfig([
     files: ['src/**/*.ts', 'src/**/*.tsx'],
     rules: {
       'no-console': 'warn',
+      // ADR-020 — canonical frontier atoms/ (Ankora CD#3) vs ui/ (Radix infra).
+      // Force AnkButton/AnkCard usage from the barrel to prevent doublons regressions.
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@/components/atoms/Button', '@/components/atoms/Card'],
+              message: 'Use AnkButton or AnkCard from @/components/atoms instead (cf. ADR-020).',
+            },
+          ],
+        },
+      ],
     },
   },
   {

--- a/src/app/[locale]/design-playground/_components/PlaygroundSection.tsx
+++ b/src/app/[locale]/design-playground/_components/PlaygroundSection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Card } from '@/components/atoms';
+import { AnkCard } from '@/components/atoms';
 
 export interface PlaygroundSectionProps {
   readonly id: string;
@@ -13,8 +13,8 @@ export function PlaygroundSection({
   children,
 }: PlaygroundSectionProps): React.JSX.Element {
   return (
-    <Card padding="lg" elevation="raised" id={id} title={title}>
+    <AnkCard padding="lg" elevation="raised" id={id} title={title}>
       <div style={{ marginTop: 8 }}>{children}</div>
-    </Card>
+    </AnkCard>
   );
 }

--- a/src/app/[locale]/design-playground/_components/demos/ButtonDemo.tsx
+++ b/src/app/[locale]/design-playground/_components/demos/ButtonDemo.tsx
@@ -1,18 +1,18 @@
 'use client';
 import * as React from 'react';
-import { Button } from '@/components/atoms';
+import { AnkButton } from '@/components/atoms';
 
 export function ButtonDemo(): React.JSX.Element {
   return (
     <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, alignItems: 'center' }}>
-      <Button>Primary md</Button>
-      <Button variant="secondary">Secondary</Button>
-      <Button variant="ghost">Ghost</Button>
-      <Button variant="destructive">Destructive</Button>
-      <Button loading>Loading</Button>
-      <Button disabled>Disabled</Button>
-      <Button size="sm">Small</Button>
-      <Button size="lg">Large</Button>
+      <AnkButton>Primary md</AnkButton>
+      <AnkButton variant="secondary">Secondary</AnkButton>
+      <AnkButton variant="ghost">Ghost</AnkButton>
+      <AnkButton variant="destructive">Destructive</AnkButton>
+      <AnkButton loading>Loading</AnkButton>
+      <AnkButton disabled>Disabled</AnkButton>
+      <AnkButton size="sm">Small</AnkButton>
+      <AnkButton size="lg">Large</AnkButton>
     </div>
   );
 }

--- a/src/app/[locale]/design-playground/_components/demos/CardDemo.tsx
+++ b/src/app/[locale]/design-playground/_components/demos/CardDemo.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { Card } from '@/components/atoms';
+import { AnkCard } from '@/components/atoms';
 
 export function CardDemo(): React.JSX.Element {
   return (
@@ -11,18 +11,18 @@ export function CardDemo(): React.JSX.Element {
         gap: 12,
       }}
     >
-      <Card title="Default" padding="md">
+      <AnkCard title="Default" padding="md">
         Body content
-      </Card>
-      <Card title="Brand tone" tone="brand" padding="md">
+      </AnkCard>
+      <AnkCard title="Brand tone" tone="brand" padding="md">
         Body
-      </Card>
-      <Card title="Warning tone" tone="warning" padding="md">
+      </AnkCard>
+      <AnkCard title="Warning tone" tone="warning" padding="md">
         Body
-      </Card>
-      <Card title="Raised elevation" elevation="raised" padding="md">
+      </AnkCard>
+      <AnkCard title="Raised elevation" elevation="raised" padding="md">
         Body
-      </Card>
+      </AnkCard>
     </div>
   );
 }

--- a/src/app/[locale]/design-playground/_components/demos/DrawerDemo.tsx
+++ b/src/app/[locale]/design-playground/_components/demos/DrawerDemo.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { Button, EditDrawer, type DrawerField } from '@/components/atoms';
+import { AnkButton, EditDrawer, type DrawerField } from '@/components/atoms';
 
 const FIELDS: ReadonlyArray<DrawerField> = [
   { type: 'text', key: 'name', label: 'Nom', required: true, placeholder: 'Mon poste' },
@@ -22,7 +22,7 @@ export function DrawerDemo(): React.JSX.Element {
   const [open, setOpen] = React.useState(false);
   return (
     <>
-      <Button onClick={() => setOpen(true)}>Ouvrir le Drawer</Button>
+      <AnkButton onClick={() => setOpen(true)}>Ouvrir le Drawer</AnkButton>
       <EditDrawer
         open={open}
         title="Démo Drawer"

--- a/src/components/atoms/AnkButton.tsx
+++ b/src/components/atoms/AnkButton.tsx
@@ -1,21 +1,21 @@
 import * as React from 'react';
 
-export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'destructive';
-export type ButtonSize = 'sm' | 'md' | 'lg';
+export type AnkButtonVariant = 'primary' | 'secondary' | 'ghost' | 'destructive';
+export type AnkButtonSize = 'sm' | 'md' | 'lg';
 
-export interface ButtonProps extends Omit<
+export interface AnkButtonProps extends Omit<
   React.ButtonHTMLAttributes<HTMLButtonElement>,
   'children'
 > {
-  readonly variant?: ButtonVariant;
-  readonly size?: ButtonSize;
+  readonly variant?: AnkButtonVariant;
+  readonly size?: AnkButtonSize;
   readonly icon?: React.ReactNode;
   readonly iconRight?: React.ReactNode;
   readonly loading?: boolean;
   readonly children?: React.ReactNode;
 }
 
-export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+export const AnkButton = React.forwardRef<HTMLButtonElement, AnkButtonProps>(function AnkButton(
   {
     variant = 'primary',
     size = 'md',

--- a/src/components/atoms/AnkCard.tsx
+++ b/src/components/atoms/AnkCard.tsx
@@ -1,20 +1,20 @@
 import * as React from 'react';
 
-export type CardPadding = 'sm' | 'md' | 'lg' | 'none';
-export type CardElevation = 'flat' | 'raised';
-export type CardTone = 'default' | 'soft' | 'brand' | 'accent' | 'warning' | 'danger';
+export type AnkCardPadding = 'sm' | 'md' | 'lg' | 'none';
+export type AnkCardElevation = 'flat' | 'raised';
+export type AnkCardTone = 'default' | 'soft' | 'brand' | 'accent' | 'warning' | 'danger';
 
-export interface CardProps extends Omit<React.HTMLAttributes<HTMLElement>, 'title'> {
-  readonly padding?: CardPadding;
-  readonly elevation?: CardElevation;
-  readonly tone?: CardTone;
+export interface AnkCardProps extends Omit<React.HTMLAttributes<HTMLElement>, 'title'> {
+  readonly padding?: AnkCardPadding;
+  readonly elevation?: AnkCardElevation;
+  readonly tone?: AnkCardTone;
   readonly eyebrow?: React.ReactNode;
   readonly title?: React.ReactNode;
   readonly footer?: React.ReactNode;
   readonly children?: React.ReactNode;
 }
 
-export function Card({
+export function AnkCard({
   padding = 'md',
   elevation = 'flat',
   tone = 'default',
@@ -24,7 +24,7 @@ export function Card({
   className,
   children,
   ...rest
-}: CardProps): React.JSX.Element {
+}: AnkCardProps): React.JSX.Element {
   const classes = [
     'atm-card',
     `atm-card--p-${padding}`,

--- a/src/components/atoms/__tests__/AnkButton.test.tsx
+++ b/src/components/atoms/__tests__/AnkButton.test.tsx
@@ -1,16 +1,16 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-import { Button } from '../Button';
+import { AnkButton } from '../AnkButton';
 
-describe('<Button /> (atom CD#3)', () => {
+describe('<AnkButton /> (atom CD#3)', () => {
   it('renders a <button> element', () => {
-    render(<Button>Click me</Button>);
+    render(<AnkButton>Click me</AnkButton>);
     expect(screen.getByRole('button', { name: 'Click me' }).tagName).toBe('BUTTON');
   });
 
   it('applies default variant=primary + size=md', () => {
-    render(<Button>Test</Button>);
+    render(<AnkButton>Test</AnkButton>);
     const btn = screen.getByRole('button');
     expect(btn.className).toContain('atm-btn--primary');
     expect(btn.className).toContain('atm-btn--md');
@@ -22,7 +22,7 @@ describe('<Button /> (atom CD#3)', () => {
     ['ghost', 'atm-btn--ghost'],
     ['destructive', 'atm-btn--destructive'],
   ] as const)('applies variant %s', (variant, cls) => {
-    render(<Button variant={variant}>X</Button>);
+    render(<AnkButton variant={variant}>X</AnkButton>);
     expect(screen.getByRole('button').className).toContain(cls);
   });
 
@@ -31,28 +31,28 @@ describe('<Button /> (atom CD#3)', () => {
     ['md', 'atm-btn--md'],
     ['lg', 'atm-btn--lg'],
   ] as const)('applies size %s', (size, cls) => {
-    render(<Button size={size}>X</Button>);
+    render(<AnkButton size={size}>X</AnkButton>);
     expect(screen.getByRole('button').className).toContain(cls);
   });
 
   it('shows spinner when loading', () => {
-    const { container } = render(<Button loading>Loading…</Button>);
+    const { container } = render(<AnkButton loading>Loading…</AnkButton>);
     expect(container.querySelector('.atm-btn-spin')).toBeTruthy();
   });
 
   it('disables button when loading', () => {
-    render(<Button loading>Loading…</Button>);
+    render(<AnkButton loading>Loading…</AnkButton>);
     expect(screen.getByRole('button')).toBeDisabled();
   });
 
   it('renders icon left and label', () => {
-    render(<Button icon={<span data-testid="icon-left">⬇</span>}>Save</Button>);
+    render(<AnkButton icon={<span data-testid="icon-left">⬇</span>}>Save</AnkButton>);
     expect(screen.getByTestId('icon-left')).toBeInTheDocument();
     expect(screen.getByText('Save')).toBeInTheDocument();
   });
 
   it('renders icon-only with aria-label', () => {
-    render(<Button icon={<span>⬇</span>} aria-label="Download" />);
+    render(<AnkButton icon={<span>⬇</span>} aria-label="Download" />);
     const btn = screen.getByRole('button', { name: 'Download' });
     expect(btn.className).toContain('atm-btn--icon-only');
   });
@@ -60,9 +60,9 @@ describe('<Button /> (atom CD#3)', () => {
   it('does not call onClick when disabled', () => {
     const onClick = vi.fn();
     render(
-      <Button disabled onClick={onClick}>
+      <AnkButton disabled onClick={onClick}>
         X
-      </Button>,
+      </AnkButton>,
     );
     fireEvent.click(screen.getByRole('button'));
     expect(onClick).not.toHaveBeenCalled();
@@ -71,9 +71,9 @@ describe('<Button /> (atom CD#3)', () => {
   it('does not call onClick when loading', () => {
     const onClick = vi.fn();
     render(
-      <Button loading onClick={onClick}>
+      <AnkButton loading onClick={onClick}>
         X
-      </Button>,
+      </AnkButton>,
     );
     fireEvent.click(screen.getByRole('button'));
     expect(onClick).not.toHaveBeenCalled();
@@ -81,13 +81,13 @@ describe('<Button /> (atom CD#3)', () => {
 
   it('forwards ref to <button>', () => {
     const ref = { current: null as HTMLButtonElement | null };
-    render(<Button ref={ref}>X</Button>);
+    render(<AnkButton ref={ref}>X</AnkButton>);
     expect(ref.current?.tagName).toBe('BUTTON');
   });
 
   it('calls onClick when active', () => {
     const onClick = vi.fn();
-    render(<Button onClick={onClick}>X</Button>);
+    render(<AnkButton onClick={onClick}>X</AnkButton>);
     fireEvent.click(screen.getByRole('button'));
     expect(onClick).toHaveBeenCalledTimes(1);
   });

--- a/src/components/atoms/__tests__/AnkCard.test.tsx
+++ b/src/components/atoms/__tests__/AnkCard.test.tsx
@@ -1,17 +1,17 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
-import { Card } from '../Card';
+import { AnkCard } from '../AnkCard';
 
-describe('<Card />', () => {
+describe('<AnkCard />', () => {
   it('renders children inside <section>', () => {
-    const { container } = render(<Card>Content</Card>);
+    const { container } = render(<AnkCard>Content</AnkCard>);
     expect(container.querySelector('section')).toBeTruthy();
     expect(screen.getByText('Content')).toBeInTheDocument();
   });
 
   it('applies default padding=md, elevation=flat, tone=default', () => {
-    const { container } = render(<Card>X</Card>);
+    const { container } = render(<AnkCard>X</AnkCard>);
     const section = container.querySelector('section')!;
     expect(section.className).toContain('atm-card--p-md');
     expect(section.className).toContain('atm-card--flat');
@@ -24,7 +24,7 @@ describe('<Card />', () => {
     ['md', 'atm-card--p-md'],
     ['lg', 'atm-card--p-lg'],
   ] as const)('applies padding %s', (p, cls) => {
-    const { container } = render(<Card padding={p}>X</Card>);
+    const { container } = render(<AnkCard padding={p}>X</AnkCard>);
     expect(container.querySelector('section')!.className).toContain(cls);
   });
 
@@ -32,7 +32,7 @@ describe('<Card />', () => {
     ['flat', 'atm-card--flat'],
     ['raised', 'atm-card--raised'],
   ] as const)('applies elevation %s', (e, cls) => {
-    const { container } = render(<Card elevation={e}>X</Card>);
+    const { container } = render(<AnkCard elevation={e}>X</AnkCard>);
     expect(container.querySelector('section')!.className).toContain(cls);
   });
 
@@ -44,32 +44,32 @@ describe('<Card />', () => {
     ['warning', 'atm-card--tone-warning'],
     ['danger', 'atm-card--tone-danger'],
   ] as const)('applies tone %s', (t, cls) => {
-    const { container } = render(<Card tone={t}>X</Card>);
+    const { container } = render(<AnkCard tone={t}>X</AnkCard>);
     expect(container.querySelector('section')!.className).toContain(cls);
   });
 
   it('renders eyebrow + title in <header>', () => {
     render(
-      <Card eyebrow="EYEBROW" title="Title">
+      <AnkCard eyebrow="EYEBROW" title="Title">
         Body
-      </Card>,
+      </AnkCard>,
     );
     expect(screen.getByText('EYEBROW')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Title' })).toBeInTheDocument();
   });
 
   it('does not render <header> when neither eyebrow nor title', () => {
-    const { container } = render(<Card>X</Card>);
+    const { container } = render(<AnkCard>X</AnkCard>);
     expect(container.querySelector('header')).toBeNull();
   });
 
   it('renders footer in <footer>', () => {
-    render(<Card footer={<span>Foot</span>}>X</Card>);
+    render(<AnkCard footer={<span>Foot</span>}>X</AnkCard>);
     expect(screen.getByText('Foot')).toBeInTheDocument();
   });
 
   it('passes through className', () => {
-    const { container } = render(<Card className="custom">X</Card>);
+    const { container } = render(<AnkCard className="custom">X</AnkCard>);
     expect(container.querySelector('section')!.className).toContain('custom');
   });
 });

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -1,11 +1,11 @@
 // Barrel exports — to be filled progressively as atoms land in PR-D4-PHASE2-A.
 // Order: cf docs/plans/PR-D4-PHASE2-A.md task list.
-export { Button } from './Button';
-export type { ButtonProps, ButtonVariant, ButtonSize } from './Button';
+export { AnkButton } from './AnkButton';
+export type { AnkButtonProps, AnkButtonVariant, AnkButtonSize } from './AnkButton';
 export { Chip } from './Chip';
 export type { ChipProps, ChipSize } from './Chip';
-export { Card } from './Card';
-export type { CardProps, CardPadding, CardElevation, CardTone } from './Card';
+export { AnkCard } from './AnkCard';
+export type { AnkCardProps, AnkCardPadding, AnkCardElevation, AnkCardTone } from './AnkCard';
 export { ProgressBar } from './ProgressBar';
 export type {
   ProgressBarProps,


### PR DESCRIPTION
## Summary

Implements **ADR-020 Option C** : frontière canonique entre `atoms/` (Ankora CD#3 visual identity) et `ui/` (Radix infrastructure).

Resolves **THI-189** (High priority), unblocks PR-D6/D7 Beta cockpit v3 sections (THI-190, THI-192, THI-195, THI-191, THI-193, THI-194).

## Pattern canonique

- `atoms/` = identité visuelle Ankora CD#3 (composants visuels purs, pas de Radix)
- `ui/` = infrastructure form/feedback Radix-based (Dialog, Form, Select, Sheet, Switch, Toast)

```ts
// ✅ Identité visuelle Ankora — composants visuels CD#3 purs
import { AnkButton, AnkCard, Chip, ProgressBar, Avatar } from '@/components/atoms';

// ✅ Infrastructure form/feedback Radix-based
import { Dialog, DialogContent } from '@/components/ui/dialog';
import { Form, FormField } from '@/components/ui/form';
```

## Changes

- Rename `atoms/Button.tsx` → `atoms/AnkButton.tsx` (export `AnkButton` + types `AnkButton*`)
- Rename `atoms/Card.tsx` → `atoms/AnkCard.tsx` (export `AnkCard` + types `AnkCard*`)
- Update `atoms/index.ts` barrel
- Rename + update tests (`AnkButton.test.tsx` 14 cas / `AnkCard.test.tsx` 16 cas — coverage identique)
- Update 4 call-sites design-playground (`PlaygroundSection`, `CardDemo`, `ButtonDemo`, `DrawerDemo`)
- Add ESLint `no-restricted-imports` rule (anti-régression : interdit `@/components/atoms/Button` ou `/Card`)
- ADR-020 status `Proposed → Accepted`

## Quality gates (local, Windows)

- ✅ `npm run lint` → 0 erreur (6 warnings pré-existants non liés à THI-189)
- ✅ `npm run lint:use-server` → 0 erreur
- ✅ `npm run typecheck` → 0 erreur
- ✅ `npm run test` → **1121/1121 tests Vitest** (94/94 fichiers)
- ⚠️ `npm run e2e` Playwright local Windows : **flaky** (TimeoutError `page.goto` 15s sur mobile-ios et chromium-desktop après runs successifs — pression CPU/RAM dev server). **Vérifié pré-existant sur main**. Aucun test E2E ne référence `atoms/Button`/`atoms/Card`/`AnkButton`/`AnkCard`. CI Linux validera proprement.

## Agents QA

- **ui-auditor** : zero risk introduit (DOM identique, classes CSS `atm-btn--*`/`atm-card--*` inchangées, ARIA intact)
- **test-runner** : GO FOR PR — coverage complète, zéro lien E2E, flakiness pré-existante

## Refs

- ADR-020 : `docs/adr/ADR-020-atoms-vs-ui-canonical-frontier.md`
- Diagnostic source : `docs/audits/2026-05-17-thi-189-atoms-vs-ui-diagnostic.md`
- Linear : THI-189
- Unblocks : THI-190 (Health gauge), THI-192 (Prochaines factures), THI-195 (Simulateur drawer), THI-191/193/194

## Test plan

- [x] Vitest unit AnkButton/AnkCard coverage identique post-renommage (14 + 16 cas)
- [x] Lint `no-restricted-imports` bloque `@/components/atoms/{Button,Card}` (anti-régression)
- [ ] CI Linux : tous les checks verts (lint, typecheck, tests, E2E, security, build)
- [ ] Sourcery silent sur dernier commit
- [ ] Smoke design-playground prod (Vercel preview)