### PR TITLE
feat(cockpit): Health score provisions gauge — v3 section #2 (THI-190)

### DIFF
--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -652,7 +652,8 @@
       "expensesCount": "{count, plural, =0 {Keine Ausgaben diesen Monat} one {1 Ausgabe diesen Monat} other {# Ausgaben diesen Monat}}",
       "expensesEmpty": "Keine Ausgaben für diesen Monat erfasst.",
       "expensesViewAll": "Alle Ausgaben anzeigen →",
-      "accountsHeading": "Meine Konten"
+      "accountsHeading": "Meine Konten",
+      "provisionHealthSectionHeading": "Gesundheit der Rücklagen"
     },
     "charges": {
       "title": "Meine Fixkosten",
@@ -933,6 +934,19 @@
     },
     "daily": {
       "cta_set_plafond": "Tägliches Limit festlegen"
+    },
+    "health": {
+      "title": "Gesundheit der Rücklagen",
+      "ratio": "Zielabdeckung",
+      "target": "Theoretisches Ziel",
+      "current": "Aktueller Saldo",
+      "empty": "Keine periodischen Kosten geplant — noch nichts anzusparen.",
+      "ariaLabel": "Gesundheit der Rücklagen: {percent}% des theoretischen Ziels",
+      "deficit": "3-Monats-Aufholplan: {amount}/Monat",
+      "status": {
+        "a_jour": "Auf Kurs",
+        "deficit": "Defizit"
+      }
     }
   },
   "glossary": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -652,7 +652,8 @@
       "expensesCount": "{count, plural, =0 {No expenses this month} one {1 expense this month} other {# expenses this month}}",
       "expensesEmpty": "No expenses recorded for this month.",
       "expensesViewAll": "View all expenses →",
-      "accountsHeading": "My accounts"
+      "accountsHeading": "My accounts",
+      "provisionHealthSectionHeading": "Provisions health"
     },
     "charges": {
       "title": "My bills",
@@ -933,6 +934,19 @@
     },
     "daily": {
       "cta_set_plafond": "Set my daily allowance"
+    },
+    "health": {
+      "title": "Provisions health",
+      "ratio": "Target coverage",
+      "target": "Theoretical target",
+      "current": "Current balance",
+      "empty": "No periodic charges scheduled — nothing to save up for yet.",
+      "ariaLabel": "Provisions health: {percent}% of theoretical target",
+      "deficit": "3-month catch-up plan: {amount}/month",
+      "status": {
+        "a_jour": "On track",
+        "deficit": "Deficit"
+      }
     }
   },
   "glossary": {

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -652,7 +652,8 @@
       "expensesCount": "{count, plural, =0 {Sin gastos este mes} one {1 gasto este mes} other {# gastos este mes}}",
       "expensesEmpty": "No hay gastos registrados este mes.",
       "expensesViewAll": "Ver todos los gastos →",
-      "accountsHeading": "Mis cuentas"
+      "accountsHeading": "Mis cuentas",
+      "provisionHealthSectionHeading": "Salud de las provisiones"
     },
     "charges": {
       "title": "Mis gastos fijos",
@@ -933,6 +934,19 @@
     },
     "daily": {
       "cta_set_plafond": "Configurar el límite diario"
+    },
+    "health": {
+      "title": "Salud de las provisiones",
+      "ratio": "Cobertura del objetivo",
+      "target": "Objetivo teórico",
+      "current": "Saldo actual",
+      "empty": "Sin gastos periódicos programados — nada para provisionar por ahora.",
+      "ariaLabel": "Salud de las provisiones: {percent}% del objetivo teórico",
+      "deficit": "Plan de recuperación a 3 meses: {amount}/mes",
+      "status": {
+        "a_jour": "Al día",
+        "deficit": "Déficit"
+      }
     }
   },
   "glossary": {

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -652,7 +652,8 @@
       "expensesCount": "{count, plural, =0 {Aucune dépense ce mois} one {1 dépense ce mois} other {# dépenses ce mois}}",
       "expensesEmpty": "Aucune dépense enregistrée pour ce mois.",
       "expensesViewAll": "Voir toutes les dépenses →",
-      "accountsHeading": "Mes comptes"
+      "accountsHeading": "Mes comptes",
+      "provisionHealthSectionHeading": "Santé des provisions"
     },
     "charges": {
       "title": "Mes charges",
@@ -933,6 +934,19 @@
     },
     "daily": {
       "cta_set_plafond": "Régler le plafond quotidien"
+    },
+    "health": {
+      "title": "Santé des provisions",
+      "ratio": "Couverture cible",
+      "target": "Cible théorique",
+      "current": "Solde actuel",
+      "empty": "Aucune charge périodique programmée — rien à provisionner pour l'instant.",
+      "ariaLabel": "Santé des provisions : {percent}% de la cible théorique",
+      "deficit": "Plan de rattrapage sur 3 mois : {amount}/mois",
+      "status": {
+        "a_jour": "À jour",
+        "deficit": "Déficit"
+      }
     }
   },
   "glossary": {

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -652,7 +652,8 @@
       "expensesCount": "{count, plural, =0 {Geen uitgaven deze maand} one {1 uitgave deze maand} other {# uitgaven deze maand}}",
       "expensesEmpty": "Geen uitgaven geregistreerd voor deze maand.",
       "expensesViewAll": "Alle uitgaven bekijken →",
-      "accountsHeading": "Mijn rekeningen"
+      "accountsHeading": "Mijn rekeningen",
+      "provisionHealthSectionHeading": "Gezondheid van de voorzieningen"
     },
     "charges": {
       "title": "Mijn vaste kosten",
@@ -933,6 +934,19 @@
     },
     "daily": {
       "cta_set_plafond": "Dagelijks plafond instellen"
+    },
+    "health": {
+      "title": "Gezondheid van de voorzieningen",
+      "ratio": "Dekking doel",
+      "target": "Theoretisch doel",
+      "current": "Huidig saldo",
+      "empty": "Geen periodieke kosten gepland — nog niets om voor te sparen.",
+      "ariaLabel": "Gezondheid van de voorzieningen: {percent}% van het theoretische doel",
+      "deficit": "Inhaalplan over 3 maanden: {amount}/maand",
+      "status": {
+        "a_jour": "Op koers",
+        "deficit": "Tekort"
+      }
     }
   },
   "glossary": {

--- a/src/app/[locale]/app/page.tsx
+++ b/src/app/[locale]/app/page.tsx
@@ -8,7 +8,9 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { AccountCard } from '@/components/features/AccountCard';
 import { EffortFinancierCard } from '@/components/dashboard/EffortFinancierCard';
 import { CapaciteEpargneCard } from '@/components/dashboard/CapaciteEpargneCard';
+import { ProvisionHealthGaugeCard } from '@/components/dashboard/ProvisionHealthGaugeCard';
 import { Expenses, Transfer, money } from '@/lib/domain';
+import { paymentKey, type PaymentLedger } from '@/lib/domain/cockpit';
 import { getWorkspaceSnapshot, toCockpitCharges } from '@/lib/data/workspace-snapshot';
 import type { AccountType } from '@/lib/schemas/account';
 import type { Locale } from '@/i18n/routing';
@@ -58,6 +60,19 @@ export default async function DashboardPage() {
 
   // PR-D3 — Bloc 2 hero radar inputs.
   const cockpitCharges = toCockpitCharges(snapshot.charges);
+
+  // THI-190 — Santé Provisions inputs (ADR-011). The PaymentLedger maps
+  // `(chargeId, year, month) → true` for charges already settled this
+  // period, so `calculerSanteProvisions()` knows which entries to skip in
+  // its cycle math.
+  const provisionsAccount = snapshot.accounts.find((a) => a.accountType === 'provisions');
+  const soldeEpargneActuel = money(provisionsAccount?.balance ?? 0);
+  const paymentsLedger: PaymentLedger = new Map(
+    snapshot.currentMonthPayments.map((p) => [
+      paymentKey(p.chargeId, p.periodYear, p.periodMonth),
+      true,
+    ]),
+  );
   // Daily allowance not yet configured: surface the inline CTA on the
   // daily_card row so the user can complete the cockpit setup without
   // hunting through Settings.
@@ -90,6 +105,32 @@ export default async function DashboardPage() {
           revenus={monthlyIncome}
           charges={cockpitCharges}
           plafondQuotidien={vieCouranteTransferAmount}
+          locale={locale}
+        />
+      </section>
+
+      {/*
+        THI-190 — Santé des Provisions (cockpit v3 section #2 of 8).
+        Answers "am I saving the right amount each month so periodic
+        bills never catch me short?" — complements the hero radar which
+        answers "what is my real monthly burden?". Always visible (even
+        on an empty workspace) so the user sees the canonical narrative.
+        Layout grid-cols-1 lg:grid-cols-3 mirrors the bloc 1 account row
+        and keeps the card at ~1/3 width on desktop (the gauge is dense,
+        not wide).
+      */}
+      <section
+        aria-labelledby="provision-health-heading"
+        className="grid grid-cols-1 gap-4 lg:grid-cols-3"
+      >
+        <h2 id="provision-health-heading" className="sr-only">
+          {t('provisionHealthSectionHeading')}
+        </h2>
+        <ProvisionHealthGaugeCard
+          charges={cockpitCharges}
+          payments={paymentsLedger}
+          soldeEpargneActuel={soldeEpargneActuel}
+          period={snapshot.currentPeriod}
           locale={locale}
         />
       </section>

--- a/src/components/dashboard/ProvisionHealthGaugeCard.tsx
+++ b/src/components/dashboard/ProvisionHealthGaugeCard.tsx
@@ -1,0 +1,197 @@
+import Decimal from 'decimal.js';
+import { Activity, AlertTriangle, CheckCircle2 } from 'lucide-react';
+import { getTranslations } from 'next-intl/server';
+
+import { ProgressBar } from '@/components/atoms';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  calculerSanteProvisions,
+  type CockpitCharge,
+  type PaymentLedger,
+  type ReferencePeriod,
+} from '@/lib/domain/cockpit';
+import { formatCurrency } from '@/lib/i18n/formatters';
+import type { Locale } from '@/i18n/routing';
+
+type Props = {
+  charges: readonly CockpitCharge[];
+  payments: PaymentLedger;
+  soldeEpargneActuel: Decimal;
+  /** Renamed from the domain's `ref` to avoid clashing with React's reserved `ref` prop. */
+  period: ReferencePeriod;
+  locale: Locale;
+};
+
+type HealthTier = 'success' | 'warning' | 'danger';
+
+/**
+ * Health score for provisions — cockpit v3 section #2 of 8 (THI-190, Beta P1).
+ *
+ * Cards #1 (EffortFinancierCard) and #2 (CapaciteEpargneCard) answer
+ * "what is my real monthly burden?". This card answers a different question:
+ * "given the periodic charges (annual/quarterly/semiannual) due over the
+ * next 12 months, am I saving the right amount each month so I'm never
+ * caught short when a bill lands?".
+ *
+ * Math is delegated to `calculerSanteProvisions()` (ADR-011) — see
+ * `src/lib/domain/cockpit/sante-provisions.ts`. The domain returns a binary
+ * `statut: 'a_jour' | 'deficit'`; the UI extrapolates a 3-tier visual:
+ *   ratio ≥ 1.0   → success (vert)   — on track
+ *   ratio ≥ 0.75  → warning (orange) — within striking distance
+ *   ratio < 0.75  → danger  (rouge)  — significant deficit
+ *
+ * Where `ratio = soldeEpargneActuel / totalEpargneTheorique`. The deficit
+ * variant also surfaces the 3-month catch-up plan (ADR-011).
+ *
+ * Empty-state contract: when `totalEpargneTheorique = 0` (no periodic
+ * charges scheduled in the next 12 months) we render an educational hint
+ * instead of a noisy gauge stuck at 0% — there is no target to track.
+ *
+ * Server Component (math + i18n only — zero hydration cost).
+ */
+export async function ProvisionHealthGaugeCard({
+  charges,
+  payments,
+  soldeEpargneActuel,
+  period,
+  locale,
+}: Props) {
+  const t = await getTranslations('dashboard.health');
+  const result = calculerSanteProvisions({
+    charges,
+    payments,
+    soldeEpargneActuel,
+    ref: period,
+  });
+  const fmt = (value: Parameters<typeof formatCurrency>[0]) => formatCurrency(value, locale);
+
+  const hasTarget = result.totalEpargneTheorique.gt(0);
+
+  // Ratio in [0, ~Infinity[. Clamped to [0, 1.5] for the ProgressBar visual
+  // (display only — accounting math keeps the raw Decimal precision).
+  const rawRatio = hasTarget
+    ? result.soldeEpargneActuel.dividedBy(result.totalEpargneTheorique).toNumber()
+    : 1;
+  const ratio = Number.isFinite(rawRatio) ? Math.max(0, rawRatio) : 0;
+  const percentLabel = Math.round(ratio * 100);
+
+  const tier: HealthTier =
+    !hasTarget || ratio >= 1.0 ? 'success' : ratio >= 0.75 ? 'warning' : 'danger';
+
+  const accent = {
+    success: {
+      ringColor: 'ring-success/15',
+      iconColor: 'text-success',
+      valueColor: 'text-success',
+      glowColor: 'bg-success/20',
+      gradientFrom: 'from-success/8',
+      Icon: CheckCircle2,
+    },
+    warning: {
+      ringColor: 'ring-warning/15',
+      iconColor: 'text-warning',
+      valueColor: 'text-warning',
+      glowColor: 'bg-warning/20',
+      gradientFrom: 'from-warning/8',
+      Icon: Activity,
+    },
+    danger: {
+      ringColor: 'ring-danger/15',
+      iconColor: 'text-danger',
+      valueColor: 'text-danger',
+      glowColor: 'bg-danger/20',
+      gradientFrom: 'from-danger/8',
+      Icon: AlertTriangle,
+    },
+  }[tier];
+
+  const statusLabel = tier === 'success' ? t('status.a_jour') : t('status.deficit');
+  // ProgressBar already exposes `role="progressbar"` + `aria-valuenow` and
+  // uses its `label` prop as the accessible name. CardTitle above is read
+  // first by screen readers, so the short `t('ratio')` label is enough —
+  // no need for a verbose duplicate aria-label on a roleless wrapper
+  // (ARIA 1.2 §6.2 forbids that).
+  const ratioLabel = t('ratio');
+
+  return (
+    <Card
+      className={`relative overflow-hidden ring-1 ring-inset ${accent.ringColor}`}
+      data-testid="provision-health-gauge-card"
+      data-tier={tier}
+    >
+      <div
+        aria-hidden
+        className={`pointer-events-none absolute inset-0 bg-linear-to-br ${accent.gradientFrom} to-transparent`}
+      />
+      <div
+        aria-hidden
+        className={`pointer-events-none absolute -right-16 -bottom-16 h-48 w-48 rounded-full ${accent.glowColor} opacity-70 blur-3xl`}
+      />
+      <CardHeader className="relative flex flex-row items-start justify-between gap-3 pb-2">
+        <div className="min-w-0">
+          <CardTitle className="text-muted-foreground text-sm font-medium">{t('title')}</CardTitle>
+        </div>
+        <accent.Icon
+          aria-hidden
+          strokeWidth={1.5}
+          className={`h-6 w-6 shrink-0 ${accent.iconColor}`}
+        />
+      </CardHeader>
+      <CardContent className="relative">
+        {hasTarget ? (
+          <>
+            <p
+              className={`text-4xl font-bold tracking-tight tabular-nums ${accent.valueColor}`}
+              data-testid="provision-health-gauge-percent"
+            >
+              {percentLabel}%
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm">{statusLabel}</p>
+            <div className="mt-4">
+              <ProgressBar
+                value={ratio}
+                max={1}
+                tone={tier}
+                size="md"
+                label={ratioLabel}
+                showValue={false}
+              />
+            </div>
+            <dl
+              className="mt-4 grid grid-cols-2 gap-3 text-xs"
+              data-testid="provision-health-gauge-breakdown"
+            >
+              <div>
+                <dt className="text-muted-foreground">{t('target')}</dt>
+                <dd className="text-foreground mt-0.5 font-semibold tabular-nums">
+                  {fmt(result.totalEpargneTheorique)}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-muted-foreground">{t('current')}</dt>
+                <dd className="text-foreground mt-0.5 font-semibold tabular-nums">
+                  {fmt(result.soldeEpargneActuel)}
+                </dd>
+              </div>
+            </dl>
+            {result.statut === 'deficit' && result.rattrapageMensuel.gt(0) && (
+              <p
+                className="text-muted-foreground mt-3 text-sm leading-relaxed"
+                data-testid="provision-health-gauge-rattrapage"
+              >
+                {t('deficit', { amount: fmt(result.rattrapageMensuel) })}
+              </p>
+            )}
+          </>
+        ) : (
+          <p
+            className="text-muted-foreground text-sm leading-relaxed"
+            data-testid="provision-health-gauge-empty"
+          >
+            {t('empty')}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/__tests__/ProvisionHealthGaugeCard.test.tsx
+++ b/src/components/dashboard/__tests__/ProvisionHealthGaugeCard.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Decimal from 'decimal.js';
+
+import messages from '../../../../messages/fr-BE.json';
+import type { CockpitCharge, PaymentLedger } from '@/lib/domain/cockpit';
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: async (namespace: string) => {
+    const walk = (root: unknown, path: string[]): unknown =>
+      path.reduce<unknown>((acc, key) => {
+        if (typeof acc === 'object' && acc !== null && key in acc) {
+          return (acc as Record<string, unknown>)[key];
+        }
+        return undefined;
+      }, root);
+    const sub = walk(messages, namespace.split('.'));
+    return (key: string, values?: Record<string, unknown>) => {
+      const value = walk(sub, key.split('.'));
+      if (typeof value !== 'string') return key;
+      // Minimal placeholder substitution to mirror next-intl behaviour for the
+      // 2 keys that take values: `ariaLabel` and `deficit`.
+      if (!values) return value;
+      return value.replace(/\{(\w+)\}/g, (_, k) => String(values[k] ?? ''));
+    };
+  },
+}));
+
+import { ProvisionHealthGaugeCard } from '../ProvisionHealthGaugeCard';
+
+const ANNUAL_CHARGE = (over: Partial<CockpitCharge>): CockpitCharge => ({
+  id: over.id ?? `c-${Math.random().toString(36).slice(2)}`,
+  label: 'Annual',
+  amount: new Decimal(1200),
+  frequency: 'annual',
+  // Due in January (ref month) and not yet paid → epargneRequise = full amount.
+  // That gives us a clean `target = amount` baseline so the ratio == soldeActuel / amount.
+  paymentMonths: [1],
+  paymentDay: 1,
+  isActive: true,
+  ...over,
+});
+
+const emptyPayments: PaymentLedger = new Map();
+const JAN = { year: 2026, month: 1 } as const;
+
+const renderCard = async (input: { charges: CockpitCharge[]; soldeEpargneActuel: Decimal }) =>
+  render(
+    await ProvisionHealthGaugeCard({
+      charges: input.charges,
+      payments: emptyPayments,
+      soldeEpargneActuel: input.soldeEpargneActuel,
+      period: JAN,
+      locale: 'fr-BE',
+    }),
+  );
+
+describe('<ProvisionHealthGaugeCard /> (THI-190 cockpit v3 #2)', () => {
+  it('renders the FR title from the dashboard.health namespace', async () => {
+    await renderCard({
+      charges: [ANNUAL_CHARGE({})],
+      soldeEpargneActuel: new Decimal(1200),
+    });
+    expect(screen.getByText(messages.dashboard.health.title)).toBeInTheDocument();
+  });
+
+  it('tier=success when ratio ≥ 1.0 (a_jour) — green token + "À jour" status', async () => {
+    // amount = 1200, due-in-ref-month → target = 1200 €. soldeActuel = 1200 → ratio = 1.0.
+    await renderCard({
+      charges: [ANNUAL_CHARGE({})],
+      soldeEpargneActuel: new Decimal(1200),
+    });
+    const card = screen.getByTestId('provision-health-gauge-card');
+    expect(card.getAttribute('data-tier')).toBe('success');
+    const percent = screen.getByTestId('provision-health-gauge-percent');
+    expect(percent.className).toContain('text-success');
+    expect(percent.textContent ?? '').toMatch(/100%/);
+    expect(screen.getByText(messages.dashboard.health.status.a_jour)).toBeInTheDocument();
+    // No rattrapage row in the on-track variant.
+    expect(screen.queryByTestId('provision-health-gauge-rattrapage')).toBeNull();
+  });
+
+  it('tier=warning when 0.75 ≤ ratio < 1.0 (deficit but close) — orange token', async () => {
+    // Target = 1200 €. 85% × 1200 = 1020 € → ratio = 0.85.
+    await renderCard({
+      charges: [ANNUAL_CHARGE({})],
+      soldeEpargneActuel: new Decimal(1020),
+    });
+    const card = screen.getByTestId('provision-health-gauge-card');
+    expect(card.getAttribute('data-tier')).toBe('warning');
+    const percent = screen.getByTestId('provision-health-gauge-percent');
+    expect(percent.className).toContain('text-warning');
+    expect(percent.textContent ?? '').toMatch(/85%/);
+    expect(screen.getByText(messages.dashboard.health.status.deficit)).toBeInTheDocument();
+    // Catch-up row visible since statut = deficit.
+    expect(screen.getByTestId('provision-health-gauge-rattrapage')).toBeInTheDocument();
+  });
+
+  it('tier=danger when ratio < 0.75 (significant deficit) — red token + rattrapage row', async () => {
+    // Target = 1200 €. 50% × 1200 = 600 € → ratio = 0.50 → danger.
+    await renderCard({
+      charges: [ANNUAL_CHARGE({})],
+      soldeEpargneActuel: new Decimal(600),
+    });
+    const card = screen.getByTestId('provision-health-gauge-card');
+    expect(card.getAttribute('data-tier')).toBe('danger');
+    const percent = screen.getByTestId('provision-health-gauge-percent');
+    expect(percent.className).toContain('text-danger');
+    expect(percent.textContent ?? '').toMatch(/50%/);
+    const rattrapage = screen.getByTestId('provision-health-gauge-rattrapage');
+    // 3-month catch-up = (1200 - 600) / 3 = 200 €/month
+    expect(rattrapage.textContent ?? '').toMatch(/200/);
+  });
+
+  it('empty state when no periodic charges (target = 0) — educational hint, no gauge', async () => {
+    // Monthly charges only → no provisioning target.
+    await renderCard({
+      charges: [
+        {
+          id: 'mensual',
+          label: 'Rent',
+          amount: new Decimal(1000),
+          frequency: 'monthly',
+          paymentMonths: [1],
+          paymentDay: 1,
+          isActive: true,
+        },
+      ],
+      soldeEpargneActuel: new Decimal(0),
+    });
+    expect(screen.getByTestId('provision-health-gauge-empty')).toBeInTheDocument();
+    expect(screen.queryByTestId('provision-health-gauge-percent')).toBeNull();
+    expect(screen.queryByTestId('provision-health-gauge-breakdown')).toBeNull();
+    // Empty variant still defaults to success tier so the card colour stays calm.
+    const card = screen.getByTestId('provision-health-gauge-card');
+    expect(card.getAttribute('data-tier')).toBe('success');
+  });
+
+  it('exposes role="progressbar" with aria-valuenow=50 + Couverture cible label (a11y contract)', async () => {
+    // Target = 1200, soldeActuel = 600 → ratio = 0.50 → aria-valuenow=50.
+    // ARIA 1.2 §6.2 forbids aria-label on roleless wrappers — the accessible
+    // name is carried by the inner `role="progressbar"` element via ProgressBar's
+    // `label` prop, NOT a wrapper div.
+    await renderCard({
+      charges: [ANNUAL_CHARGE({})],
+      soldeEpargneActuel: new Decimal(600),
+    });
+    const bar = document.querySelector('[role="progressbar"]');
+    expect(bar).not.toBeNull();
+    expect(bar?.getAttribute('aria-valuenow')).toBe('50');
+    expect(bar?.getAttribute('aria-valuemin')).toBe('0');
+    expect(bar?.getAttribute('aria-valuemax')).toBe('100');
+    expect(bar?.getAttribute('aria-label')).toBe(messages.dashboard.health.ratio);
+  });
+});
+
+describe('dashboard.health — i18n parity (5 locales)', () => {
+  it.each(['fr-BE', 'en', 'de-DE', 'es-ES', 'nl-BE'] as const)(
+    'locale %s exposes title + ratio + target + current + empty + ariaLabel + deficit + status.{a_jour,deficit}',
+    async (locale) => {
+      const m = (await import(`../../../../messages/${locale}.json`)).default as {
+        dashboard: {
+          health: {
+            title?: string;
+            ratio?: string;
+            target?: string;
+            current?: string;
+            empty?: string;
+            ariaLabel?: string;
+            deficit?: string;
+            status?: { a_jour?: string; deficit?: string };
+          };
+        };
+      };
+      const h = m.dashboard.health;
+      expect(h.title).toBeTypeOf('string');
+      expect((h.title ?? '').length).toBeGreaterThan(0);
+      expect(h.ratio).toBeTypeOf('string');
+      expect(h.target).toBeTypeOf('string');
+      expect(h.current).toBeTypeOf('string');
+      expect(h.empty).toBeTypeOf('string');
+      expect(h.ariaLabel).toBeTypeOf('string');
+      expect((h.ariaLabel ?? '').includes('{percent}')).toBe(true);
+      expect(h.deficit).toBeTypeOf('string');
+      expect((h.deficit ?? '').includes('{amount}')).toBe(true);
+      expect(h.status?.a_jour).toBeTypeOf('string');
+      expect(h.status?.deficit).toBeTypeOf('string');
+    },
+  );
+
+  it.each(['fr-BE', 'en', 'de-DE', 'es-ES', 'nl-BE'] as const)(
+    'locale %s exposes app.dashboard.provisionHealthSectionHeading',
+    async (locale) => {
+      const m = (await import(`../../../../messages/${locale}.json`)).default as {
+        app: { dashboard: { provisionHealthSectionHeading?: string } };
+      };
+      expect(m.app.dashboard.provisionHealthSectionHeading).toBeTypeOf('string');
+      expect((m.app.dashboard.provisionHealthSectionHeading ?? '').length).toBeGreaterThan(0);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Implements **Beta P1 cockpit v3 section 2/8** — "Santé des provisions" gauge avec 3 tiers visuels (vert/orange/rouge) et plan rattrapage 3 mois si déficit (ADR-011).

1ère section cockpit v3 mergée post-THI-189 (frontière atoms/ui canonique active, ADR-020).

## Pattern post-THI-189

- Wrapper `<Card>` via `@/components/ui/card` (shadcn, infrastructure Radix-pattern)
- `<ProgressBar>` from `@/components/atoms` (CD#3 visual identity)
- Server Component pur (math + i18n only, zero hydration cost)

## Math (domain reuse — 0 régression)

- `calculerSanteProvisions()` (ADR-011) consommé sans modif
- 3 tiers UI extrapolés du statut binaire `'a_jour' | 'deficit'` :
  - vert ≥ 1.0 (`success`)
  - orange ≥ 0.75 (`warning`)
  - rouge < 0.75 (`danger`)
- Empty state safe quand `totalEpargneTheorique = 0` (pas de division par zéro)

## Changes

- New `src/components/dashboard/ProvisionHealthGaugeCard.tsx` (~200 lignes, Server Component)
- Integration in `src/app/[locale]/app/page.tsx` après hero radar (EffortFinancier + Capacite), nouvelle section `grid-cols-1 lg:grid-cols-3` avec `sr-only h2`
- i18n 5 locales (fr-BE, en, nl-BE, de-DE, es-ES) — **parité stricte**, 10 clés `dashboard.health.*` + 1 clé `app.dashboard.provisionHealthSectionHeading`
- Tests Vitest **16 cas** (5 comportementaux + 10 parité i18n + 1 a11y `role=progressbar`)
- 0 domain change

## Quality gates (local Windows)

- ✅ `npm run lint` → 0 erreur (6 warnings pré-existants non liés à THI-190)
- ✅ `npm run lint:use-server` → 0 erreur
- ✅ `npm run typecheck` → 0 erreur
- ✅ `npm run test` → **95/95 fichiers + 1137/1137 tests Vitest**
- ⚠️ `npm run e2e` → délégué CI Linux (flaky Windows local confirmé sur PR #165, infra-only — aucun test E2E ne touche `ProvisionHealthGaugeCard`)

## Agents QA (6/6)

| Agent | Verdict |
|---|---|
| ui-auditor | PASS (fix double aria-label appliqué post-audit — ARIA 1.2 §6.2) |
| dashboard-ux-auditor | PASS_WITH_NOTES (cohérence Monarch Money, tokens semantic OK) |
| financial-formula-validator | PASS HIGH confidence sur 7 points (math intacte) |
| i18n-auditor | PASS_WITH_NOTES (parité 5/5 OK, placeholders OK) |
| test-runner | ALL_GREEN (coverage domain 99.07%) |
| mobile-ios-auditor | PASS_WITH_NOTES (zero blocker iOS, 2 notes ios-low non bloquantes) |

## Refs

- Linear: **THI-190** (Beta P1)
- ADR-011 (Plan rattrapage 3 mois)
- ADR-020 (atoms/ui frontier — PR #165, mergée 18/05)
- Diagnostic source: `docs/audits/2026-05-17-thi-190-health-gauge-diagnostic.md`
- **Unblocks** : 5/8 sections cockpit v3 restantes (THI-192/195/191/193/194)

## Test plan

- [x] Vitest 16/16 (3-tier + empty state + a11y + parité 5 locales)
- [x] Lint + Typecheck + use-server : 0 erreur
- [x] 6 agents QA exécutés et verts
- [ ] CI Linux : tous checks verts (lint, typecheck, tests, E2E, security, build)
- [ ] Sourcery silent sur dernier commit
- [ ] Smoke `/app` dashboard prod (Vercel preview)