### PR TITLE
fix(csp): migrate error pages inline fontFamily to font-display utility (THI-249)

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,6 +1,6 @@
 # ankora.be — Full content export for LLMs
 
-Last generated: 2026-05-19
+Last generated: 2026-05-20
 Canonical URL: https://ankora.be
 License: content available for citation with attribution. Code is proprietary.
 

--- a/src/app/[locale]/__tests__/error.test.tsx
+++ b/src/app/[locale]/__tests__/error.test.tsx
@@ -73,10 +73,17 @@ describe('<ErrorBoundary /> — error.tsx route-level', () => {
     expect(haystack).not.toContain('user@example.com leaked');
   });
 
-  it('uses Fraunces for the title (var(--font-display))', () => {
+  it('uses Fraunces for the title via font-display utility (no inline style — THI-249 CSP)', () => {
+    // THI-249 (2026-05-20): migrated from `style={{ fontFamily: 'var(--font-display)' }}`
+    // to the Tailwind 4 auto-generated `font-display` utility class so the
+    // strict CSP `style-src 'self' 'nonce-XXX'` no longer flags this surface.
+    // Element-level inline `style="..."` attributes are not covered by
+    // nonces; only `<style>` tags are. The utility class resolves the same
+    // `var(--font-display)` token statically through `globals.css @theme`.
     const { container } = renderBoundary();
     const heading = container.querySelector('h1');
-    expect(heading?.getAttribute('style')).toContain('var(--font-display)');
+    expect(heading?.className).toContain('font-display');
+    expect(heading?.hasAttribute('style')).toBe(false);
   });
 });
 

--- a/src/app/[locale]/error.tsx
+++ b/src/app/[locale]/error.tsx
@@ -40,10 +40,7 @@ export default function ErrorBoundary({ error, reset }: ErrorProps) {
         >
           <AlertTriangle className="h-8 w-8" />
         </div>
-        <h1
-          className="text-foreground text-4xl font-bold tracking-tight md:text-5xl"
-          style={{ fontFamily: 'var(--font-display)' }}
-        >
+        <h1 className="text-foreground font-display text-4xl font-bold tracking-tight md:text-5xl">
           {t('title')}
         </h1>
         <p className="text-muted-foreground mt-4 text-base leading-relaxed">{t('description')}</p>

--- a/src/app/__tests__/global-error.test.tsx
+++ b/src/app/__tests__/global-error.test.tsx
@@ -80,6 +80,21 @@ describe('<GlobalError /> — root html/body error boundary', () => {
     expect(screen.getByRole('alert')).toBeInTheDocument();
   });
 
+  it('uses Fraunces for the title via font-display utility (no inline style — THI-249 CSP)', () => {
+    // THI-249 (2026-05-20): migrated from `style={{ fontFamily: 'var(--font-display)' }}`
+    // to the Tailwind 4 auto-generated `font-display` utility class so the
+    // strict CSP `style-src 'self' 'nonce-XXX'` no longer flags this surface.
+    // Mirrors the analogous guards in `not-found.test.tsx` and
+    // `[locale]/__tests__/error.test.tsx` — without this assertion a future
+    // edit could silently re-introduce an inline `style={{ ... }}` on the H1
+    // of `global-error.tsx` and only surface as a CSP console warning in prod.
+    // Flagged by `security-auditor` agent (asymmetric coverage finding).
+    renderInDoc('fr-BE');
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(heading.className).toContain('font-display');
+    expect(heading.hasAttribute('style')).toBe(false);
+  });
+
   it('emits <html lang="fr"> when the FR copy is shown (a11y/SEO — Sourcery #1)', () => {
     document.documentElement.lang = 'fr-BE';
     const html = renderToStaticMarkup(

--- a/src/app/__tests__/not-found.test.tsx
+++ b/src/app/__tests__/not-found.test.tsx
@@ -68,10 +68,18 @@ describe('<NotFound /> — root-level branded 404', () => {
     expect(container.textContent).toContain('Page introuvable');
   });
 
-  it('uses Fraunces (var(--font-display)) for the H1', async () => {
+  it('uses Fraunces (font-display utility) for the H1 without inline style (THI-249 CSP)', async () => {
+    // THI-249 (2026-05-20): migrated from `style={{ fontFamily: 'var(--font-display)' }}`
+    // to the Tailwind 4 auto-generated `font-display` utility class. The strict CSP
+    // `style-src 'self' 'nonce-XXX'` blocks any inline `style="..."` attribute
+    // even when the page itself carries a valid nonce on its <script>/<style>
+    // tags — nonces do not cover element-level style attributes. The utility
+    // class resolves the same `var(--font-display)` token statically through
+    // `globals.css @theme`, so visual rendering is identical.
     const { container } = await renderTree();
     const heading = container.querySelector('h1');
-    expect(heading?.getAttribute('style')).toContain('var(--font-display)');
+    expect(heading?.className).toContain('font-display');
+    expect(heading?.hasAttribute('style')).toBe(false);
   });
 
   it('exposes a noindex meta via generateMetadata', async () => {

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -54,10 +54,7 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
       <body className="bg-background font-sans antialiased">
         <main role="alert" className="flex min-h-dvh items-center justify-center px-4 py-16">
           <div className="mx-auto max-w-md text-center">
-            <h1
-              className="text-foreground text-4xl font-bold tracking-tight md:text-5xl"
-              style={{ fontFamily: 'var(--font-display)' }}
-            >
+            <h1 className="text-foreground font-display text-4xl font-bold tracking-tight md:text-5xl">
               {copy.title}
             </h1>
             <p className="text-muted-foreground mt-4 text-base leading-relaxed">

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -69,10 +69,7 @@ export default async function NotFound() {
             <p className="text-brand-700 font-mono text-sm font-medium tracking-widest uppercase">
               {copy.label}
             </p>
-            <h1
-              className="text-foreground mt-3 text-4xl font-bold tracking-tight md:text-5xl"
-              style={{ fontFamily: 'var(--font-display)' }}
-            >
+            <h1 className="text-foreground font-display mt-3 text-4xl font-bold tracking-tight md:text-5xl">
               {copy.title}
             </h1>
             <p className="text-muted-foreground mt-4 text-base leading-relaxed">


### PR DESCRIPTION
## Summary

P0 fix for the CSP regression visible in prod on 2026-05-19 (DevTools mobile console) — flagged as a **P1 out-of-scope finding** by the [`ui-auditor`](.claude/agents/ui-auditor.md) agent during the [PR #174](https://github.com/thierryvm/ankora/pull/174) perf review.

> `Applying inline style violates style-src 'self' nonce-XXX`

Closes the open item from audit [THI-243 §QA findings](https://github.com/thierryvm/ankora/blob/main/docs/audits/2026-05-19-thi-225-perf-investigation-1sec-nav-lag.md).

## Root cause

Three error surfaces carried `style={{ fontFamily: 'var(--font-display)' }}` on their `<h1>`:

| File | Line |
| --- | --- |
| `src/app/not-found.tsx` | 74 |
| `src/app/global-error.tsx` | 59 |
| `src/app/[locale]/error.tsx` | 45 |

The strict CSP `style-src 'self' 'nonce-XXX'` **does not cover element-level `style="..."` attributes** — only `<style>` tags and external stylesheets. Nonces apply to `<style>` and `<script>` tags, never to inline style attributes. Result: every 404 hit, every error boundary trigger, and every locale error logged a CSP violation in the browser console.

## Fix

Replace each inline style with the **Tailwind 4 auto-generated `font-display` utility class** (driven by `--font-display` token in `globals.css @theme`). Tailwind emits `.font-display { font-family: var(--font-display) }` statically in the prebuilt CSS bundle served via `_next/static/`, covered by `style-src 'self'`.

The `font-display` utility is already used in production by Hero, FAQ, Feature, FooterCTA, Pricing, Principles, WhatIfDemo, WhatIfDemoClient — well-established pattern. Visual rendering is byte-for-byte identical (same token resolution).

## Scope strict (per @cowork)

This PR fixes ONLY the 3 error pages flagged by the audit. Two backlog Linear tickets to file:

- **THI-256 (LOW)** — design-playground inline styles (~20). Sandbox is already guarded by `NODE_ENV + ANKORA_PLAYGROUND_ENABLED` env check + `notFound()` in prod (`src/app/[locale]/design-playground/page.tsx`), so no CSP violation surfaces in prod public. Hygiene cleanup only.
- **THI-257 (MEDIUM)** — atoms with dynamic inline styles (Avatar fontSize, ColorPicker gridTemplateColumns/backgroundColor, ProgressBar width %). Architectural decision required (CSS custom property pattern, refactor to pre-computed classes, or scope-bounded `unsafe-hashes`).

False positives confirmed:

- `src/app/[locale]/opengraph-image.tsx` — Next.js ImageResponse API renders React → PNG server-side. CSP does not apply to bitmap output.
- `LangSwitcher.test.tsx:88` — test file, not executed in prod.

## Test plan

### Quality gates (5/5 PASS)

- [x] `npm run lint` — 0 errors, 6 pre-existing warnings (untouched files)
- [x] `npm run lint:use-server` — 0 errors
- [x] `npm run typecheck` — 0 errors
- [x] `npm run test` — **1179/1179 pass** (+1 new test on `global-error` for symmetric anti-regression coverage, raised by `security-auditor`)
- [x] `npm run build` — success

### QA agents (2/2 APPROVED, 0 blocker after fix)

- [x] **security-auditor** — APPROVED (initial APPROVED_WITH_NOTES, finding addressed in-PR). CSP `style-src` strict reste intact, **0 `unsafe-inline`, 0 `unsafe-hashes` added**. Tailwind utility generated statically at build, no runtime `<style>` injection. Defense-in-depth `hasAttribute('style') === false` added on all 3 test files (symmetric coverage).
- [x] **ui-auditor** — APPROVED. Confirms the P1 it had flagged on PR #174 is now definitively resolved. Visual rendering identical, no a11y/contrast/responsive regression.

### Anti-regression guards in tests

Each of the 3 tests now asserts:

```js
expect(heading?.className).toContain('font-display');     // positive coverage
expect(heading?.hasAttribute('style')).toBe(false);       // anti-regression guard
```

If any future edit re-introduces an inline `style={{ ... }}` on these `<h1>` elements, CI catches it before the CSP violation can ship to prod again.

### Smoke test plan (post-merge @thierry)

1. Open prod URL with a deliberately invalid path → 404 (`/foo`) — verify Fraunces serif rendering on H1
2. DevTools Console : **0** `Applying inline style violates style-src` warning (the original regression)
3. Repeat with a `/fr-BE/foo` or any path that triggers `[locale]/error.tsx`
4. Pour `global-error.tsx` : trigger via test runtime error (hard to reproduce naturally, but log signature absent in Sentry/Vercel logs is sufficient evidence)

## Links

- **Linear** : [THI-249](https://linear.app/thierryvm/issue/THI-249) (this fix)
- **Audit source** : [THI-243](https://linear.app/thierryvm/issue/THI-243) — closes the out-of-scope ui-auditor finding from there
- **PR #174** (Phase A perf fix) — completes its hors-scope P1 ui-auditor finding
- **PR #171** (P0 V2) — established the `@layer utilities` migration pattern (`.bg-brand-radial`, `.accent-brand-400`) used as precedent

## Refs

- Worktree: `F:\PROJECTS\Apps\ankora-worktrees\fix-thi-249-csp-inline-error-pages` (cleaned post-merge)
- 6 files changed, 38 insertions, 17 deletions
- Commit: `1b7a8c6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)