### PR TITLE
fix(prod): P0 V2 — SW fonts cache + CSP inline style migration + drawer WebKit portal

### DIFF
--- a/docs/audits/2026-05-19-prod-p0-v2-bugs-diagnostic.md
+++ b/docs/audits/2026-05-19-prod-p0-v2-bugs-diagnostic.md
@@ -8,10 +8,10 @@
 
 ## Résumé exécutif
 
-| Bug | Statut         | Root cause                                                   | Sévérité | Effort fix |
-| --- | -------------- | ------------------------------------------------------------ | -------- | ---------- |
-| #1bis CSP inline style | CONFIRMÉ | React `style={{...}}` rendu en HTML attribute, bloqué par `style-src 'self' 'nonce-XYZ'` strict | P0       | S          |
-| #2bis Fonts OTS parse  | CONFIRMÉ | ServiceWorker cache poisoned avec ancien HTML 404 pré-PR #169 — sert `0x0A0A0A0A` au lieu du TTF | P0       | XS         |
+| Bug                    | Statut   | Root cause                                                                                                          | Sévérité | Effort fix |
+| ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------- | -------- | ---------- |
+| #1bis CSP inline style | CONFIRMÉ | React `style={{...}}` rendu en HTML attribute, bloqué par `style-src 'self' 'nonce-XYZ'` strict                     | P0       | S          |
+| #2bis Fonts OTS parse  | CONFIRMÉ | ServiceWorker cache poisoned avec ancien HTML 404 pré-PR #169 — sert `0x0A0A0A0A` au lieu du TTF                    | P0       | XS         |
 | #4 Drawer mobile       | CONFIRMÉ | Parent `<header sticky z-40 backdrop-blur>` crée un stacking context iOS Safari qui confine le drawer enfant `z-40` | P0       | S          |
 
 **Recommandation @cc-ankora** : un seul PR multi-fix discipliné. Bug #2bis = 1 ligne sw.js (effort minimal, déblocage majeur). Bug #1bis = 3 sources factuelles identifiées, migration vers utility classes CSS sans toucher au CSP. Bug #4 = React Portal vers `document.body`.
@@ -54,11 +54,11 @@ Quoi qu'il en soit, **le cache SW contient une mauvaise réponse pour `/fonts/*`
 
 ### Options de fix
 
-| Option | Effort | Risque |
-| ------ | ------ | ------ |
+| Option                                                         | Effort        | Risque                                                                                |
+| -------------------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------- |
 | **A. Bump `CACHE_VERSION` + ajouter `/fonts/` à `isBypass()`** | XS (2 lignes) | Aucun — force invalidation + ne cache plus jamais les fonts (HTTP cache natif suffit) |
-| B. Bump `CACHE_VERSION` seul | XS (1 ligne) | Bas — réinvalide une fois, mais nouvelles caches /fonts/* possibles à l'avenir |
-| C. Ajouter validation TTF signature dans le SW avant de servir | M | Moyen — complexité accrue, risque effets de bord |
+| B. Bump `CACHE_VERSION` seul                                   | XS (1 ligne)  | Bas — réinvalide une fois, mais nouvelles caches /fonts/\* possibles à l'avenir       |
+| C. Ajouter validation TTF signature dans le SW avant de servir | M             | Moyen — complexité accrue, risque effets de bord                                      |
 
 **Recommandation @cc-ankora** : **Option A**. Bump version (`v2-20260519`) + exclure `/fonts/` du cache SW. Les fonts sont des assets statiques peu modifiés, le HTTP cache natif du browser + `Cache-Control` du serveur suffisent largement. Pas besoin du SW pour ça.
 
@@ -76,30 +76,32 @@ Quoi qu'il en soit, **le cache SW contient une mauvaise réponse pour `/fonts/*`
 
 3 violations DevTools console identifiées par @cowork, 3 sources factuelles confirmées :
 
-| # | Source | Ligne | Style |
-| - | ------ | ----- | ----- |
-| 1 | `src/components/marketing/landing/sections/Hero.tsx` | L50-53 | `background: 'radial-gradient(50% 60% at 50% 20%, color-mix(in oklab, var(--color-brand-400) 15%, transparent), transparent 70%)'` |
-| 2 | `src/components/marketing/landing/sections/WhatIfDemoClient.tsx` | L175 | `accentColor: 'var(--color-brand-400)'` |
-| 3 | `src/components/marketing/landing/sections/WhatIfDemoClient.tsx` | L339 | `fontVariantNumeric: 'tabular-nums'` |
+| #   | Source                                                           | Ligne  | Style                                                                                                                              |
+| --- | ---------------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `src/components/marketing/landing/sections/Hero.tsx`             | L50-53 | `background: 'radial-gradient(50% 60% at 50% 20%, color-mix(in oklab, var(--color-brand-400) 15%, transparent), transparent 70%)'` |
+| 2   | `src/components/marketing/landing/sections/WhatIfDemoClient.tsx` | L175   | `accentColor: 'var(--color-brand-400)'`                                                                                            |
+| 3   | `src/components/marketing/landing/sections/WhatIfDemoClient.tsx` | L339   | `fontVariantNumeric: 'tabular-nums'`                                                                                               |
 
 Les autres `style={{...}}` du codebase (Avatar, Chip, ColorPicker, ProgressBar, design-playground, opengraph-image, error pages) :
+
 - soit ne sont pas sur des pages publiques (design-playground)
-- soit ont des valeurs **dynamiques runtime** (ProgressBar width, Avatar size) qui changent post-hydration — CSP applique côté SSR donc bloqué technically, mais @cowork n'a pas listé ces 7 violations spécifiquement
+- soit ont des valeurs **dynamiques runtime** (ProgressBar width, Avatar size) qui changent post-hydration — CSP applique côté SSR donc techniquement bloqué, mais @cowork n'a pas listé ces 7 violations spécifiquement
 - opengraph-image utilise next/og `ImageResponse` qui n'a pas la même contrainte CSP
 
 **Pourquoi ces 3 spécifiquement** : ils sont rendus SSR sur la landing page `/`, page la plus visitée + la plus visible.
 
 ### Options de fix
 
-| Option | Effort | Risque |
-| ------ | ------ | ------ |
-| A. Ajouter `'unsafe-hashes'` à `style-src` dans `proxy.ts` CSP | XS | **Moyen** — relâche la politique CSP, security-auditor doit valider, ouvre la voie à de futurs inline styles non audités |
-| **B. Migrer les 3 styles vers utility CSS classes (Tailwind + globals.css)** | S | Bas — pas de changement CSP, design intact, plus maintenable |
-| C. style.setProperty() via useEffect côté client | M | Élevé — anti-pattern SSR, FOUC possible, ne marche que sur composants client |
+| Option                                                                       | Effort | Risque                                                                                                                   |
+| ---------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------ |
+| A. Ajouter `'unsafe-hashes'` à `style-src` dans `proxy.ts` CSP               | XS     | **Moyen** — relâche la politique CSP, security-auditor doit valider, ouvre la voie à de futurs inline styles non audités |
+| **B. Migrer les 3 styles vers utility CSS classes (Tailwind + globals.css)** | S      | Bas — pas de changement CSP, design intact, plus maintenable                                                             |
+| C. style.setProperty() via useEffect côté client                             | M      | Élevé — anti-pattern SSR, FOUC possible, ne marche que sur composants client                                             |
 
 **Recommandation @cc-ankora** : **Option B**.
 
 Mapping fix :
+
 - **Style #3** (font-variant-numeric) → Tailwind class `tabular-nums` (déjà disponible)
 - **Style #2** (accent-color) → Tailwind arbitrary value `accent-[var(--color-brand-400)]` OU créer utility CSS `.accent-brand-400 { accent-color: var(--color-brand-400); }`
 - **Style #1** (hero radial gradient) → créer utility CSS `.hero-radial-glow { background: radial-gradient(...); }` dans `globals.css` `@layer utilities`
@@ -140,12 +142,14 @@ Sur pages cockpit (`/app/*`), même structure mais via `Header.tsx:41` (même cl
 **Pourquoi le drawer est confiné** :
 
 CSS spec — un élément crée un **stacking context** lorsque :
+
 - `position: sticky` AVEC `z-index !== auto` ✅ Header
 - `backdrop-filter` non-`none` ✅ Header (`backdrop-blur`)
 
 Un descendant `position: fixed` est positionné par rapport au viewport, MAIS **reste dans le stacking context de son ancêtre le plus proche qui en crée un**.
 
 Donc :
+
 - Le drawer (`fixed top-0 right-0 z-40`) est positioned au viewport ✅
 - Mais son **z-index 40 est interne au stacking context du header**
 - Le contenu `<main>` n'a pas de stacking context (z-auto implicite)
@@ -156,12 +160,12 @@ Pattern documenté pour iOS Safari : voir [Stack Overflow CSS stacking context b
 
 ### Options de fix
 
-| Option | Effort | Risque |
-| ------ | ------ | ------ |
-| A. Retirer `backdrop-blur` du header | XS | Élevé — perte du glassmorphism visuel signature de la marque |
-| B. Retirer `z-40` du header (utiliser `z-auto` ou no-z-index) | XS | Moyen — header n'est plus au-dessus du contenu lors du scroll, casse le sticky behavior |
-| **C. React Portal — porter le drawer (overlay + nav) vers `document.body` direct** | S | Bas — pattern standard React, échappe complètement au stacking context parent |
-| D. `isolation: isolate` sur le drawer | XS | Élevé — ne résout pas le problème (isolation ouvre un nouveau stacking context au lieu d'échapper au parent) |
+| Option                                                                             | Effort | Risque                                                                                                       |
+| ---------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------ |
+| A. Retirer `backdrop-blur` du header                                               | XS     | Élevé — perte du glassmorphism visuel signature de la marque                                                 |
+| B. Retirer `z-40` du header (utiliser `z-auto` ou no-z-index)                      | XS     | Moyen — header n'est plus au-dessus du contenu lors du scroll, casse le sticky behavior                      |
+| **C. React Portal — porter le drawer (overlay + nav) vers `document.body` direct** | S      | Bas — pattern standard React, échappe complètement au stacking context parent                                |
+| D. `isolation: isolate` sur le drawer                                              | XS     | Élevé — ne résout pas le problème (isolation ouvre un nouveau stacking context au lieu d'échapper au parent) |
 
 **Recommandation @cc-ankora** : **Option C**. React Portal vers `document.body` est le pattern canonique pour les overlays/modals/drawers qui doivent échapper au stacking context du composant qui les déclenche.
 

--- a/docs/audits/2026-05-19-prod-p0-v2-bugs-diagnostic.md
+++ b/docs/audits/2026-05-19-prod-p0-v2-bugs-diagnostic.md
@@ -1,0 +1,248 @@
+# Diagnostic P0 V2 — 3 bugs résiduels post-PR #169 (19 mai 2026)
+
+**Auteur** : @cc-ankora (Opus 4.7)
+**Branche** : `feat/fix-prod-p0-v2` (worktree isolé)
+**Base** : `494c56a` (origin/main post PR #169 + #170)
+**Date diagnostic** : 2026-05-19, 09h00 CEST (session matinale post-cleanup)
+**Smoke test source** : @thierry iPhone 14 Safari + PWA réel + DevTools Brave 2026-05-18 ~22h CEST
+
+## Résumé exécutif
+
+| Bug | Statut         | Root cause                                                   | Sévérité | Effort fix |
+| --- | -------------- | ------------------------------------------------------------ | -------- | ---------- |
+| #1bis CSP inline style | CONFIRMÉ | React `style={{...}}` rendu en HTML attribute, bloqué par `style-src 'self' 'nonce-XYZ'` strict | P0       | S          |
+| #2bis Fonts OTS parse  | CONFIRMÉ | ServiceWorker cache poisoned avec ancien HTML 404 pré-PR #169 — sert `0x0A0A0A0A` au lieu du TTF | P0       | XS         |
+| #4 Drawer mobile       | CONFIRMÉ | Parent `<header sticky z-40 backdrop-blur>` crée un stacking context iOS Safari qui confine le drawer enfant `z-40` | P0       | S          |
+
+**Recommandation @cc-ankora** : un seul PR multi-fix discipliné. Bug #2bis = 1 ligne sw.js (effort minimal, déblocage majeur). Bug #1bis = 3 sources factuelles identifiées, migration vers utility classes CSS sans toucher au CSP. Bug #4 = React Portal vers `document.body`.
+
+---
+
+## Bug #2bis — Fonts OTS parsing error (ServiceWorker cache poisoning)
+
+### Évidence factuelle
+
+**Serveur prod sert le bon TTF** (testé via curl avec iPhone UA + Desktop UA) :
+
+```
+$ curl -A "Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 ...)" -sI https://ankora.be/fonts/Inter-Variable.ttf
+HTTP/1.1 200 OK
+Content-Type: font/ttf
+Content-Length: 879708
+
+$ curl -sA "Mozilla/5.0 (iPhone)" https://ankora.be/fonts/Inter-Variable.ttf | head -c 16 | xxd
+00000000: 0001 0000 0013 0100 0004 0030 4744 4546  ...........0GDEF
+                                                    ^^^^^^^^^^^^^^^ TTF magic + GDEF table
+```
+
+→ Signature TTF valide (`0x00010000`), pas de HTML, pas de newlines. Le serveur va bien.
+
+**ServiceWorker intercepte** : [`public/sw.js:40-86`](public/sw.js) — `isBypass()` exclut `/app`, `/auth`, `/api`, `/_next/data`, `/onboarding` MAIS PAS `/fonts/*`. Donc `/fonts/Inter-Variable.ttf` passe par la branche cache-first (ligne 73-84) :
+
+```js
+event.respondWith(
+  caches.match(request).then(
+    (cached) =>
+      cached ?? fetch(request).then(...)
+  ),
+);
+```
+
+**Cache poisoning** : avant PR #169 (mergé hier 18h47 CEST), `/fonts/Inter-Variable.ttf` retournait HTTP 404 + page HTML `_not-found` (le matcher proxy.ts ne couvrait pas `.ttf`). Le SW a caché cette mauvaise réponse au moment du premier accès. Le HTML commence par `<!DOCTYPE html>` qui en bytes ASCII = `0x3C 0x21 0x44 0x4F` ; mais l'erreur `invalid sfntVersion: 168430090 = 0x0A0A0A0A = '\n\n\n\n'` suggère que le browser lit 4 newlines au début. Hypothèse : avant PR #169, Next.js servait un HTML qui commençait avec des retours à la ligne (preformatted ou erreur boundary), encodé en UTF-8 sans BOM.
+
+Quoi qu'il en soit, **le cache SW contient une mauvaise réponse pour `/fonts/*` chez les visiteurs qui ont accédé au site avant PR #169**.
+
+### Options de fix
+
+| Option | Effort | Risque |
+| ------ | ------ | ------ |
+| **A. Bump `CACHE_VERSION` + ajouter `/fonts/` à `isBypass()`** | XS (2 lignes) | Aucun — force invalidation + ne cache plus jamais les fonts (HTTP cache natif suffit) |
+| B. Bump `CACHE_VERSION` seul | XS (1 ligne) | Bas — réinvalide une fois, mais nouvelles caches /fonts/* possibles à l'avenir |
+| C. Ajouter validation TTF signature dans le SW avant de servir | M | Moyen — complexité accrue, risque effets de bord |
+
+**Recommandation @cc-ankora** : **Option A**. Bump version (`v2-20260519`) + exclure `/fonts/` du cache SW. Les fonts sont des assets statiques peu modifiés, le HTTP cache natif du browser + `Cache-Control` du serveur suffisent largement. Pas besoin du SW pour ça.
+
+### Vérification post-fix attendue
+
+- Au prochain visit, l'event `activate` du nouveau SW (`CACHE_VERSION` bumpé) supprime toutes les anciennes caches (logique déjà en place ligne 31-37)
+- `/fonts/*` n'est plus jamais caché par le SW
+- Le browser fait des HTTP requests directes au serveur, qui retourne le bon TTF (`Cache-Control: public, max-age=0, must-revalidate` côté Vercel — peut être optimisé en sous-issue)
+
+---
+
+## Bug #1bis — CSP inline style attributes (style-src strict bloque)
+
+### Évidence factuelle
+
+3 violations DevTools console identifiées par @cowork, 3 sources factuelles confirmées :
+
+| # | Source | Ligne | Style |
+| - | ------ | ----- | ----- |
+| 1 | `src/components/marketing/landing/sections/Hero.tsx` | L50-53 | `background: 'radial-gradient(50% 60% at 50% 20%, color-mix(in oklab, var(--color-brand-400) 15%, transparent), transparent 70%)'` |
+| 2 | `src/components/marketing/landing/sections/WhatIfDemoClient.tsx` | L175 | `accentColor: 'var(--color-brand-400)'` |
+| 3 | `src/components/marketing/landing/sections/WhatIfDemoClient.tsx` | L339 | `fontVariantNumeric: 'tabular-nums'` |
+
+Les autres `style={{...}}` du codebase (Avatar, Chip, ColorPicker, ProgressBar, design-playground, opengraph-image, error pages) :
+- soit ne sont pas sur des pages publiques (design-playground)
+- soit ont des valeurs **dynamiques runtime** (ProgressBar width, Avatar size) qui changent post-hydration — CSP applique côté SSR donc bloqué technically, mais @cowork n'a pas listé ces 7 violations spécifiquement
+- opengraph-image utilise next/og `ImageResponse` qui n'a pas la même contrainte CSP
+
+**Pourquoi ces 3 spécifiquement** : ils sont rendus SSR sur la landing page `/`, page la plus visitée + la plus visible.
+
+### Options de fix
+
+| Option | Effort | Risque |
+| ------ | ------ | ------ |
+| A. Ajouter `'unsafe-hashes'` à `style-src` dans `proxy.ts` CSP | XS | **Moyen** — relâche la politique CSP, security-auditor doit valider, ouvre la voie à de futurs inline styles non audités |
+| **B. Migrer les 3 styles vers utility CSS classes (Tailwind + globals.css)** | S | Bas — pas de changement CSP, design intact, plus maintenable |
+| C. style.setProperty() via useEffect côté client | M | Élevé — anti-pattern SSR, FOUC possible, ne marche que sur composants client |
+
+**Recommandation @cc-ankora** : **Option B**.
+
+Mapping fix :
+- **Style #3** (font-variant-numeric) → Tailwind class `tabular-nums` (déjà disponible)
+- **Style #2** (accent-color) → Tailwind arbitrary value `accent-[var(--color-brand-400)]` OU créer utility CSS `.accent-brand-400 { accent-color: var(--color-brand-400); }`
+- **Style #1** (hero radial gradient) → créer utility CSS `.hero-radial-glow { background: radial-gradient(...); }` dans `globals.css` `@layer utilities`
+
+### Impact sécurité
+
+- Pas de relaxation CSP — `'unsafe-hashes'` PAS ajouté
+- `style-src 'self' 'nonce-XYZ'` reste strict
+- security-auditor à passer mais zéro changement à proxy.ts
+
+---
+
+## Bug #4 — Drawer mobile s'affiche en dessous du contenu (iOS Safari)
+
+### Évidence factuelle
+
+**Hiérarchie DOM** (landing `/`) :
+
+```
+<html overflow-x-clip>
+  <body overflow-x-clip>
+    <header sticky top-0 z-40 backdrop-blur>      ← MktNav.tsx:47 (marketing)
+      <BrandHomeLink />
+      <nav desktop links />
+      <HeaderNav>                                  ← inside header
+        <button hamburger />
+        <div fixed inset-0 z-30 bg-black/50 />    ← overlay
+        <nav fixed top-0 right-0 z-40 w-80 />     ← drawer
+      </HeaderNav>
+    </header>
+    <main>{children}</main>
+  </body>
+</html>
+```
+
+Sur pages cockpit (`/app/*`), même structure mais via `Header.tsx:41` (même classes `sticky top-0 z-40 backdrop-blur`).
+
+**Pourquoi le drawer est confiné** :
+
+CSS spec — un élément crée un **stacking context** lorsque :
+- `position: sticky` AVEC `z-index !== auto` ✅ Header
+- `backdrop-filter` non-`none` ✅ Header (`backdrop-blur`)
+
+Un descendant `position: fixed` est positionné par rapport au viewport, MAIS **reste dans le stacking context de son ancêtre le plus proche qui en crée un**.
+
+Donc :
+- Le drawer (`fixed top-0 right-0 z-40`) est positioned au viewport ✅
+- Mais son **z-index 40 est interne au stacking context du header**
+- Le contenu `<main>` n'a pas de stacking context (z-auto implicite)
+- Sur Chrome/Firefox, le stacking context du header est élevé "haut" car z-40 → le drawer apparaît au-dessus du main
+- Sur **iOS Safari**, le `backdrop-filter` crée un stacking context plus contraint, **confiné à la hauteur visuelle du header**. Le drawer (descendant) hérite de cette contrainte et se rend en dessous du `<main>` qui occupe l'écran
+
+Pattern documenté pour iOS Safari : voir [Stack Overflow CSS stacking context backdrop-filter iOS](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context) et le runbook interne `docs/runbooks/dev-on-iphone.md`.
+
+### Options de fix
+
+| Option | Effort | Risque |
+| ------ | ------ | ------ |
+| A. Retirer `backdrop-blur` du header | XS | Élevé — perte du glassmorphism visuel signature de la marque |
+| B. Retirer `z-40` du header (utiliser `z-auto` ou no-z-index) | XS | Moyen — header n'est plus au-dessus du contenu lors du scroll, casse le sticky behavior |
+| **C. React Portal — porter le drawer (overlay + nav) vers `document.body` direct** | S | Bas — pattern standard React, échappe complètement au stacking context parent |
+| D. `isolation: isolate` sur le drawer | XS | Élevé — ne résout pas le problème (isolation ouvre un nouveau stacking context au lieu d'échapper au parent) |
+
+**Recommandation @cc-ankora** : **Option C**. React Portal vers `document.body` est le pattern canonique pour les overlays/modals/drawers qui doivent échapper au stacking context du composant qui les déclenche.
+
+### Plan implémentation
+
+Modifier `src/components/layout/HeaderNav.tsx` :
+
+```tsx
+import { createPortal } from 'react-dom';
+
+// État local pour SSR safety
+const [mounted, setMounted] = useState(false);
+useEffect(() => setMounted(true), []);
+
+// Garde le bouton hamburger inline (dans le header)
+return (
+  <>
+    <button onClick={...} ref={triggerRef}>{isOpen ? <X /> : <Menu />}</button>
+
+    {/* Drawer + overlay rendus dans body via Portal */}
+    {mounted && isOpen && createPortal(
+      <>
+        <div className="fixed inset-0 z-30 bg-black/50" onClick={handleDrawerClose} />
+        <nav id="mobile-nav-drawer" ref={navRef} role="dialog" ...>
+          {/* contenu drawer existant */}
+        </nav>
+      </>,
+      document.body,
+    )}
+
+    <div className="hidden items-center gap-2 lg:flex">
+      {/* desktop theme toggle + locale switcher */}
+    </div>
+  </>
+);
+```
+
+Le `mounted` state évite l'hydration mismatch (Portal ne peut pas rendre côté SSR car `document` n'existe pas).
+
+### Impact
+
+- ✅ Drawer rendu directement dans `<body>` → échappe à tout stacking context parent
+- ✅ z-index relatif au document body (z-30 overlay, z-40 drawer)
+- ✅ Pas de changement CSS, juste de hiérarchie React
+- ⚠️ Tests Playwright qui targetent `header [role="dialog"]` ou similar doivent être adaptés (probablement aucun car le drawer a `id="mobile-nav-drawer"` au top level)
+
+---
+
+## Ordre d'exécution recommandé
+
+1. **Bug #2bis (SW fonts)** — 2 lignes sw.js, plus simple. Débloquage immédiat pour visiteurs avec cache poisoned.
+2. **Bug #1bis (CSP inline style)** — migration vers utility CSS, 3 fichiers touchés (Hero.tsx, WhatIfDemoClient.tsx, globals.css), aucun changement CSP.
+3. **Bug #4 (drawer Portal)** — refactor HeaderNav.tsx pour utiliser createPortal, scope contained dans 1 fichier.
+
+Tous tiennent dans un seul PR cohérent (scope discipliné : "production hotfixes V2 18/05") sur 4-5 fichiers.
+
+## Quality gates obligatoires post-fix
+
+- `npm run lint`, `lint:use-server`, `typecheck`, `test`, `e2e`, `build`
+- Smoke localhost prod (`npm run start`) :
+  - Console = 0 erreur CSP `style-src`
+  - DevTools Application → Service Workers → vérifier nouvelle version, anciennes caches purgées
+  - DevTools Mobile (iPhone 14) → ouvrir drawer → vérifier rendering au-dessus du contenu
+
+## Agents QA obligatoires
+
+- `security-auditor` — touch sw.js + style migrations (BLOCKER)
+- `ui-auditor` — vérification utility classes design system
+- `mobile-ios-auditor` — drawer Portal sur iOS Safari WebKit
+- `gdpr-compliance-auditor` — ServiceWorker change impact
+- `test-runner`
+
+## Smoke test prod post-merge (DoD step 5)
+
+- **@thierry iPhone 14 Safari + PWA** : ouvrir `/`, drawer mobile → liens visibles **au-dessus** du contenu, Console DevTools = 0 violation CSP, fonts chargées sans OTS error
+- **@cowork DevTools Brave** : Console = 0 CSP error, Network = 0 font OTS error, drawer correctement positionné en desktop emulation iPhone
+
+## STOP CONDITIONS rencontrées
+
+Aucune. Les 3 root causes sont confirmées et factuelles. Effort total estimé < 1.5 jour.
+
+---
+
+**FIN DIAGNOSTIC — @cc-ankora attend validation @cowork avant Phase 3 (fix).**

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,6 +1,6 @@
 # ankora.be — Full content export for LLMs
 
-Last generated: 2026-05-18
+Last generated: 2026-05-19
 Canonical URL: https://ankora.be
 License: content available for citation with attribution. Code is proprietary.
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -5,7 +5,12 @@
  * RLS and session freshness.
  */
 
-const CACHE_VERSION = 'ankora-v1-20260417';
+// Bumped 2026-05-19 (PR P0-V2) to purge caches poisoned with the HTML 404 that
+// /fonts/*.ttf used to return before PR #169 fixed the middleware matcher. The
+// `activate` handler below deletes any cache whose key doesn't start with the
+// current `CACHE_VERSION`, so bumping this constant is the canonical way to
+// force a clean slate across all returning visitors on first SW activation.
+const CACHE_VERSION = 'ankora-v2-20260519';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 
 const PRECACHE_URLS = [
@@ -43,7 +48,15 @@ function isBypass(url) {
     url.pathname.startsWith('/auth') ||
     url.pathname.startsWith('/api') ||
     url.pathname.startsWith('/_next/data') ||
-    url.pathname.startsWith('/onboarding')
+    url.pathname.startsWith('/onboarding') ||
+    // Self-hosted variable fonts. The browser HTTP cache + Vercel
+    // Cache-Control already handle them efficiently; routing them through the
+    // SW cache risked serving a stale HTML 404 from before PR #169 (when the
+    // middleware matcher didn't exclude .ttf), which the browser then tried to
+    // parse as a font and rejected with `OTS parsing error: invalid
+    // sfntVersion: 168430090 (0x0A0A0A0A = '\n\n\n\n')`. Bypassing the SW
+    // here makes that whole class of cache-poisoning bugs impossible.
+    url.pathname.startsWith('/fonts/')
   );
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -428,5 +428,32 @@ body > main {
   color: var(--color-brand-900);
 }
 
+/* ---------- Utility classes — replace inline style attributes ----------
+   Inline `style="..."` attributes in React components are rendered as HTML
+   attributes and blocked by the strict CSP (`style-src 'self' 'nonce-XYZ'`,
+   no `'unsafe-hashes'`). Each declaration here mirrors the original inline
+   style verbatim so the visual remains identical while staying CSP-compliant.
+   Added 2026-05-19 (PR P0-V2) — see docs/audits/2026-05-19-prod-p0-v2-bugs-diagnostic.md. */
+@layer utilities {
+  /* Hero radial glow — replaces inline gradient in Hero.tsx.
+     Pulls from --color-brand-400 via color-mix so it stays in sync with the
+     design system across light + dark + admin accent flips. */
+  .bg-brand-radial {
+    background: radial-gradient(
+      50% 60% at 50% 20%,
+      color-mix(in oklab, var(--color-brand-400) 15%, transparent),
+      transparent 70%
+    );
+  }
+
+  /* Custom accent color for native form controls (range slider thumb/track).
+     Replaces inline `style={{ accentColor: 'var(--color-brand-400)' }}` in
+     WhatIfDemoClient.tsx — Tailwind 4 does not yet ship a token-based
+     accent-* utility for design-system CSS variables. */
+  .accent-brand-400 {
+    accent-color: var(--color-brand-400);
+  }
+}
+
 /* ---------- Atoms (CD#3 — PR-D4-PHASE2-A) ---------- */
 @import '../components/atoms/atoms.css';

--- a/src/components/layout/HeaderNav.tsx
+++ b/src/components/layout/HeaderNav.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from '
 import { createPortal } from 'react-dom';
 import { Menu, Moon, Sun, X } from 'lucide-react';
 import { Link } from '@/i18n/navigation';
+import { useIsClient } from '@/lib/hooks/useIsClient';
 import { LocaleSwitcher } from './LocaleSwitcher';
 
 function subscribeToTheme(callback: () => void) {
@@ -21,25 +22,6 @@ function getThemeSnapshot() {
 }
 
 function getServerThemeSnapshot() {
-  return false;
-}
-
-// SSR-safe `mounted` flag for the drawer portal. We use
-// `useSyncExternalStore` instead of `useState(false) + useEffect(() =>
-// setMounted(true), [])` so we don't trip the React 19 lint rule
-// `react-hooks/set-state-in-effect`. The store never actually changes between
-// renders on a given environment — server snapshot returns `false` (so the
-// portal never renders during SSR, where `document` is undefined), client
-// snapshot returns `true` (so the portal renders after hydration). The subscribe
-// function is a no-op because there is nothing to subscribe to: the mounted
-// state is intrinsic to the environment, not an external observable.
-function subscribeToMount() {
-  return () => {};
-}
-function getMountSnapshot() {
-  return true;
-}
-function getServerMountSnapshot() {
   return false;
 }
 
@@ -74,11 +56,11 @@ export function HeaderNav({
   // sticky` + `z-index` + `backdrop-filter` is a triple stacking-context
   // trigger that confined the drawer's z-40 to the header's painted region on
   // iOS Safari. Symptom: drawer rendered BELOW the page content on iPhone
-  // (works on Chromium emulation, breaks on real WebKit). `mounted` gates the
-  // portal so SSR doesn't try to access `document` (which doesn't exist
+  // (works on Chromium emulation, breaks on real WebKit). `isClient` gates
+  // the portal so SSR doesn't try to access `document` (which doesn't exist
   // server-side); the bare hamburger button still renders during the brief
   // pre-mount window so the trigger is always visible.
-  const mounted = useSyncExternalStore(subscribeToMount, getMountSnapshot, getServerMountSnapshot);
+  const isClient = useIsClient();
   // PR-D5 a11y: replaced the previous `<label htmlFor="menu-toggle">` +
   // `<input type="checkbox" hidden>` pattern by a real `<button aria-expanded
   // aria-controls>`. The label/input pair fooled AT (VoiceOver/NVDA
@@ -406,11 +388,11 @@ export function HeaderNav({
 
       {/* Bug #4 (PR P0-V2): overlay + drawer rendered via React Portal into
           <body> so they escape the parent <header sticky z-40 backdrop-blur>
-          stacking context. `mounted` guards SSR (document only exists
-          client-side). When the portal hasn't mounted yet, the trigger button
-          above still works — clicking it sets isOpen = true; the portal then
-          appears on the next render after the useEffect runs. */}
-      {mounted && drawerOverlayAndPanel && createPortal(drawerOverlayAndPanel, document.body)}
+          stacking context. `isClient` guards SSR (document only exists
+          client-side). When the portal hasn't activated yet, the trigger
+          button above still works — clicking it sets isOpen = true; the
+          portal then appears on the next render after the store flips. */}
+      {isClient && isOpen && createPortal(drawerOverlayAndPanel, document.body)}
 
       {/* Desktop theme toggle + locale switcher - visible on desktop only */}
       <div className="hidden items-center gap-2 lg:flex">

--- a/src/components/layout/HeaderNav.tsx
+++ b/src/components/layout/HeaderNav.tsx
@@ -2,7 +2,8 @@
 
 import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
-import { Sun, Moon, Menu, X } from 'lucide-react';
+import { createPortal } from 'react-dom';
+import { Menu, Moon, Sun, X } from 'lucide-react';
 import { Link } from '@/i18n/navigation';
 import { LocaleSwitcher } from './LocaleSwitcher';
 
@@ -20,6 +21,25 @@ function getThemeSnapshot() {
 }
 
 function getServerThemeSnapshot() {
+  return false;
+}
+
+// SSR-safe `mounted` flag for the drawer portal. We use
+// `useSyncExternalStore` instead of `useState(false) + useEffect(() =>
+// setMounted(true), [])` so we don't trip the React 19 lint rule
+// `react-hooks/set-state-in-effect`. The store never actually changes between
+// renders on a given environment — server snapshot returns `false` (so the
+// portal never renders during SSR, where `document` is undefined), client
+// snapshot returns `true` (so the portal renders after hydration). The subscribe
+// function is a no-op because there is nothing to subscribe to: the mounted
+// state is intrinsic to the environment, not an external observable.
+function subscribeToMount() {
+  return () => {};
+}
+function getMountSnapshot() {
+  return true;
+}
+function getServerMountSnapshot() {
   return false;
 }
 
@@ -48,6 +68,17 @@ export function HeaderNav({
   const tMkt = useTranslations('landing.mktnav.links');
   const isDark = useSyncExternalStore(subscribeToTheme, getThemeSnapshot, getServerThemeSnapshot);
   const [isOpen, setIsOpen] = useState(false);
+  // Bug #4 fix (PR P0-V2, 2026-05-19): drawer + overlay rendered via React
+  // Portal into `document.body` to escape every ancestor stacking context.
+  // Parent <header> uses `sticky top-0 z-40 backdrop-blur` — `position:
+  // sticky` + `z-index` + `backdrop-filter` is a triple stacking-context
+  // trigger that confined the drawer's z-40 to the header's painted region on
+  // iOS Safari. Symptom: drawer rendered BELOW the page content on iPhone
+  // (works on Chromium emulation, breaks on real WebKit). `mounted` gates the
+  // portal so SSR doesn't try to access `document` (which doesn't exist
+  // server-side); the bare hamburger button still renders during the brief
+  // pre-mount window so the trigger is always visible.
+  const mounted = useSyncExternalStore(subscribeToMount, getMountSnapshot, getServerMountSnapshot);
   // PR-D5 a11y: replaced the previous `<label htmlFor="menu-toggle">` +
   // `<input type="checkbox" hidden>` pattern by a real `<button aria-expanded
   // aria-controls>`. The label/input pair fooled AT (VoiceOver/NVDA
@@ -131,6 +162,231 @@ export function HeaderNav({
     triggerRef.current?.focus();
   }, []);
 
+  const drawerOverlayAndPanel = isOpen ? (
+    <>
+      {/* Drawer overlay - visible when drawer is open.
+          z-[60] on overlay + z-[70] on the panel keeps them above any sticky
+          header (z-40) when the portal lands them as direct children of
+          <body>. Using arbitrary values here (Tailwind has no z-60/z-70 step
+          by default) to stay unambiguously above z-50 modals/toasts. */}
+      <div
+        className="fixed inset-0 z-[60] bg-black/50 lg:hidden"
+        onClick={handleDrawerClose}
+        aria-hidden="true"
+      />
+
+      {/* Mobile drawer — conditional render to avoid contributing to scrollWidth
+          when closed. The previous `translate-x-full` pattern (off-canvas
+          slide-in) caused 320px of horizontal overflow on `/` viewport 375px
+          (WCAG 2.1 Reflow 1.4.10), because `position: fixed + translate` keeps
+          the box in the page's overflow flow. Mounting/unmounting on `isOpen`
+          removes that overflow at the cost of the slide animation — re-add via
+          Framer Motion (AnimatePresence) or CSS view-transitions in a follow-up
+          PR (issue to be opened post-merge). */}
+      <nav
+        id="mobile-nav-drawer"
+        ref={navRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('nav.mobileLabel')}
+        className="bg-card border-border fixed top-0 right-0 bottom-0 z-[70] w-80 overflow-y-auto border-l lg:hidden"
+      >
+        {/* PR-D5: dropped `sticky top-0` — same Playwright iPhone 14 WebKit
+              pointer-event interception as the footer below. Drawer content
+              fits the mobile viewport without needing sticky chrome. */}
+        <div className="border-border bg-card flex items-center justify-between border-b p-4">
+          <span className="text-sm font-semibold">{t('nav.menu')}</span>
+          <button
+            onClick={handleDrawerClose}
+            className="hover:bg-muted focus-visible:ring-brand-600 flex h-8 w-8 items-center justify-center rounded-md focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+            aria-label={t('nav.close')}
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Navigation links */}
+        <div className="space-y-2 p-4">
+          {variant === 'marketing' && (
+            <>
+              {/* PR-UX-1 — parity with MktNav desktop: Product / Simulator /
+                    Pricing point at on-page anchors; FAQ kept as the only
+                    cross-page entry. `#features` (previous target) never
+                    existed in the landing DOM — `#principles` is canonical. */}
+              <Link
+                href="/#principles"
+                onClick={handleDrawerClose}
+                className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+              >
+                {tMkt('product')}
+              </Link>
+              <Link
+                href="/#simulator"
+                onClick={handleDrawerClose}
+                className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+              >
+                {tMkt('simulator')}
+              </Link>
+              <Link
+                href="/#pricing"
+                onClick={handleDrawerClose}
+                className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+              >
+                {tMkt('pricing')}
+              </Link>
+              <Link
+                href="/faq"
+                onClick={handleDrawerClose}
+                className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+              >
+                {t('nav.faq')}
+              </Link>
+
+              {/* PR-D5 — auth entrypoints inside the mobile drawer.
+                    Resolves BUG-iOS-003 (login unreachable in ≤ 2 taps from
+                    landing on iPhone — the header CTAs were `hidden sm:`,
+                    invisible below 640px, and the drawer had no fallback).
+                    `data-testid` on the login link lets Playwright target
+                    it directly without role/name globbing — `getByRole('link',
+                    { name: /se connecter/i })` also matches the (hidden)
+                    desktop header CTA and `.first()` picks the wrong one.
+
+                    When the visitor is already signed in, replace the
+                    login/signup pair with a single "My cockpit" link so the
+                    drawer stays consistent with the desktop CTA. Avoids the
+                    UX bug where a returning user lands on `/` and thinks
+                    their session expired. */}
+              <div className="border-border mt-2 space-y-2 border-t pt-2">
+                {isAuthenticated ? (
+                  <Link
+                    href="/app"
+                    onClick={handleDrawerClose}
+                    data-testid="drawer-cockpit-link"
+                    className="bg-brand-700 hover:bg-brand-800 focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-center text-sm font-medium text-white transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                  >
+                    {t('nav.myCockpit')}
+                  </Link>
+                ) : (
+                  <>
+                    <Link
+                      href="/login"
+                      onClick={handleDrawerClose}
+                      data-testid="drawer-login-link"
+                      className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                    >
+                      {t('nav.login')}
+                    </Link>
+                    <Link
+                      href="/signup"
+                      onClick={handleDrawerClose}
+                      data-testid="drawer-signup-link"
+                      className="bg-brand-700 hover:bg-brand-800 focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-center text-sm font-medium text-white transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                    >
+                      {t('nav.signup')}
+                    </Link>
+                  </>
+                )}
+              </div>
+            </>
+          )}
+
+          {variant === 'app' && (
+            <>
+              <Link
+                href="/app"
+                onClick={handleDrawerClose}
+                className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+              >
+                {t('nav.dashboard')}
+              </Link>
+              <Link
+                href="/app/accounts"
+                onClick={handleDrawerClose}
+                className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+              >
+                {t('nav.accounts')}
+              </Link>
+              <Link
+                href="/app/charges"
+                onClick={handleDrawerClose}
+                className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+              >
+                {t('nav.charges')}
+              </Link>
+              <Link
+                href="/app/expenses"
+                onClick={handleDrawerClose}
+                className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+              >
+                {t('nav.expenses')}
+              </Link>
+              <Link
+                href="/app/simulator"
+                onClick={handleDrawerClose}
+                className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+              >
+                {t('nav.simulator')}
+              </Link>
+              <Link
+                href="/app/settings"
+                onClick={handleDrawerClose}
+                className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+              >
+                {t('nav.settings')}
+              </Link>
+              {/* PR-UX-1 — admin entry mirrors the desktop cockpit nav
+                    (Header.tsx). Route is `/admin` (not `/app/admin`).
+                    Amber dot uses `bg-amber-700` for WCAG SC 1.4.11 parity
+                    in both themes (≈ 4.46:1 light, ≈ 3.32:1 dark). Bumped
+                    from amber-600 (failed AA in light mode at ≈ 2.91:1).
+                    `aria-label` carries the "founder only" context so AT
+                    users get the same hint as desktop. */}
+              {isAdmin && (
+                <Link
+                  href="/admin"
+                  onClick={handleDrawerClose}
+                  aria-label={t('nav.adminAriaLabel')}
+                  className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 flex items-center justify-between rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                >
+                  <span>{t('nav.admin')}</span>
+                  <span
+                    aria-hidden="true"
+                    className="inline-block h-1.5 w-1.5 rounded-full bg-amber-700"
+                  />
+                </Link>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* Drawer footer - theme toggle + locale switcher.
+              PR-D5: `sticky bottom-0` removed — on Playwright iPhone 14
+              WebKit the sticky footer was reported as intercepting pointer
+              events on links above it (visible regression in the auth-flow
+              ≤ 2 taps test). Functionally equivalent in normal flow because
+              the drawer content rarely overflows the viewport on mobile;
+              if it ever does we'll re-introduce sticky behind a feature
+              detect. */}
+        <div className="border-border bg-card mt-auto space-y-3 border-t p-4">
+          <button
+            onClick={toggleTheme}
+            className="bg-surface-muted text-foreground hover:bg-surface-muted/80 focus-visible:ring-brand-600 flex w-full items-center justify-between rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+            aria-label={isDark ? t('nav.lightMode') : t('nav.darkMode')}
+          >
+            <span className="dark:hidden">{t('nav.darkMode')}</span>
+            <span className="hidden dark:block">{t('nav.lightMode')}</span>
+            <div className="h-4 w-4">
+              <Moon className="h-4 w-4 dark:hidden" aria-hidden="true" />
+              <Sun className="hidden h-4 w-4 dark:block" aria-hidden="true" />
+            </div>
+          </button>
+
+          <LocaleSwitcher />
+        </div>
+      </nav>
+    </>
+  ) : null;
+
   return (
     <>
       {/* Hamburger menu - visible on mobile only.
@@ -148,226 +404,13 @@ export function HeaderNav({
         {isOpen ? <X className="h-5 w-5" aria-hidden /> : <Menu className="h-5 w-5" aria-hidden />}
       </button>
 
-      {/* Drawer overlay - visible when drawer is open */}
-      {isOpen && (
-        <div
-          className="fixed inset-0 z-30 bg-black/50 lg:hidden"
-          onClick={handleDrawerClose}
-          aria-hidden="true"
-        />
-      )}
-
-      {/* Mobile drawer — conditional render to avoid contributing to scrollWidth
-          when closed. The previous `translate-x-full` pattern (off-canvas
-          slide-in) caused 320px of horizontal overflow on `/` viewport 375px
-          (WCAG 2.1 Reflow 1.4.10), because `position: fixed + translate` keeps
-          the box in the page's overflow flow. Mounting/unmounting on `isOpen`
-          removes that overflow at the cost of the slide animation — re-add via
-          Framer Motion (AnimatePresence) or CSS view-transitions in a follow-up
-          PR (issue to be opened post-merge). */}
-      {isOpen && (
-        <nav
-          id="mobile-nav-drawer"
-          ref={navRef}
-          role="dialog"
-          aria-modal="true"
-          aria-label={t('nav.mobileLabel')}
-          className="bg-card border-border fixed top-0 right-0 bottom-0 z-40 w-80 overflow-y-auto border-l lg:hidden"
-        >
-          {/* PR-D5: dropped `sticky top-0` — same Playwright iPhone 14 WebKit
-              pointer-event interception as the footer below. Drawer content
-              fits the mobile viewport without needing sticky chrome. */}
-          <div className="border-border bg-card flex items-center justify-between border-b p-4">
-            <span className="text-sm font-semibold">{t('nav.menu')}</span>
-            <button
-              onClick={handleDrawerClose}
-              className="hover:bg-muted focus-visible:ring-brand-600 flex h-8 w-8 items-center justify-center rounded-md focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-              aria-label={t('nav.close')}
-            >
-              <X className="h-4 w-4" />
-            </button>
-          </div>
-
-          {/* Navigation links */}
-          <div className="space-y-2 p-4">
-            {variant === 'marketing' && (
-              <>
-                {/* PR-UX-1 — parity with MktNav desktop: Product / Simulator /
-                    Pricing point at on-page anchors; FAQ kept as the only
-                    cross-page entry. `#features` (previous target) never
-                    existed in the landing DOM — `#principles` is canonical. */}
-                <Link
-                  href="/#principles"
-                  onClick={handleDrawerClose}
-                  className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-                >
-                  {tMkt('product')}
-                </Link>
-                <Link
-                  href="/#simulator"
-                  onClick={handleDrawerClose}
-                  className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-                >
-                  {tMkt('simulator')}
-                </Link>
-                <Link
-                  href="/#pricing"
-                  onClick={handleDrawerClose}
-                  className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-                >
-                  {tMkt('pricing')}
-                </Link>
-                <Link
-                  href="/faq"
-                  onClick={handleDrawerClose}
-                  className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-                >
-                  {t('nav.faq')}
-                </Link>
-
-                {/* PR-D5 — auth entrypoints inside the mobile drawer.
-                    Resolves BUG-iOS-003 (login unreachable in ≤ 2 taps from
-                    landing on iPhone — the header CTAs were `hidden sm:`,
-                    invisible below 640px, and the drawer had no fallback).
-                    `data-testid` on the login link lets Playwright target
-                    it directly without role/name globbing — `getByRole('link',
-                    { name: /se connecter/i })` also matches the (hidden)
-                    desktop header CTA and `.first()` picks the wrong one.
-
-                    When the visitor is already signed in, replace the
-                    login/signup pair with a single "My cockpit" link so the
-                    drawer stays consistent with the desktop CTA. Avoids the
-                    UX bug where a returning user lands on `/` and thinks
-                    their session expired. */}
-                <div className="border-border mt-2 space-y-2 border-t pt-2">
-                  {isAuthenticated ? (
-                    <Link
-                      href="/app"
-                      onClick={handleDrawerClose}
-                      data-testid="drawer-cockpit-link"
-                      className="bg-brand-700 hover:bg-brand-800 focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-center text-sm font-medium text-white transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-                    >
-                      {t('nav.myCockpit')}
-                    </Link>
-                  ) : (
-                    <>
-                      <Link
-                        href="/login"
-                        onClick={handleDrawerClose}
-                        data-testid="drawer-login-link"
-                        className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-                      >
-                        {t('nav.login')}
-                      </Link>
-                      <Link
-                        href="/signup"
-                        onClick={handleDrawerClose}
-                        data-testid="drawer-signup-link"
-                        className="bg-brand-700 hover:bg-brand-800 focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-center text-sm font-medium text-white transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-                      >
-                        {t('nav.signup')}
-                      </Link>
-                    </>
-                  )}
-                </div>
-              </>
-            )}
-
-            {variant === 'app' && (
-              <>
-                <Link
-                  href="/app"
-                  onClick={handleDrawerClose}
-                  className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-                >
-                  {t('nav.dashboard')}
-                </Link>
-                <Link
-                  href="/app/accounts"
-                  onClick={handleDrawerClose}
-                  className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-                >
-                  {t('nav.accounts')}
-                </Link>
-                <Link
-                  href="/app/charges"
-                  onClick={handleDrawerClose}
-                  className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-                >
-                  {t('nav.charges')}
-                </Link>
-                <Link
-                  href="/app/expenses"
-                  onClick={handleDrawerClose}
-                  className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-                >
-                  {t('nav.expenses')}
-                </Link>
-                <Link
-                  href="/app/simulator"
-                  onClick={handleDrawerClose}
-                  className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-                >
-                  {t('nav.simulator')}
-                </Link>
-                <Link
-                  href="/app/settings"
-                  onClick={handleDrawerClose}
-                  className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-                >
-                  {t('nav.settings')}
-                </Link>
-                {/* PR-UX-1 — admin entry mirrors the desktop cockpit nav
-                    (Header.tsx). Route is `/admin` (not `/app/admin`).
-                    Amber dot uses `bg-amber-700` for WCAG SC 1.4.11 parity
-                    in both themes (≈ 4.46:1 light, ≈ 3.32:1 dark). Bumped
-                    from amber-600 (failed AA in light mode at ≈ 2.91:1).
-                    `aria-label` carries the "founder only" context so AT
-                    users get the same hint as desktop. */}
-                {isAdmin && (
-                  <Link
-                    href="/admin"
-                    onClick={handleDrawerClose}
-                    aria-label={t('nav.adminAriaLabel')}
-                    className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 flex items-center justify-between rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-                  >
-                    <span>{t('nav.admin')}</span>
-                    <span
-                      aria-hidden="true"
-                      className="inline-block h-1.5 w-1.5 rounded-full bg-amber-700"
-                    />
-                  </Link>
-                )}
-              </>
-            )}
-          </div>
-
-          {/* Drawer footer - theme toggle + locale switcher.
-              PR-D5: `sticky bottom-0` removed — on Playwright iPhone 14
-              WebKit the sticky footer was reported as intercepting pointer
-              events on links above it (visible regression in the auth-flow
-              ≤ 2 taps test). Functionally equivalent in normal flow because
-              the drawer content rarely overflows the viewport on mobile;
-              if it ever does we'll re-introduce sticky behind a feature
-              detect. */}
-          <div className="border-border bg-card mt-auto space-y-3 border-t p-4">
-            <button
-              onClick={toggleTheme}
-              className="bg-surface-muted text-foreground hover:bg-surface-muted/80 focus-visible:ring-brand-600 flex w-full items-center justify-between rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-              aria-label={isDark ? t('nav.lightMode') : t('nav.darkMode')}
-            >
-              <span className="dark:hidden">{t('nav.darkMode')}</span>
-              <span className="hidden dark:block">{t('nav.lightMode')}</span>
-              <div className="h-4 w-4">
-                <Moon className="h-4 w-4 dark:hidden" aria-hidden="true" />
-                <Sun className="hidden h-4 w-4 dark:block" aria-hidden="true" />
-              </div>
-            </button>
-
-            <LocaleSwitcher />
-          </div>
-        </nav>
-      )}
+      {/* Bug #4 (PR P0-V2): overlay + drawer rendered via React Portal into
+          <body> so they escape the parent <header sticky z-40 backdrop-blur>
+          stacking context. `mounted` guards SSR (document only exists
+          client-side). When the portal hasn't mounted yet, the trigger button
+          above still works — clicking it sets isOpen = true; the portal then
+          appears on the next render after the useEffect runs. */}
+      {mounted && drawerOverlayAndPanel && createPortal(drawerOverlayAndPanel, document.body)}
 
       {/* Desktop theme toggle + locale switcher - visible on desktop only */}
       <div className="hidden items-center gap-2 lg:flex">

--- a/src/components/marketing/landing/sections/Hero.tsx
+++ b/src/components/marketing/landing/sections/Hero.tsx
@@ -38,19 +38,16 @@ export async function Hero() {
       className="relative mx-auto max-w-6xl overflow-hidden px-4 pt-20 pb-16 text-center md:px-6 md:pt-28"
     >
       {/* Decorative radial glow (cc-design fidelity).
-          Inline `style.background` bypasses any potential cascade quirk where
-          a class-based `background` could be overridden by Tailwind utility
-          backgrounds — this guarantees the gradient renders. The colour pulls
-          from `--color-brand-400` via `color-mix` so it stays in sync with
-          the design system across light + dark + admin accent flips. */}
+          Uses the `.bg-brand-radial` utility (defined in globals.css
+          `@layer utilities`) so the style is applied via a stylesheet rule
+          rather than an inline `style="..."` attribute — the strict CSP
+          (`style-src 'self' 'nonce-XYZ'`, no `'unsafe-hashes'`) blocks inline
+          attributes outright. The gradient still pulls from --color-brand-400
+          via `color-mix` so it stays in sync with the design system. */}
       <div
         aria-hidden="true"
         data-testid="hero-radial-glow"
-        className="pointer-events-none absolute -inset-x-[20%] -top-[40%] z-0 h-[90%]"
-        style={{
-          background:
-            'radial-gradient(50% 60% at 50% 20%, color-mix(in oklab, var(--color-brand-400) 15%, transparent), transparent 70%)',
-        }}
+        className="bg-brand-radial pointer-events-none absolute -inset-x-[20%] -top-[40%] z-0 h-[90%]"
       />
 
       <div className="relative z-10 mx-auto max-w-3xl">

--- a/src/components/marketing/landing/sections/WhatIfDemoClient.tsx
+++ b/src/components/marketing/landing/sections/WhatIfDemoClient.tsx
@@ -172,8 +172,7 @@ export function WhatIfDemoClient() {
             aria-label={t('controls.slider_aria', {
               label: t(`scenarios.${scenarioId}.label`),
             })}
-            style={{ accentColor: 'var(--color-brand-400)' }}
-            className="h-6 w-full"
+            className="accent-brand-400 h-6 w-full"
           />
           <div className="text-muted-foreground mt-0.5 flex justify-between font-mono text-xs">
             <span>{scenario.min} €</span>
@@ -336,7 +335,7 @@ export function WhatIfDemoClient() {
                       fontWeight="600"
                       fill="var(--color-brand-text-strong)"
                       textAnchor={i === 0 ? 'start' : 'end'}
-                      style={{ fontVariantNumeric: 'tabular-nums' }}
+                      className="tabular-nums"
                     >
                       {v.toLocaleString(locale)} €
                     </text>

--- a/src/components/marketing/landing/sections/__tests__/Hero.test.tsx
+++ b/src/components/marketing/landing/sections/__tests__/Hero.test.tsx
@@ -99,14 +99,18 @@ describe('<Hero />', () => {
     expect(reserve.className).toContain('text-brand-text-strong');
   });
 
-  it('renders the decorative radial glow as aria-hidden with an inline radial-gradient', async () => {
+  it('renders the decorative radial glow as aria-hidden via the .bg-brand-radial utility class', async () => {
     await renderHero();
     const glow = screen.getByTestId('hero-radial-glow');
     expect(glow).toHaveAttribute('aria-hidden', 'true');
-    // Inline style guarantees the gradient renders even if a class-based
-    // background were ever overridden by a Tailwind utility.
-    expect(glow.style.background).toContain('radial-gradient');
-    expect(glow.style.background).toContain('var(--color-brand-400)');
+    // PR P0-V2 (2026-05-19): the inline `style="background: radial-gradient(...)"`
+    // was migrated to the `.bg-brand-radial` utility class defined in
+    // `globals.css @layer utilities`. The strict CSP (`style-src 'self'
+    // 'nonce-XYZ'`, no `'unsafe-hashes'`) blocked the inline attribute in
+    // production. The visual remains identical — the test asserts the class
+    // is present rather than the inline style.
+    expect(glow.className).toContain('bg-brand-radial');
+    expect(glow.style.background).toBe('');
   });
 
   it('exposes the section as a named landmark via aria-labelledby="hero-heading"', async () => {

--- a/src/components/marketing/landing/sections/__tests__/WhatIfDemoClient.test.tsx
+++ b/src/components/marketing/landing/sections/__tests__/WhatIfDemoClient.test.tsx
@@ -124,11 +124,17 @@ describe('<WhatIfDemoClient />', () => {
     expect(line?.getAttribute('class')).toContain('motion-reduce:transition-none');
   });
 
-  it('drives the slider accent colour from var(--color-brand-400)', () => {
+  it('drives the slider accent colour via the .accent-brand-400 utility class', () => {
     render(<WhatIfDemoClient />);
     const slider = screen.getByRole('slider') as HTMLInputElement;
-    // jsdom serialises the inline accent-color as a CSS string
-    expect(slider.style.accentColor).toBe('var(--color-brand-400)');
+    // PR P0-V2 (2026-05-19): the inline `style="accent-color: var(...)"`
+    // was migrated to the `.accent-brand-400` utility class defined in
+    // `globals.css @layer utilities`. The strict CSP (`style-src 'self'
+    // 'nonce-XYZ'`, no `'unsafe-hashes'`) blocked the inline attribute in
+    // production. The visual remains identical — the test asserts the class
+    // is present rather than the inline style.
+    expect(slider.className).toContain('accent-brand-400');
+    expect(slider.style.accentColor).toBe('');
   });
 
   it('passes the active scenario label into the slider aria-label', () => {

--- a/src/lib/hooks/useIsClient.ts
+++ b/src/lib/hooks/useIsClient.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+/**
+ * SSR-safe "is this rendering on the client?" flag, implemented as a
+ * `useSyncExternalStore` so it does not trip the React 19 lint rule
+ * `react-hooks/set-state-in-effect` (which fires on the naive
+ * `useState(false) + useEffect(() => setMounted(true), [])` pattern).
+ *
+ * The underlying "store" is intentionally not observable — there is nothing
+ * to subscribe to, because the environment (server vs client) is fixed for
+ * the lifetime of any given render. The client snapshot returns `true`, the
+ * server snapshot returns `false`, and the subscribe function is a no-op
+ * because the value never needs to update mid-render.
+ *
+ * Primary use case: gating `React.createPortal(..., document.body)` so the
+ * portal never tries to render during SSR (where `document` is undefined).
+ *
+ * Introduced 2026-05-19 (PR P0-V2) per Sourcery review on PR #171.
+ */
+function subscribeToClientEnv(): () => void {
+  return () => {};
+}
+
+function getClientSnapshot(): boolean {
+  return true;
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+export function useIsClient(): boolean {
+  return useSyncExternalStore(subscribeToClientEnv, getClientSnapshot, getServerSnapshot);
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -115,6 +115,15 @@ export const config = {
      *   localizable page path and routes it to /_not-found (404). Symptom
      *   observed in prod on 2026-05-18: globals.css @font-face fallbacks
      *   failed to load. Cf. docs/audits/2026-05-18-prod-p0-bugs-diagnostic.md.
+     * - `/sw.js` ServiceWorker entry point. Without this exclusion next-intl
+     *   routes /sw.js to /_not-found (HTTP 404) and
+     *   `navigator.serviceWorker.register('/sw.js')` in
+     *   `ServiceWorkerRegister.tsx` silently fails. Worse, users who installed
+     *   the SW before this fix have a cached SW that the browser can never
+     *   UPDATE (the `update` request also 404s) — they stay on the old SW
+     *   indefinitely, which is the actual root cause of the iPhone Safari +
+     *   PWA "OTS parsing error: invalid sfntVersion: 168430090" font bug.
+     *   Cf. docs/audits/2026-05-19-prod-p0-v2-bugs-diagnostic.md.
      *
      * Note on RSC prefetches: previously excluded via `missing:` to avoid
      * caching a fresh CSP nonce across users. That was over-cautious — RSC
@@ -124,6 +133,6 @@ export const config = {
      * The middleware now runs on prefetches too; each prefetch gets its own
      * per-request nonce that is never shared with another user.
      */
-    '/((?!api|auth/callback|monitoring|_next/static|_next/image|_vercel|favicon.ico|icon.svg|apple-icon.svg|manifest.webmanifest|robots.txt|sitemap.xml|llms\\.txt|.*\\.(?:png|jpg|jpeg|gif|svg|webp|avif|ico|ttf|woff|woff2|otf|eot)).*)',
+    '/((?!api|auth/callback|monitoring|_next/static|_next/image|_vercel|favicon.ico|icon.svg|apple-icon.svg|manifest.webmanifest|sw\\.js|robots.txt|sitemap.xml|llms\\.txt|.*\\.(?:png|jpg|jpeg|gif|svg|webp|avif|ico|ttf|woff|woff2|otf|eot)).*)',
   ],
 };


### PR DESCRIPTION
## Summary

3 P0 prod bugs résolus + 1 root cause critique découvert pendant le smoke test de cette PR. Détectés en smoke @thierry iPhone 14 Safari + PWA 2026-05-18 ~22h CEST (post-merge PR #169).

| # | Bug | Root cause | Fix |
| - | --- | ---------- | --- |
| **CRITICAL DISCOVERY** | `/sw.js` → HTTP 404 en prod (curl confirme) | Matcher `src/proxy.ts` n'excluait pas `sw.js` → next-intl le routait vers `/_not-found`. Users avec SW pré-PR #169 ne pouvaient JAMAIS update | Ajouter `sw\.js` à la regex d'exclusion (vrai root cause Bug #2bis) |
| **#1bis CSP inline style** | 3 inline `style="..."` bloqués par strict CSP | Hero radial-gradient + WhatIfDemo accent-color + WhatIfDemo font-variant-numeric | Migration vers utility classes (`@layer utilities` + Tailwind natif) |
| **#2bis Fonts OTS** | SW cache poisoned avec HTML 404 pré-PR #169 | Activate handler purge poisoned caches via bump `CACHE_VERSION` + `/fonts/` ajouté à `isBypass()` | Cf. CRITICAL DISCOVERY ci-dessus + sw.js update |
| **#4 Drawer iOS stacking** | `<header sticky z-40 backdrop-blur>` confine `z-40` drawer enfant sur WebKit | React Portal vers `document.body` + `useSyncExternalStore` SSR guard |

## Diagnostic complet

[`docs/audits/2026-05-19-prod-p0-v2-bugs-diagnostic.md`](docs/audits/2026-05-19-prod-p0-v2-bugs-diagnostic.md)

## QA agents (PASS_WITH_NOTES, no blocker)

- **security-auditor** : CSP strict préservé, pas de `'unsafe-hashes'`. sw.js bypass middleware OK (asset statique). Portal pattern safe. OWASP A05/A03 + RGPD OK.
- **mobile-ios-auditor** : Portal architecturalement correct pour iOS Safari. Focus trap + scroll lock survivent. `useSyncExternalStore` SSR-safe. Notes post-merge (hors scope) : safe-area-inset-top sur drawer header, tokens `--z-overlay`/`--z-drawer`.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run lint:use-server` — 0 errors
- [x] `npm run typecheck` — 0 errors
- [x] `npm run test` — 1147/1147 passed (2 tests Hero + WhatIfDemo adaptés aux className au lieu d'inline style)
- [x] `npm run build` — success
- [x] Local prod smoke (`npm run start`) :
  - [x] `/sw.js` → HTTP 200 + `CACHE_VERSION = 'ankora-v2-20260519'`
  - [x] `/fonts/{Inter,Fraunces,JetBrainsMono}-Variable.ttf` → HTTP 200
  - [x] Landing HTML : 0 inline `style=`, 0 `<script>` sans nonce
  - [x] `aria-controls="mobile-nav-drawer"` hamburger SSR rendered
- [ ] `npm run e2e` — **flaky locally** (collision port 3000 avec processus background résiduels, même pattern que PR #169). CI sera le juge.
- [ ] **@thierry post-merge** : iPhone 14 Safari + PWA réel — drawer mobile au-dessus du contenu, fonts sans OTS error
- [ ] **@cowork post-merge** : DevTools Brave — Console = 0 CSP violation, Network = 0 font OTS, /sw.js = 200 OK

## E2E flakers pré-existants (hors scope P0)

Identiques au PR #169 : `admin-security-headers /fr-BE/admin`, `mobile-ios pwa-install` flaky WebKit emulation, `a11y baseline` axe-core flakers, `mobile-ios simulator` scrollIntoView timeout. Documentés dans le PR #169 et `docs/runbooks/dev-on-iphone.md`.

## Refs

- Smoke test source : @thierry iPhone 14 Safari + PWA réel + @cowork DevTools Brave 2026-05-18 ~22h CEST
- Branche depuis `origin/main` `494c56a` (post PR #169 + PR #170)
- Worktree : `F:\PROJECTS\Apps\ankora-worktrees\fix-prod-p0-v2`
- Linear : THI-224

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Correction de problèmes critiques en production concernant le service worker, le chargement des polices, les styles inline soumis à la CSP, et la superposition du tiroir de navigation mobile sur Safari iOS.

Bug Fixes:
- Restaurer l’endpoint du service worker `/sw.js` en l’excluant du routage de `next-intl` afin que l’enregistrement et les mises à jour ne renvoient plus d’erreur 404.
- Purger les caches de service worker précédemment corrompus et ignorer les requêtes `/fonts/` dans le SW pour éliminer les réponses HTML obsolètes provoquant des erreurs d’analyse OTS des polices.
- Migrer le dégradé du hero, la couleur accent du slider et le style numérique tabulaire des styles inline vers des classes utilitaires CSS afin de respecter la CSP stricte et supprimer les violations liées aux styles inline.
- Rendre le tiroir de navigation mobile et l’overlay via un portail React dans `document.body` avec des z-index élevés pour que le tiroir apparaisse de manière fiable au-dessus du contenu de la page sur Safari iOS et en PWA.

Documentation:
- Ajouter un rapport de diagnostic détaillé documentant les bugs P0 en production, leurs causes profondes et les correctifs choisis.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix production-critical issues with the service worker, font loading, CSP inline styles, and mobile drawer layering on iOS Safari.

Bug Fixes:
- Restore the /sw.js service worker endpoint by excluding it from next-intl routing so registration and updates no longer 404.
- Purge previously poisoned service worker caches and bypass /fonts/ requests in the SW to eliminate stale HTML responses causing font OTS parsing errors.
- Migrate hero gradient, slider accent color, and tabular numeric styling from inline styles to CSS utility classes to comply with the strict CSP and remove inline-style violations.
- Render the mobile navigation drawer and overlay via a React portal into document.body with elevated z-indexes so the drawer reliably appears above page content on iOS Safari and PWA.

Documentation:
- Add a detailed diagnostic report documenting the production P0 bugs, their root causes, and the chosen fixes.

</details>