### PR TITLE
feat(layout): Apple-HIG Bottom Tab Bar on /app mobile (THI-277, PR-BETA-6)

### DIFF
--- a/docs/prs/PR-BETA-6-bottom-tab-bar-report.md
+++ b/docs/prs/PR-BETA-6-bottom-tab-bar-report.md
@@ -1,0 +1,185 @@
+# PR-BETA-6 — Bottom Tab Bar mobile Apple HIG
+
+**Linear** : THI-277 — PR-BETA-6 Bottom Tab Bar mobile Apple HIG
+**Branch** : `feat/pr-beta-6-bottom-tab-bar`
+**Date** : 2026-05-25
+**Pilote** : @cc-ankora (Claude Opus 4.7)
+**Demandeur** : @thierry via @cowork brief — feedback iPhone réel 24/05 : drawer right-to-left perturbant.
+
+---
+
+## TL;DR
+
+Remplacement du drawer right-to-left mobile par un **Bottom Tab Bar Apple HIG** (5 tabs : Cockpit, Factures, Dépenses, Simuler, Plus) sur la surface `/app/*`. Sheet « Plus » slide-up qui agrège Comptes, Paramètres, Admin, FAQ, Glossaire, Légal, Thème, Langue, Déconnexion. Le drawer marketing (landing / FAQ / glossary / legal) reste inchangé jusqu'à la passe BETA-5 sur la nav marketing.
+
+---
+
+## Scope livré
+
+### Composants créés
+
+- `src/components/layout/BottomTabBar.tsx` — Client Component. 5 tabs + détection active par `usePathname()` (exact match sur `/app`, `startsWith` ailleurs), `aria-current="page"`, haptic best-effort, `pb-[env(safe-area-inset-bottom)]`, `md:hidden`.
+- `src/components/layout/MoreSheet.tsx` — Client Component. Sheet modal slide-up portalé dans `document.body`, scroll lock iOS-safe (pattern `position: fixed` + scrollY restore, parité avec HeaderNav), focus trap Tab/Shift+Tab, dismiss Escape + backdrop tap.
+
+### Fichiers modifiés
+
+- `src/app/[locale]/app/layout.tsx` — Montage `<BottomTabBar isAdmin={…} />` après `<Footer />`. `main` reçoit `pb-24 md:py-12` pour libérer ~96px sous le contenu (clear bar 48px + safe-area iPhone + air).
+- `src/components/layout/HeaderNav.tsx` — Court-circuit `variant === 'app'` : ni hamburger ni drawer portalisé. Le ThemeToggle + LocaleSwitcher desktop (≥ lg) restent intacts.
+- `src/components/layout/__tests__/HeaderNav.test.tsx` — Tests app-variant refactorés pour vérifier l'absence du trigger/drawer (anti-regression).
+
+### Composants supprimés / dépréciés
+
+- Aucun. Le drawer right-to-left reste utilisé par le variant `'marketing'` (landing/FAQ/glossary/legal). Les blocks `{variant === 'app' && …}` dans le drawer sont désormais inatteignables (`isMarketing` court-circuite avant) — code mort à nettoyer dans une PR de cleanup ciblée (hors scope BETA-6, anti scope-creep).
+
+### i18n — 5 locales (parity 24/24)
+
+Nouveau namespace racine `layout` ajouté à `messages/{fr-BE,en,nl-BE,de-DE,es-ES}.json` :
+
+- `layout.bottomTab.{label,cockpit,bills,expenses,simulate,more}`
+- `layout.moreSheet.title`, `layout.moreSheet.close`
+- `layout.moreSheet.sections.{cockpit,resources,preferences,account}`
+- `layout.moreSheet.links.{accounts,settings,admin,adminAriaLabel,faq,glossary,legalCgu,legalPrivacy,legalCookies,logout,darkMode,lightMode}`
+
+Parity check programmatique :
+
+```text
+✓ fr-BE — 24 keys
+✓ nl-BE — 24 keys
+✓ en    — 24 keys
+✓ es-ES — 24 keys
+✓ de-DE — 24 keys
+```
+
+### Tokens CSS
+
+Aucun nouveau token introduit. Réutilisation stricte des tokens existants (cf. `docs/design/token-usage.md`) :
+
+- `bg-background/85` + `backdrop-blur-xl` = Liquid Glass effect (Apple HIG light)
+- `border-border/40` = hairline séparateur
+- `text-foreground` + `font-medium` = tab active
+- `text-muted-foreground` = tab inactive
+- `bg-amber-700` (marker admin, parity Header.tsx / HeaderNav.tsx — WCAG SC 1.4.11 ≥ 3:1 contrast)
+
+---
+
+## Tests
+
+### Vitest — `src/components/layout/__tests__/BottomTabBar.test.tsx` (19 tests)
+
+Couvre :
+
+- Rendu des 5 tabs + labels FR localisés
+- Routing href canonique (`/app`, `/app/charges`, `/app/expenses`, `/app/simulator`)
+- Détection active (`/app` exact, `/app/charges` startsWith, `/app/expenses/123` sub-route)
+- Sheet open/close : tap, backdrop, Escape
+- iOS scroll lock : `position: fixed`, `top: -scrollY`, `width: 100%`, `overflow: hidden`
+- Sheet content : Accounts/Settings/Admin (conditional), FAQ/Glossary/Legal, ThemeToggle, LocaleSwitcher, Logout (form action)
+- Contrat a11y : `aria-controls`, `aria-haspopup="dialog"`, dialog landmark, `aria-current="page"`
+
+### Vitest — `src/components/layout/__tests__/HeaderNav.test.tsx` (12 tests refactorés)
+
+App variant désormais vérifié comme **absent** (zero trigger, zero drawer, zero Admin link side-by-side avec BottomTabBar).
+
+### Playwright — `e2e/mobile-ios/bottom-tab-bar.spec.ts` (6 tests, iPhone 14/15 Pro Max/SE)
+
+- 5 tabs visibles + hamburger absent sur `/app`
+- Active state switch via navigation
+- More sheet open/close (tap, backdrop, Escape)
+- safe-area-inset-bottom : bar flush à `viewport.height`
+- main padding-bottom ≥ 48px (clear bar)
+
+Auto-skip si pas de Supabase service role key (env CI dummy). À valider sur preview Vercel par @thierry post-merge.
+
+### Résultats locaux (2026-05-25)
+
+```text
+npm run lint              → 0 erreurs (6 warnings pré-existants, hors scope)
+npm run lint:use-server   → 0 erreurs
+npm run typecheck         → 0 erreurs
+npm run test (1228 tests) → 100% pass — 100 files, 25.5s
+```
+
+E2E Playwright **non exécutés localement** : nécessitent un serveur Supabase + service role key. Validation CI sur preview Vercel + smoke iPhone réel par @thierry.
+
+---
+
+## Métriques
+
+### Performance
+
+- BottomTabBar = Client Component léger (5 icônes lucide tree-shaken, `useTransition`, `useState`, `useCallback`). Pas de dépendance lourde ajoutée.
+- MoreSheet = portal + scroll lock pattern déjà utilisé dans HeaderNav (zero coût d'apprentissage runtime).
+- Lighthouse Perf mobile ≥ 95 attendu (à valider sur preview Vercel avec `lighthouse-auditor`).
+
+### Accessibilité (WCAG 2.2 AA)
+
+- Touch targets : tab `flex-1` × `h-12` ≥ 44×44px (largeur > 60px sur viewport 390px, hauteur 48px + safe-area).
+- `aria-current="page"` sur tab active.
+- `aria-haspopup="dialog"` + `aria-controls="more-sheet"` sur le bouton More.
+- Sheet `role="dialog"` + `aria-modal="true"` + `aria-label="Plus"` (localisé).
+- Focus trap Tab/Shift+Tab + Escape + restauration focus déclencheur.
+- `focus-visible:ring-2 ring-brand-600 ring-inset` sur chaque tab.
+- Contrast `text-muted-foreground` sur `bg-background/85` — passe AA (tokens design system existants).
+
+### Mobile iOS WebKit (canonical target)
+
+- `pb-[env(safe-area-inset-bottom)]` : home indicator iPhone clair.
+- `position: fixed` scroll lock : rubber-band Safari neutralisé (pattern THI-250 réutilisé).
+- `backdrop-blur-xl` : Liquid Glass effect Safari WebKit.
+- `bg-background/85` opacité semi-transparente : effet glass-morphism iOS.
+
+---
+
+## Smoke test à faire @thierry POST-merge sur preview Vercel (iPhone réel)
+
+Checklist canonique pour valider le PR avant promotion prod :
+
+1. ☐ Ouvrir `/app` sur iPhone Safari → BottomTabBar visible au fond, 5 tabs (Cockpit / Factures / Dépenses / Simuler / Plus)
+2. ☐ Tab "Cockpit" doit être active (highlight foreground + font-medium)
+3. ☐ Tap "Factures" → URL `/app/charges`, tab "Factures" devient active
+4. ☐ Tap "Plus" → sheet slide-up depuis le bas, dialog "Plus" visible
+5. ☐ Sheet contient : Comptes, Paramètres, FAQ, Glossaire, CGU, Confidentialité, Cookies, ThemeToggle, LocaleSwitcher, Déconnexion
+6. ☐ Tap backdrop → sheet ferme proprement
+7. ☐ Tap bouton X dans le sheet → sheet ferme
+8. ☐ Bar respecte la safe-area iPhone (home indicator visible sous la bar, pas en-dessous)
+9. ☐ Aucun hamburger dans le header sur `/app/*` (drawer right-to-left supprimé)
+10. ☐ Sur landing `/` (marketing variant), le hamburger right-to-left RESTE — vérifier que la nav marketing mobile est inchangée
+
+---
+
+## DoD 5/5
+
+| #   | Critère                                                 | Status | Preuve                                               |
+| --- | ------------------------------------------------------- | ------ | ---------------------------------------------------- |
+| 1   | CI verts (Lint, Typecheck, Tests, E2E, Security, Build) | ⏳     | À vérifier sur PR ouverte                            |
+| 2   | Sourcery silent sur dernier commit                      | ⏳     | À vérifier post-push                                 |
+| 3   | Reviews approved + résolues                             | ⏳     | @thierry valide                                      |
+| 4   | 0 conflit main                                          | ✅     | Branche basée sur `fafa94e` (main à jour 2026-05-25) |
+| 5   | Rapport livré                                           | ✅     | Ce fichier                                           |
+
+---
+
+## Linkage Linear
+
+- **Ticket** : THI-277 PR-BETA-6 Bottom Tab Bar mobile Apple HIG
+- **Status open** : In Progress
+- **Status merge** : Done
+
+---
+
+## Notes hors-scope (à traiter séparément)
+
+- **Sourcery warning sur `e2e/mobile-ios/dashboard.spec.ts:89`** signalé par l'IDE pendant cette PR (`suggestion:use-object-destructuring`). Fichier non modifié par BETA-6 — ticket à ouvrir si pas déjà tracké (probablement debt pré-PR-QA-1b).
+- **Code mort dans `HeaderNav.tsx`** : le block `{variant === 'app' && …}` dans `drawerOverlayAndPanel` est désormais inatteignable. À nettoyer dans une PR cleanup (`refactor(layout): remove dead app-variant drawer block in HeaderNav`), 5 minutes.
+- **Drag-to-dismiss MoreSheet** : pas implémenté pour BETA-6 (backdrop tap + Escape couvrent le dismiss). Follow-up Linear si feedback @thierry post-merge.
+- **LocaleSwitcher consolidation header** : prévue PR-BETA-5 (cf. `CLAUDE.md` Ankora « sera consolidé en BETA-5 »). Pour BETA-6, le LocaleSwitcher mobile vit dans le sheet "Plus".
+
+---
+
+## Refs
+
+- Doctrine mobile-first : `CLAUDE.md` Ankora §"Cap v1.0 publique"
+- Apple HIG Bottom Tab Bar : 5 tabs max + sheet modal slide-up
+- Smoke iPhone réel @thierry 24/05 : drawer right-to-left perturbant
+- Sprint Beta tracker : `docs/reports/2026-05-24-reset-strategique-prod-vs-vision-cowork.md` §4.3
+- Pattern scroll lock iOS : `src/components/layout/HeaderNav.tsx` JSDoc (THI-250)

--- a/docs/prs/PR-BETA-6-bottom-tab-bar-report.md
+++ b/docs/prs/PR-BETA-6-bottom-tab-bar-report.md
@@ -2,13 +2,104 @@
 
 **Linear** : THI-277 — PR-BETA-6 Bottom Tab Bar mobile Apple HIG
 **Branch** : `feat/pr-beta-6-bottom-tab-bar`
-**Date** : 2026-05-25
+**Date** : 2026-05-25 (v1 + Hotfix Option A v3 same-day)
 **Pilote** : @cc-ankora (Claude Opus 4.7)
 **Demandeur** : @thierry via @cowork brief — feedback iPhone réel 24/05 : drawer right-to-left perturbant.
 
 ---
 
-## TL;DR
+## Hotfix Option A v3 — Bottom Tab Bar persistente authenticated (25/05/2026)
+
+### Contexte
+
+Smoke iPhone réel @thierry sur preview Vercel de PR #182 v1 a révélé deux bugs UX :
+
+1. **🔴 Bloquant — Admin sans retour** : user tap Admin dans sheet « Plus » → arrive sur `/admin` → BottomTabBar disparaît (car mountée uniquement sur `/app/*`) → user piégé sans retour vers cockpit
+2. **🟡 UX disjointe — Pages resources** : tap FAQ/Glossaire/CGU/Privacy/Cookies → arrive sur layout marketing `(public)` avec burger menu ancien format → expérience visuellement incohérente entre auth et marketing chrome
+
+### Solution
+
+Pattern **Apple HIG iOS 18 « persistent tab bar across in-app destinations »**. BottomTabBar mountée au `src/app/[locale]/layout.tsx` racine, conditionnée par `isAuthenticated && !isExcludedRoute(unprefixedPathname)`.
+
+- Auth check : `getOptionalUser()` server-side (fail-soft, retourne `null` sans throw)
+- Pathname : lecture `headers().get('x-pathname')` (déjà setté par `src/proxy.ts`)
+- Locale prefix stripping : helper `stripLocalePrefix(pathname, routing.locales)` (next-intl `localePrefix: 'as-needed'`)
+- Exclusions : `BOTTOM_TAB_BAR_EXCLUDED_ROUTES = ['/', '/login', '/signup', '/forgot-password', '/reset-password', '/callback', '/offline', '/onboarding']`
+
+### Bugs résolus
+
+- ✅ `/admin/*` maintenant avec BottomTabBar persistante (retour Cockpit possible via tap tab)
+- ✅ `/faq`, `/glossaire`, `/legal/{cgu,privacy,cookies}` idem (cohérence UX authenticated)
+- ✅ Tab `Cockpit` ramène user vers `/app` depuis n'importe quelle surface
+
+### Addendum 2026-05-25 (post-audit cross-layouts) — Footer overlap + Cookie Pref GDPR
+
+Deux items ajoutés au scope par @cowork après audit nav cross-layouts :
+
+1. **Footer padding-bottom** (`src/components/layout/Footer.tsx`) : `pb-[calc(env(safe-area-inset-bottom)+3.5rem)] md:pb-10` sur le div interne. Sans ça, la BottomTabBar (`h-12` + safe-area) cache les liens footer sur mobile authenticated → liens GDPR inaccessibles. Desktop (≥md) garde `pb-10` car bar `md:hidden`.
+
+2. **CookiePreferencesLink dans MoreSheet** (`src/components/layout/MoreSheet.tsx` section preferences) : mirror du composant utilisé dans Footer, après LocaleSwitcher. Couvre **GDPR art. 7(3)** : « le retrait du consentement doit être aussi aisé que son obtention ». Si la barre cache temporairement le footer pendant scroll, le user a toujours accès aux préférences via le sheet « Plus ».
+
+### Fichiers modifiés (Hotfix v3 + addendum)
+
+- `src/components/layout/BottomTabBar.tsx` — exports `BOTTOM_TAB_BAR_EXCLUDED_ROUTES`, `isExcludedRoute`, `stripLocalePrefix`
+- `src/app/[locale]/layout.tsx` — mount conditionnel `<BottomTabBar isAdmin={…} />` après `<Toaster />` (4 nouveaux imports : `headers`, `getOptionalUser`, `isAdmin`, `BottomTabBar` + 2 helpers)
+- `src/app/[locale]/app/layout.tsx` — demount BottomTabBar + `isAdmin` (déplacés au root, évite double mount)
+- `src/components/layout/Footer.tsx` — padding-bottom safe-area + h-bar sur mobile
+- `src/components/layout/MoreSheet.tsx` — `<CookiePreferencesLink />` ajouté section preferences (data-testid `more-sheet-cookie-preferences`)
+
+### Fichiers explicitement NON touchés (anti scope-creep)
+
+- `src/app/[locale]/admin/layout.tsx` — le mount root suffit
+- `src/app/[locale]/(public)/layout.tsx` — burger menu marketing reste, coexistence acceptée jusqu'à PR-BETA-5 (cf. notes hors-scope)
+
+### Tests Vitest étendus (BottomTabBar.test.tsx : 19 → 32 specs, +13)
+
+- `BOTTOM_TAB_BAR_EXCLUDED_ROUTES + isExcludedRoute` : 3 specs (allow-list locked, in-app destinations, readonly export)
+- `stripLocalePrefix` : 4 specs (locale prefix strip, bare locale → root, no-prefix passthrough, false-positive guard `/enrollment`)
+- `<MoreSheet />` Cookie Preferences : 1 spec (GDPR art. 7(3) reachability)
+
+### Tests Playwright étendus (bottom-tab-bar.spec.ts : 6 → 12 specs, +6)
+
+- `Plus → FAQ` : bar visible sur `/faq` post-navigation
+- `Plus → Privacy` + retour Cockpit : flux complet « no trap »
+- `Footer NOT hidden by bar on /faq` : assert last footer link bottom ≤ bar top
+- `More sheet Cookie Preferences` : `more-sheet-cookie-preferences` visible
+- `Anonymous /faq` : bar absente (gating auth)
+- `Anonymous /` : bar absente (landing reste marketing pur)
+
+### Bugs hors-scope (suite PR-BETA-5)
+
+- Burger menu marketing visible sur pages `(public)` quand user authenticated → coexistence acceptable temporairement, harmonisation prévue PR-BETA-5 Landing nav consolidée
+- Labels footer EN « Terms » vs « CGU » : scope BETA-5 (i18n harmonization)
+- Glossaire dans Footer : scope BETA-5
+- Padding-bottom main sur `/admin/*` (AdminTopbar layout n'a pas pb-24) : non bloquant car admin desktop principalement + footer fournit l'air maintenant
+
+### Smoke test à faire @thierry AVANT merge sur preview Vercel iPhone réel
+
+- [ ] `/app` → bar visible 5 tabs
+- [ ] Tap Plus → tap Admin → assert bar toujours visible sur `/admin` + retour `/app` via tab Cockpit OK
+- [ ] Tap Plus → tap FAQ → assert bar visible sur `/faq` + scroll bottom + assert footer CookiePreferencesLink lisible (pas caché)
+- [ ] Tap Plus → tap CGU → assert bar visible sur `/legal/cgu` + retour `/app` via tab Cockpit OK
+- [ ] Tap Plus → assert section « Préférences » contient Cookie Preferences entry
+- [ ] Anonymous (déconnecté) → `/faq` → assert bar INVISIBLE
+- [ ] Anonymous → `/` → assert bar INVISIBLE
+- [ ] Sur `/app`, `/login`, `/signup`, `/onboarding` : bar visibilité conforme allow-list
+
+### Résultats locaux (2026-05-25)
+
+```text
+npm run lint              → 0 erreurs (6 warnings pré-existants, hors scope)
+npm run lint:use-server   → 0 erreurs
+npm run typecheck         → 0 erreurs
+npm run test (1236 tests) → 100% pass (+8 vs v1 — 100 files, 21.8 s)
+```
+
+E2E Playwright **non exécutés localement** : nécessitent Supabase service role key. Validation CI sur preview Vercel + smoke iPhone réel par @thierry.
+
+---
+
+## TL;DR (v1)
 
 Remplacement du drawer right-to-left mobile par un **Bottom Tab Bar Apple HIG** (5 tabs : Cockpit, Factures, Dépenses, Simuler, Plus) sur la surface `/app/*`. Sheet « Plus » slide-up qui agrège Comptes, Paramètres, Admin, FAQ, Glossaire, Légal, Thème, Langue, Déconnexion. Le drawer marketing (landing / FAQ / glossary / legal) reste inchangé jusqu'à la passe BETA-5 sur la nav marketing.
 

--- a/e2e/mobile-ios/bottom-tab-bar.spec.ts
+++ b/e2e/mobile-ios/bottom-tab-bar.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * bottom-tab-bar.spec.ts — PR-BETA-6 (THI-277, 2026-05-25).
+ *
+ * Apple-HIG Bottom Tab Bar regression coverage. The bar replaces the
+ * right-to-left drawer for the `/app/*` surface on mobile. iPhone WebKit
+ * is the canonical target — Safari WebKit ships the safe-area-inset
+ * semantics, the rubber-band scroll, and the Liquid Glass `backdrop-blur`
+ * that the design relies on.
+ *
+ * Specs use the shared `seededUser` fixture: each spec runs against a real
+ * onboarded user inside Supabase and is auto-skipped when the env can't
+ * provision one (no SUPABASE_SERVICE_ROLE_KEY in CI dummy environments).
+ */
+
+import { expect } from '@playwright/test';
+import { test } from './fixtures/mobile-test';
+
+test.describe('BottomTabBar — iPhone Safari WebKit (PR-BETA-6 / THI-277)', () => {
+  test('renders 5 tabs on /app, hides the legacy hamburger drawer', async ({
+    page,
+    seededUser,
+  }) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(seededUser.email);
+    await page.getByLabel('Mot de passe').fill(seededUser.password);
+    await page.getByRole('button', { name: /^se connecter$/i }).click();
+    await page.waitForURL(/\/app\b/, { timeout: 15_000 });
+    await page.waitForLoadState('networkidle');
+
+    // The bar lives at the bottom of the viewport, visible only ≤ 768px.
+    await expect(page.getByTestId('bottom-tab-bar')).toBeVisible();
+    await expect(page.getByTestId('bottom-tab-cockpit')).toBeVisible();
+    await expect(page.getByTestId('bottom-tab-bills')).toBeVisible();
+    await expect(page.getByTestId('bottom-tab-expenses')).toBeVisible();
+    await expect(page.getByTestId('bottom-tab-simulate')).toBeVisible();
+    await expect(page.getByTestId('bottom-tab-more')).toBeVisible();
+
+    // The legacy hamburger trigger MUST NOT be rendered on /app/* for the
+    // app variant — the BottomTabBar is the canonical mobile-nav surface.
+    await expect(page.getByTestId('header-nav-trigger')).toHaveCount(0);
+  });
+
+  test('cockpit tab is marked aria-current on /app, switches when navigating', async ({
+    page,
+    seededUser,
+  }) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(seededUser.email);
+    await page.getByLabel('Mot de passe').fill(seededUser.password);
+    await page.getByRole('button', { name: /^se connecter$/i }).click();
+    await page.waitForURL(/\/app\b/, { timeout: 15_000 });
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('bottom-tab-cockpit')).toHaveAttribute('aria-current', 'page');
+
+    await page.getByTestId('bottom-tab-bills').click();
+    await page.waitForURL(/\/app\/charges/, { timeout: 10_000 });
+    await expect(page.getByTestId('bottom-tab-bills')).toHaveAttribute('aria-current', 'page');
+    await expect(page.getByTestId('bottom-tab-cockpit')).not.toHaveAttribute('aria-current');
+
+    await page.getByTestId('bottom-tab-expenses').click();
+    await page.waitForURL(/\/app\/expenses/, { timeout: 10_000 });
+    await expect(page.getByTestId('bottom-tab-expenses')).toHaveAttribute('aria-current', 'page');
+  });
+
+  test('More sheet opens via tap and closes via backdrop click', async ({ page, seededUser }) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(seededUser.email);
+    await page.getByLabel('Mot de passe').fill(seededUser.password);
+    await page.getByRole('button', { name: /^se connecter$/i }).click();
+    await page.waitForURL(/\/app\b/, { timeout: 15_000 });
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('bottom-tab-more').click();
+    await expect(page.getByTestId('more-sheet')).toBeVisible();
+    await expect(page.getByRole('dialog', { name: 'Plus' })).toBeVisible();
+
+    // Sheet content sanity: at least the canonical Accounts + Settings links.
+    await expect(page.getByTestId('more-sheet-link-accounts')).toBeVisible();
+    await expect(page.getByTestId('more-sheet-link-settings')).toBeVisible();
+    await expect(page.getByTestId('more-sheet-logout')).toBeVisible();
+
+    // Backdrop tap dismisses (Apple iOS sheet behaviour parity).
+    await page.getByTestId('more-sheet-backdrop').click();
+    await expect(page.getByTestId('more-sheet')).toBeHidden();
+  });
+
+  test('More sheet closes on Escape and restores trigger focus', async ({ page, seededUser }) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(seededUser.email);
+    await page.getByLabel('Mot de passe').fill(seededUser.password);
+    await page.getByRole('button', { name: /^se connecter$/i }).click();
+    await page.waitForURL(/\/app\b/, { timeout: 15_000 });
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('bottom-tab-more').click();
+    await expect(page.getByTestId('more-sheet')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(page.getByTestId('more-sheet')).toBeHidden();
+  });
+
+  test('safe-area-inset-bottom reserved: bar sits flush at the bottom edge', async ({
+    page,
+    seededUser,
+  }) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(seededUser.email);
+    await page.getByLabel('Mot de passe').fill(seededUser.password);
+    await page.getByRole('button', { name: /^se connecter$/i }).click();
+    await page.waitForURL(/\/app\b/, { timeout: 15_000 });
+    await page.waitForLoadState('networkidle');
+
+    const measurement = await page.getByTestId('bottom-tab-bar').evaluate((el) => {
+      const rect = el.getBoundingClientRect();
+      return {
+        bottom: rect.bottom,
+        viewportHeight: window.innerHeight,
+      };
+    });
+
+    // The bar is anchored at the viewport bottom (allow a 2-px sub-pixel
+    // rounding tolerance — emulators can report fractional values).
+    expect(Math.abs(measurement.bottom - measurement.viewportHeight)).toBeLessThanOrEqual(2);
+  });
+
+  test('main content padding clears the bar (no hidden CTA under the tab bar)', async ({
+    page,
+    seededUser,
+  }) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(seededUser.email);
+    await page.getByLabel('Mot de passe').fill(seededUser.password);
+    await page.getByRole('button', { name: /^se connecter$/i }).click();
+    await page.waitForURL(/\/app\b/, { timeout: 15_000 });
+    await page.waitForLoadState('networkidle');
+
+    const overlap = await page.evaluate(() => {
+      const main = document.getElementById('main');
+      const bar = document.querySelector('[data-testid="bottom-tab-bar"]');
+      if (!main || !bar) return null;
+      const mainRect = main.getBoundingClientRect();
+      const barRect = bar.getBoundingClientRect();
+      return {
+        mainPaddingBottom: parseFloat(getComputedStyle(main).paddingBottom),
+        barHeight: barRect.height,
+        // True if the main content's *padded* bottom is at or above the
+        // bar's top edge — content cleared.
+        cleared: mainRect.bottom - mainRect.height + main.scrollHeight <= barRect.top + 200,
+      };
+    });
+
+    expect(overlap, 'BottomTabBar / main relationship must be measurable').not.toBeNull();
+    if (overlap) {
+      // The `pb-24` (~96px) added in app/layout.tsx clears the 48-px bar +
+      // the iPhone home indicator safe area + breathing room.
+      expect(overlap.mainPaddingBottom).toBeGreaterThanOrEqual(48);
+    }
+  });
+});

--- a/e2e/mobile-ios/bottom-tab-bar.spec.ts
+++ b/e2e/mobile-ios/bottom-tab-bar.spec.ts
@@ -158,3 +158,129 @@ test.describe('BottomTabBar — iPhone Safari WebKit (PR-BETA-6 / THI-277)', () 
     }
   });
 });
+
+test.describe('BottomTabBar persistence — Hotfix Option A v3 (THI-277, 2026-05-25)', () => {
+  // Verifies the persistent-bar contract on the surfaces that the iPhone
+  // smoke 2026-05-25 flagged: /admin (admin sans retour) and the
+  // resources pages (/faq, /legal/*, /glossaire). Each spec navigates
+  // through the More sheet entries to the destination and asserts the
+  // bar survives the navigation.
+
+  test('Plus → FAQ keeps the bar visible on /faq', async ({ page, seededUser }) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(seededUser.email);
+    await page.getByLabel('Mot de passe').fill(seededUser.password);
+    await page.getByRole('button', { name: /^se connecter$/i }).click();
+    await page.waitForURL(/\/app\b/, { timeout: 15_000 });
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('bottom-tab-more').click();
+    await page.getByTestId('more-sheet-link-faq').click();
+    await page.waitForURL(/\/faq\b/, { timeout: 10_000 });
+
+    // The bar must STILL be mounted — this is the persistence contract
+    // that the iPhone smoke 2026-05-25 surfaced as broken on PR #182 v1.
+    await expect(page.getByTestId('bottom-tab-bar')).toBeVisible();
+    await expect(page.getByTestId('bottom-tab-cockpit')).toBeVisible();
+  });
+
+  test('Plus → Privacy keeps the bar visible AND tap Cockpit returns to /app', async ({
+    page,
+    seededUser,
+  }) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(seededUser.email);
+    await page.getByLabel('Mot de passe').fill(seededUser.password);
+    await page.getByRole('button', { name: /^se connecter$/i }).click();
+    await page.waitForURL(/\/app\b/, { timeout: 15_000 });
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('bottom-tab-more').click();
+    await page.getByTestId('more-sheet-link-legal-privacy').click();
+    await page.waitForURL(/\/legal\/privacy\b/, { timeout: 10_000 });
+    await expect(page.getByTestId('bottom-tab-bar')).toBeVisible();
+
+    // Return-to-cockpit affordance — the whole point of the persistent
+    // bar pattern. Without this, the user is trapped (the bug @thierry
+    // reported on 2026-05-25).
+    await page.getByTestId('bottom-tab-cockpit').click();
+    await page.waitForURL(/\/app\b/, { timeout: 10_000 });
+    await expect(page.getByTestId('bottom-tab-cockpit')).toHaveAttribute('aria-current', 'page');
+  });
+
+  test('Footer is NOT hidden by the bar on /faq mobile (GDPR art. 7(3) reachability)', async ({
+    page,
+    seededUser,
+  }) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(seededUser.email);
+    await page.getByLabel('Mot de passe').fill(seededUser.password);
+    await page.getByRole('button', { name: /^se connecter$/i }).click();
+    await page.waitForURL(/\/app\b/, { timeout: 15_000 });
+    await page.waitForLoadState('networkidle');
+
+    await page.goto('/faq');
+    await page.waitForLoadState('networkidle');
+
+    // Scroll to the bottom — the footer's CookiePreferencesLink must be
+    // reachable (RGPD art. 7(3)). If the BottomTabBar overlapped, the
+    // link would be hidden behind it.
+    await page.evaluate(() => window.scrollTo({ top: document.body.scrollHeight }));
+    await page.waitForTimeout(300);
+
+    const measurement = await page.evaluate(() => {
+      const footer = document.querySelector('footer');
+      const bar = document.querySelector('[data-testid="bottom-tab-bar"]');
+      if (!footer || !bar) return null;
+      const footerLinks = footer.querySelectorAll('a, button');
+      const barRect = bar.getBoundingClientRect();
+      const lastLink = footerLinks[footerLinks.length - 1];
+      const lastLinkRect = lastLink?.getBoundingClientRect();
+      return {
+        lastLinkBottom: lastLinkRect?.bottom ?? 0,
+        barTop: barRect.top,
+        // The footer's bottom-most interactive element must sit ABOVE the
+        // bar's top edge (allow a 4-px sub-pixel tolerance).
+        cleared: lastLinkRect ? lastLinkRect.bottom <= barRect.top + 4 : false,
+      };
+    });
+
+    expect(measurement).not.toBeNull();
+    if (measurement) {
+      expect(
+        measurement.cleared,
+        `Footer last link bottom=${measurement.lastLinkBottom}px must be ≤ bar top=${measurement.barTop}px`,
+      ).toBe(true);
+    }
+  });
+
+  test('More sheet exposes Cookie Preferences (GDPR mirror of the footer link)', async ({
+    page,
+    seededUser,
+  }) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(seededUser.email);
+    await page.getByLabel('Mot de passe').fill(seededUser.password);
+    await page.getByRole('button', { name: /^se connecter$/i }).click();
+    await page.waitForURL(/\/app\b/, { timeout: 15_000 });
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('bottom-tab-more').click();
+    await expect(page.getByTestId('more-sheet-cookie-preferences')).toBeVisible();
+  });
+
+  test('Anonymous visitor on /faq does NOT see the BottomTabBar', async ({ page }) => {
+    // No login — the visitor is anonymous. The bar must not render even
+    // though /faq is not in the excluded routes list, because the gate is
+    // `isAuthenticated && !isExcludedRoute(...)`.
+    await page.goto('/faq');
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByTestId('bottom-tab-bar')).toHaveCount(0);
+  });
+
+  test('Anonymous visitor on landing does NOT see the BottomTabBar', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByTestId('bottom-tab-bar')).toHaveCount(0);
+  });
+});

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -69,6 +69,40 @@
       "annual": "Jährlich"
     }
   },
+  "layout": {
+    "bottomTab": {
+      "label": "Mobile Hauptnavigation",
+      "cockpit": "Cockpit",
+      "bills": "Rechnungen",
+      "expenses": "Ausgaben",
+      "simulate": "Simulieren",
+      "more": "Mehr"
+    },
+    "moreSheet": {
+      "title": "Mehr",
+      "close": "Schließen",
+      "sections": {
+        "cockpit": "Mein Cockpit",
+        "resources": "Ressourcen",
+        "preferences": "Einstellungen",
+        "account": "Konto"
+      },
+      "links": {
+        "accounts": "Konten",
+        "settings": "Einstellungen",
+        "admin": "Admin",
+        "adminAriaLabel": "Adminbereich (nur Gründer)",
+        "faq": "FAQ",
+        "glossary": "Glossar",
+        "legalCgu": "AGB",
+        "legalPrivacy": "Datenschutz",
+        "legalCookies": "Cookies",
+        "logout": "Abmelden",
+        "darkMode": "Dunkler Modus",
+        "lightMode": "Heller Modus"
+      }
+    }
+  },
   "ui": {
     "scrollToTop": "Nach oben scrollen",
     "localeSwitcher": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -69,6 +69,40 @@
       "annual": "Annual"
     }
   },
+  "layout": {
+    "bottomTab": {
+      "label": "Mobile primary navigation",
+      "cockpit": "Cockpit",
+      "bills": "Bills",
+      "expenses": "Expenses",
+      "simulate": "Simulate",
+      "more": "More"
+    },
+    "moreSheet": {
+      "title": "More",
+      "close": "Close",
+      "sections": {
+        "cockpit": "My cockpit",
+        "resources": "Resources",
+        "preferences": "Preferences",
+        "account": "Account"
+      },
+      "links": {
+        "accounts": "Accounts",
+        "settings": "Settings",
+        "admin": "Admin",
+        "adminAriaLabel": "Admin area (founder only)",
+        "faq": "FAQ",
+        "glossary": "Glossary",
+        "legalCgu": "Terms",
+        "legalPrivacy": "Privacy",
+        "legalCookies": "Cookies",
+        "logout": "Sign out",
+        "darkMode": "Dark mode",
+        "lightMode": "Light mode"
+      }
+    }
+  },
   "ui": {
     "scrollToTop": "Scroll back to top",
     "localeSwitcher": {

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -69,6 +69,40 @@
       "annual": "Anual"
     }
   },
+  "layout": {
+    "bottomTab": {
+      "label": "Navegación principal móvil",
+      "cockpit": "Cockpit",
+      "bills": "Facturas",
+      "expenses": "Gastos",
+      "simulate": "Simular",
+      "more": "Más"
+    },
+    "moreSheet": {
+      "title": "Más",
+      "close": "Cerrar",
+      "sections": {
+        "cockpit": "Mi cockpit",
+        "resources": "Recursos",
+        "preferences": "Preferencias",
+        "account": "Cuenta"
+      },
+      "links": {
+        "accounts": "Cuentas",
+        "settings": "Ajustes",
+        "admin": "Admin",
+        "adminAriaLabel": "Zona admin (solo fundador)",
+        "faq": "FAQ",
+        "glossary": "Glosario",
+        "legalCgu": "Condiciones",
+        "legalPrivacy": "Privacidad",
+        "legalCookies": "Cookies",
+        "logout": "Cerrar sesión",
+        "darkMode": "Modo oscuro",
+        "lightMode": "Modo claro"
+      }
+    }
+  },
   "ui": {
     "scrollToTop": "Volver arriba",
     "localeSwitcher": {

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -69,6 +69,40 @@
       "annual": "Annuel"
     }
   },
+  "layout": {
+    "bottomTab": {
+      "label": "Navigation principale mobile",
+      "cockpit": "Cockpit",
+      "bills": "Factures",
+      "expenses": "Dépenses",
+      "simulate": "Simuler",
+      "more": "Plus"
+    },
+    "moreSheet": {
+      "title": "Plus",
+      "close": "Fermer",
+      "sections": {
+        "cockpit": "Mon cockpit",
+        "resources": "Ressources",
+        "preferences": "Préférences",
+        "account": "Compte"
+      },
+      "links": {
+        "accounts": "Comptes",
+        "settings": "Paramètres",
+        "admin": "Admin",
+        "adminAriaLabel": "Espace admin (réservé fondateur)",
+        "faq": "FAQ",
+        "glossary": "Glossaire",
+        "legalCgu": "CGU",
+        "legalPrivacy": "Confidentialité",
+        "legalCookies": "Cookies",
+        "logout": "Se déconnecter",
+        "darkMode": "Mode sombre",
+        "lightMode": "Mode clair"
+      }
+    }
+  },
   "ui": {
     "scrollToTop": "Remonter en haut de la page",
     "localeSwitcher": {

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -69,6 +69,40 @@
       "annual": "Jaarlijks"
     }
   },
+  "layout": {
+    "bottomTab": {
+      "label": "Mobiele hoofdnavigatie",
+      "cockpit": "Cockpit",
+      "bills": "Facturen",
+      "expenses": "Uitgaven",
+      "simulate": "Simuleren",
+      "more": "Meer"
+    },
+    "moreSheet": {
+      "title": "Meer",
+      "close": "Sluiten",
+      "sections": {
+        "cockpit": "Mijn cockpit",
+        "resources": "Bronnen",
+        "preferences": "Voorkeuren",
+        "account": "Account"
+      },
+      "links": {
+        "accounts": "Rekeningen",
+        "settings": "Instellingen",
+        "admin": "Admin",
+        "adminAriaLabel": "Adminzone (alleen oprichter)",
+        "faq": "FAQ",
+        "glossary": "Woordenlijst",
+        "legalCgu": "Voorwaarden",
+        "legalPrivacy": "Privacy",
+        "legalCookies": "Cookies",
+        "logout": "Afmelden",
+        "darkMode": "Donkere modus",
+        "lightMode": "Lichte modus"
+      }
+    }
+  },
   "ui": {
     "scrollToTop": "Terug naar boven",
     "localeSwitcher": {

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,6 +1,6 @@
 # ankora.be — Full content export for LLMs
 
-Last generated: 2026-05-24
+Last generated: 2026-05-25
 Canonical URL: https://ankora.be
 License: content available for citation with attribution. Code is proprietary.
 

--- a/src/app/[locale]/(public)/layout.tsx
+++ b/src/app/[locale]/(public)/layout.tsx
@@ -1,10 +1,17 @@
 import { ScrollToTop } from '@/components/layout/ScrollToTop';
+import { shouldMountBottomTabBar } from '@/lib/layout/bottom-tab-bar-state';
 
-export default function PublicLayout({ children }: { children: React.ReactNode }) {
+export default async function PublicLayout({ children }: { children: React.ReactNode }) {
+  // PR-BETA-6 hotfix #4 (THI-277, 2026-05-25, @thierry iPhone smoke): the
+  // ScrollToTop FAB was hidden behind the persistent BottomTabBar on iPhone
+  // Safari for authenticated visitors on `/faq`, `/legal/*`, `/glossaire`.
+  // Lift the FAB above the bar when the bar will mount; otherwise keep the
+  // original safe-area-only offset.
+  const liftedForBottomBar = await shouldMountBottomTabBar();
   return (
     <>
       {children}
-      <ScrollToTop />
+      <ScrollToTop liftedForBottomBar={liftedForBottomBar} />
     </>
   );
 }

--- a/src/app/[locale]/app/layout.tsx
+++ b/src/app/[locale]/app/layout.tsx
@@ -1,34 +1,25 @@
 import { Header } from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer';
 import { AppBreadcrumbs } from '@/components/layout/AppBreadcrumbs';
-import { BottomTabBar } from '@/components/layout/BottomTabBar';
 import { requireUser } from '@/lib/auth/require-user';
-import { isAdmin } from '@/lib/auth/is-admin';
 
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   await requireUser();
-  // PR-BETA-6 (THI-277) — admin flag flows into BottomTabBar so the More
-  // sheet exposes the admin entry to privileged sessions only. Same
-  // server-side gate as Header.tsx — never trusted to the client.
-  const userIsAdmin = await isAdmin();
+  // PR-BETA-6 Hotfix Option A v3 (THI-277, 2026-05-25): the BottomTabBar is
+  // now mounted ONCE at the locale root `src/app/[locale]/layout.tsx` so it
+  // stays mounted across in-app navigation (cockpit → admin → faq → legal).
+  // The mount + isAdmin gating both live there; this layout only needs to
+  // keep the cockpit chrome (Header, breadcrumbs, footer) and the
+  // `pb-24 md:py-12` main padding that reserves space below the bar on
+  // mobile (the bar is `md:hidden`, so desktop keeps the original `py-12`).
   return (
     <>
       <Header variant="app" isAuthenticated />
       <AppBreadcrumbs />
-      {/*
-       * PR-BETA-6 (THI-277): the mobile BottomTabBar adds 48px + the iPhone
-       * safe-area-inset-bottom at the foot of the viewport. Without an
-       * equivalent bottom-padding the last row of cockpit content (CTA
-       * buttons, transactions list) sits behind the bar. `pb-24` on mobile
-       * (~96px = 48 bar + 32 air + ~16 safe-area) clears the bar even on
-       * notched devices; `md:pb-12` restores the original desktop padding
-       * (the bar is hidden ≥ 768px).
-       */}
       <main id="main" className="mx-auto w-full max-w-6xl px-4 pt-8 pb-24 md:px-6 md:py-12">
         {children}
       </main>
       <Footer />
-      <BottomTabBar isAdmin={userIsAdmin} />
     </>
   );
 }

--- a/src/app/[locale]/app/layout.tsx
+++ b/src/app/[locale]/app/layout.tsx
@@ -1,18 +1,34 @@
 import { Header } from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer';
 import { AppBreadcrumbs } from '@/components/layout/AppBreadcrumbs';
+import { BottomTabBar } from '@/components/layout/BottomTabBar';
 import { requireUser } from '@/lib/auth/require-user';
+import { isAdmin } from '@/lib/auth/is-admin';
 
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   await requireUser();
+  // PR-BETA-6 (THI-277) — admin flag flows into BottomTabBar so the More
+  // sheet exposes the admin entry to privileged sessions only. Same
+  // server-side gate as Header.tsx — never trusted to the client.
+  const userIsAdmin = await isAdmin();
   return (
     <>
       <Header variant="app" isAuthenticated />
       <AppBreadcrumbs />
-      <main id="main" className="mx-auto w-full max-w-6xl px-4 py-8 md:px-6 md:py-12">
+      {/*
+       * PR-BETA-6 (THI-277): the mobile BottomTabBar adds 48px + the iPhone
+       * safe-area-inset-bottom at the foot of the viewport. Without an
+       * equivalent bottom-padding the last row of cockpit content (CTA
+       * buttons, transactions list) sits behind the bar. `pb-24` on mobile
+       * (~96px = 48 bar + 32 air + ~16 safe-area) clears the bar even on
+       * notched devices; `md:pb-12` restores the original desktop padding
+       * (the bar is hidden ≥ 768px).
+       */}
+      <main id="main" className="mx-auto w-full max-w-6xl px-4 pt-8 pb-24 md:px-6 md:py-12">
         {children}
       </main>
       <Footer />
+      <BottomTabBar isAdmin={userIsAdmin} />
     </>
   );
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -14,7 +14,8 @@ import { Toaster } from '@/components/ui/toast';
 import { JsonLd } from '@/components/seo/JsonLd';
 import { ServiceWorkerRegister } from '@/components/pwa/ServiceWorkerRegister';
 import { ThemeBootScript } from '@/components/theme/ThemeBootScript';
-import { BottomTabBar, isExcludedRoute, stripLocalePrefix } from '@/components/layout/BottomTabBar';
+import { BottomTabBar } from '@/components/layout/BottomTabBar';
+import { isExcludedRoute, stripLocalePrefix } from '@/components/layout/bottom-tab-bar.routes';
 import { getOptionalUser } from '@/lib/auth/require-user';
 import { isAdmin } from '@/lib/auth/is-admin';
 

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata, Viewport } from 'next';
 import { notFound } from 'next/navigation';
-import { cookies, headers } from 'next/headers';
+import { cookies } from 'next/headers';
 
 import { NextIntlClientProvider, hasLocale } from 'next-intl';
 import { getMessages, setRequestLocale, getTranslations } from 'next-intl/server';
@@ -15,8 +15,7 @@ import { JsonLd } from '@/components/seo/JsonLd';
 import { ServiceWorkerRegister } from '@/components/pwa/ServiceWorkerRegister';
 import { ThemeBootScript } from '@/components/theme/ThemeBootScript';
 import { BottomTabBar } from '@/components/layout/BottomTabBar';
-import { isExcludedRoute, stripLocalePrefix } from '@/components/layout/bottom-tab-bar.routes';
-import { getOptionalUser } from '@/lib/auth/require-user';
+import { shouldMountBottomTabBar } from '@/lib/layout/bottom-tab-bar-state';
 import { isAdmin } from '@/lib/auth/is-admin';
 
 import '../globals.css';
@@ -150,28 +149,12 @@ export default async function LocaleLayout({
   const dataTheme = themeCookie === 'dark' ? 'dark' : undefined;
 
   // PR-BETA-6 Hotfix Option A v3 (THI-277, 2026-05-25) — persistent
-  // BottomTabBar mount.
-  //
-  // The bar is rendered ONCE here at the locale root so it stays mounted
-  // across in-app navigation (cockpit → admin → faq → legal …). Two server-
-  // side gates decide whether to render:
-  //
-  //   1. `user` — visitors without a session never see the bar (landing,
-  //      anon FAQ/legal/glossary keep their marketing chrome). Fail-soft via
-  //      `getOptionalUser()` so transient Supabase blips never 500 the page.
-  //   2. `!isExcludedRoute(unprefixedPathname)` — focused full-screen flows
-  //      (login/signup/reset-password/onboarding/offline) and the landing
-  //      itself never show the bar.
-  //
-  // The pathname is read from the `x-pathname` request header that
-  // `src/proxy.ts` sets BEFORE next-intl runs (cf. proxy JSDoc + PR-SEC-
-  // ADMIN P1-A). `stripLocalePrefix` removes the optional `/<locale>/`
-  // prefix so the exclusion list works whatever locale the visitor uses.
-  const requestHeaders = await headers();
-  const rawPathname = requestHeaders.get('x-pathname') ?? '/';
-  const unprefixedPathname = stripLocalePrefix(rawPathname, routing.locales);
-  const user = await getOptionalUser();
-  const showBottomTabBar = !!user && !isExcludedRoute(unprefixedPathname);
+  // BottomTabBar mount. Centralised in `shouldMountBottomTabBar()`
+  // (wrapped in React `cache()`) so this mount decision and the four
+  // satellite consumers (Header burger suppression, Footer nav hiding,
+  // ScrollToTop FAB lift, this mount) all collapse onto a single
+  // server-side computation per request.
+  const showBottomTabBar = await shouldMountBottomTabBar();
   // `isAdmin()` re-runs the Supabase `getUser()` round-trip inside the
   // helper. Cheap (already cached server-side per-request by Supabase)
   // and lets the helper stay self-contained — no need to pipe the user

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata, Viewport } from 'next';
 import { notFound } from 'next/navigation';
-import { cookies } from 'next/headers';
+import { cookies, headers } from 'next/headers';
 
 import { NextIntlClientProvider, hasLocale } from 'next-intl';
 import { getMessages, setRequestLocale, getTranslations } from 'next-intl/server';
@@ -14,6 +14,9 @@ import { Toaster } from '@/components/ui/toast';
 import { JsonLd } from '@/components/seo/JsonLd';
 import { ServiceWorkerRegister } from '@/components/pwa/ServiceWorkerRegister';
 import { ThemeBootScript } from '@/components/theme/ThemeBootScript';
+import { BottomTabBar, isExcludedRoute, stripLocalePrefix } from '@/components/layout/BottomTabBar';
+import { getOptionalUser } from '@/lib/auth/require-user';
+import { isAdmin } from '@/lib/auth/is-admin';
 
 import '../globals.css';
 
@@ -145,6 +148,35 @@ export default async function LocaleLayout({
   const themeCookie = cookieStore.get('theme')?.value;
   const dataTheme = themeCookie === 'dark' ? 'dark' : undefined;
 
+  // PR-BETA-6 Hotfix Option A v3 (THI-277, 2026-05-25) — persistent
+  // BottomTabBar mount.
+  //
+  // The bar is rendered ONCE here at the locale root so it stays mounted
+  // across in-app navigation (cockpit → admin → faq → legal …). Two server-
+  // side gates decide whether to render:
+  //
+  //   1. `user` — visitors without a session never see the bar (landing,
+  //      anon FAQ/legal/glossary keep their marketing chrome). Fail-soft via
+  //      `getOptionalUser()` so transient Supabase blips never 500 the page.
+  //   2. `!isExcludedRoute(unprefixedPathname)` — focused full-screen flows
+  //      (login/signup/reset-password/onboarding/offline) and the landing
+  //      itself never show the bar.
+  //
+  // The pathname is read from the `x-pathname` request header that
+  // `src/proxy.ts` sets BEFORE next-intl runs (cf. proxy JSDoc + PR-SEC-
+  // ADMIN P1-A). `stripLocalePrefix` removes the optional `/<locale>/`
+  // prefix so the exclusion list works whatever locale the visitor uses.
+  const requestHeaders = await headers();
+  const rawPathname = requestHeaders.get('x-pathname') ?? '/';
+  const unprefixedPathname = stripLocalePrefix(rawPathname, routing.locales);
+  const user = await getOptionalUser();
+  const showBottomTabBar = !!user && !isExcludedRoute(unprefixedPathname);
+  // `isAdmin()` re-runs the Supabase `getUser()` round-trip inside the
+  // helper. Cheap (already cached server-side per-request by Supabase)
+  // and lets the helper stay self-contained — no need to pipe the user
+  // object into a new isAdminFor(user) variant just for this mount site.
+  const showAdminEntry = showBottomTabBar && (await isAdmin());
+
   return (
     <html
       lang={locale}
@@ -187,6 +219,7 @@ export default async function LocaleLayout({
           {children}
           <ConsentBanner />
           <Toaster />
+          {showBottomTabBar && <BottomTabBar isAdmin={showAdminEntry} />}
           <ServiceWorkerRegister />
           <JsonLd data={organizationJsonLd} />
           <Analytics />

--- a/src/components/layout/BottomTabBar.tsx
+++ b/src/components/layout/BottomTabBar.tsx
@@ -49,55 +49,12 @@ import { MoreSheet } from './MoreSheet';
  * Wrapped in a guard so tests under jsdom don't blow up.
  */
 
-/**
- * Routes where the persistent BottomTabBar must NOT render even if the
- * visitor is authenticated. Landing keeps its marketing chrome; auth and
- * onboarding pages stay focused full-screen flows; `/offline` is the PWA
- * fallback (no nav makes sense without network); `/callback` is the OAuth
- * roundtrip (also stripped by the next-intl matcher, but belt-and-
- * suspenders). Compare against the locale-stripped pathname.
- */
-export const BOTTOM_TAB_BAR_EXCLUDED_ROUTES = [
-  '/',
-  '/login',
-  '/signup',
-  '/forgot-password',
-  '/reset-password',
-  '/callback',
-  '/offline',
-  '/onboarding',
-] as const;
-
-/**
- * Strip the optional `localePrefix: 'as-needed'` segment from a pathname so
- * the exclusion check works regardless of the visitor's locale (default
- * `fr-BE` renders unprefixed; every other locale prefixes the URL).
- *
- * Exported so the root layout can compute the unprefixed path once and pass
- * it to `isExcludedRoute`. Lives next to the routes constant for cohesion
- * with the rest of the bar's mounting contract.
- */
-export function stripLocalePrefix(pathname: string, locales: readonly string[]): string {
-  for (const locale of locales) {
-    if (pathname === `/${locale}`) return '/';
-    if (pathname.startsWith(`/${locale}/`)) {
-      return pathname.slice(`/${locale}`.length);
-    }
-  }
-  return pathname;
-}
-
-/**
- * Returns `true` when the bar must NOT render for the given unprefixed
- * pathname. Driven by the `BOTTOM_TAB_BAR_EXCLUDED_ROUTES` allow-list and
- * an explicit exact-match — sub-routes (e.g. `/reset-password/xxx`, if
- * ever added) would need their own entry, deliberately to avoid hiding
- * the bar by accident on a deep cockpit URL that happens to share a
- * prefix.
- */
-export function isExcludedRoute(unprefixedPathname: string): boolean {
-  return (BOTTOM_TAB_BAR_EXCLUDED_ROUTES as readonly string[]).includes(unprefixedPathname);
-}
+// PR-BETA-6 hotfix #2 (2026-05-25): the mount gating helpers
+// (`BOTTOM_TAB_BAR_EXCLUDED_ROUTES`, `stripLocalePrefix`, `isExcludedRoute`)
+// live in the server-safe `./bottom-tab-bar.routes` module so the Server
+// Component `[locale]/layout.tsx` can import them without crossing the
+// `'use client'` boundary of this file (which crashes every page render
+// on Next.js 16 + React 19, observed on PR #182 preview Vercel).
 
 type TabId = 'cockpit' | 'bills' | 'expenses' | 'simulate' | 'more';
 

--- a/src/components/layout/BottomTabBar.tsx
+++ b/src/components/layout/BottomTabBar.tsx
@@ -11,20 +11,29 @@ import { MoreSheet } from './MoreSheet';
 /**
  * PR-BETA-6 — Bottom Tab Bar mobile (Apple HIG, THI-277).
  *
- * Replaces the right-to-left drawer (HeaderNav) for the `app` variant on
+ * Replaces the right-to-left drawer (HeaderNav) for authenticated users on
  * mobile. Five tabs is the Apple HIG hard cap — anything else goes into the
  * "More" sheet (slide-up modal) so the bar stays scannable at a glance.
  *
- * Visibility rules:
+ * Visibility rules (Hotfix Option A v3, 2026-05-25 — Apple HIG iOS 18
+ * "persistent tab bar across in-app destinations"):
  * - Hidden ≥ 768px (`md:hidden`) — desktop keeps the top-of-page nav.
- * - Mounted ONLY in `/app/*` (driven by `src/app/[locale]/app/layout.tsx`)
- *   so the marketing surfaces (landing, FAQ, legal, glossary) preserve their
- *   existing mobile drawer until the marketing nav is reworked separately.
+ * - Mounted at the locale root `src/app/[locale]/layout.tsx` and gated by
+ *   `isAuthenticated && !isExcludedRoute(pathname)`. So the bar is present
+ *   on `/app/*`, `/admin/*`, `/faq`, `/glossaire`, `/legal/*` once the user
+ *   is signed in — fixes the "Admin sans retour" trap reported on iPhone
+ *   smoke 2026-05-25 and the disjointed UX on resources pages.
+ * - Excluded surfaces (`/`, `/login`, `/signup`, `/forgot-password`,
+ *   `/reset-password`, `/callback`, `/offline`, `/onboarding`): the bar is
+ *   not rendered. The landing keeps its marketing chrome; auth pages keep
+ *   their focused full-screen flow; onboarding stays distraction-free.
  *
  * Active-tab detection: strict `startsWith` against the localised pathname
  * with a special case for the root `/app` route (otherwise every sub-route
  * would light up the Cockpit tab AND its own). next-intl strips the locale
- * prefix from `usePathname()` so we compare against unprefixed paths.
+ * prefix from `usePathname()` so we compare against unprefixed paths. When
+ * the user is on a non-`/app/*` surface (admin, faq, legal) NO tab is
+ * marked active — the bar then acts as a "return to cockpit" surface.
  *
  * Touch targets: each tab is 44×44px minimum (Apple HIG accessibility) — the
  * outer button is `h-12` (48px) and stretches via `flex-1` so the total tap
@@ -39,6 +48,57 @@ import { MoreSheet } from './MoreSheet';
  * and on iOS Safari (Vibration API is Android-only at time of writing).
  * Wrapped in a guard so tests under jsdom don't blow up.
  */
+
+/**
+ * Routes where the persistent BottomTabBar must NOT render even if the
+ * visitor is authenticated. Landing keeps its marketing chrome; auth and
+ * onboarding pages stay focused full-screen flows; `/offline` is the PWA
+ * fallback (no nav makes sense without network); `/callback` is the OAuth
+ * roundtrip (also stripped by the next-intl matcher, but belt-and-
+ * suspenders). Compare against the locale-stripped pathname.
+ */
+export const BOTTOM_TAB_BAR_EXCLUDED_ROUTES = [
+  '/',
+  '/login',
+  '/signup',
+  '/forgot-password',
+  '/reset-password',
+  '/callback',
+  '/offline',
+  '/onboarding',
+] as const;
+
+/**
+ * Strip the optional `localePrefix: 'as-needed'` segment from a pathname so
+ * the exclusion check works regardless of the visitor's locale (default
+ * `fr-BE` renders unprefixed; every other locale prefixes the URL).
+ *
+ * Exported so the root layout can compute the unprefixed path once and pass
+ * it to `isExcludedRoute`. Lives next to the routes constant for cohesion
+ * with the rest of the bar's mounting contract.
+ */
+export function stripLocalePrefix(pathname: string, locales: readonly string[]): string {
+  for (const locale of locales) {
+    if (pathname === `/${locale}`) return '/';
+    if (pathname.startsWith(`/${locale}/`)) {
+      return pathname.slice(`/${locale}`.length);
+    }
+  }
+  return pathname;
+}
+
+/**
+ * Returns `true` when the bar must NOT render for the given unprefixed
+ * pathname. Driven by the `BOTTOM_TAB_BAR_EXCLUDED_ROUTES` allow-list and
+ * an explicit exact-match — sub-routes (e.g. `/reset-password/xxx`, if
+ * ever added) would need their own entry, deliberately to avoid hiding
+ * the bar by accident on a deep cockpit URL that happens to share a
+ * prefix.
+ */
+export function isExcludedRoute(unprefixedPathname: string): boolean {
+  return (BOTTOM_TAB_BAR_EXCLUDED_ROUTES as readonly string[]).includes(unprefixedPathname);
+}
+
 type TabId = 'cockpit' | 'bills' | 'expenses' | 'simulate' | 'more';
 
 type Tab = {

--- a/src/components/layout/BottomTabBar.tsx
+++ b/src/components/layout/BottomTabBar.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import { useState, useTransition, useCallback } from 'react';
+import { LayoutDashboard, Receipt, Wallet, Sparkles, Menu } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+import { Link } from '@/i18n/navigation';
+import { usePathname } from '@/i18n/navigation';
+import { MoreSheet } from './MoreSheet';
+
+/**
+ * PR-BETA-6 — Bottom Tab Bar mobile (Apple HIG, THI-277).
+ *
+ * Replaces the right-to-left drawer (HeaderNav) for the `app` variant on
+ * mobile. Five tabs is the Apple HIG hard cap — anything else goes into the
+ * "More" sheet (slide-up modal) so the bar stays scannable at a glance.
+ *
+ * Visibility rules:
+ * - Hidden ≥ 768px (`md:hidden`) — desktop keeps the top-of-page nav.
+ * - Mounted ONLY in `/app/*` (driven by `src/app/[locale]/app/layout.tsx`)
+ *   so the marketing surfaces (landing, FAQ, legal, glossary) preserve their
+ *   existing mobile drawer until the marketing nav is reworked separately.
+ *
+ * Active-tab detection: strict `startsWith` against the localised pathname
+ * with a special case for the root `/app` route (otherwise every sub-route
+ * would light up the Cockpit tab AND its own). next-intl strips the locale
+ * prefix from `usePathname()` so we compare against unprefixed paths.
+ *
+ * Touch targets: each tab is 44×44px minimum (Apple HIG accessibility) — the
+ * outer button is `h-12` (48px) and stretches via `flex-1` so the total tap
+ * surface easily exceeds the minimum.
+ *
+ * Safe-area: `pb-[env(safe-area-inset-bottom)]` reserves the iPhone home
+ * indicator area in standalone PWA mode (Add-to-Home-Screen). The site
+ * declares `viewport-fit=cover` upstream in `[locale]/layout.tsx`, so the
+ * inset is non-zero on real hardware.
+ *
+ * Haptic feedback: `navigator.vibrate(10)` is a best-effort no-op on desktop
+ * and on iOS Safari (Vibration API is Android-only at time of writing).
+ * Wrapped in a guard so tests under jsdom don't blow up.
+ */
+type TabId = 'cockpit' | 'bills' | 'expenses' | 'simulate' | 'more';
+
+type Tab = {
+  id: TabId;
+  href: string;
+  labelKey: 'cockpit' | 'bills' | 'expenses' | 'simulate' | 'more';
+  // Mark routes that must use a startsWith comparison vs the exact-match
+  // `/app` root. We only have one exact-match tab today but keeping the
+  // shape explicit prevents a future refactor from quietly breaking the
+  // cockpit highlight.
+  match: 'exact' | 'startsWith';
+  icon: typeof LayoutDashboard;
+};
+
+const TABS: readonly Tab[] = [
+  { id: 'cockpit', href: '/app', labelKey: 'cockpit', match: 'exact', icon: LayoutDashboard },
+  { id: 'bills', href: '/app/charges', labelKey: 'bills', match: 'startsWith', icon: Receipt },
+  {
+    id: 'expenses',
+    href: '/app/expenses',
+    labelKey: 'expenses',
+    match: 'startsWith',
+    icon: Wallet,
+  },
+  {
+    id: 'simulate',
+    href: '/app/simulator',
+    labelKey: 'simulate',
+    match: 'startsWith',
+    icon: Sparkles,
+  },
+] as const;
+
+function isActive(pathname: string, tab: Tab): boolean {
+  if (tab.match === 'exact') return pathname === tab.href;
+  return pathname === tab.href || pathname.startsWith(`${tab.href}/`);
+}
+
+function triggerHapticFeedback(): void {
+  if (typeof navigator === 'undefined') return;
+  if (typeof navigator.vibrate !== 'function') return;
+  try {
+    navigator.vibrate(10);
+  } catch {
+    // Some browsers throw if vibration is disabled by user agent policy.
+  }
+}
+
+export type BottomTabBarProps = {
+  /**
+   * Mirrors the `isAdmin` prop on `HeaderNav` so the More sheet can expose
+   * the admin entry when the signed-in user is privileged. Server-resolved
+   * upstream (`isAdmin()` in `Header.tsx` / app layout) — the client never
+   * trusts itself. Default `false` keeps non-admin sessions clean.
+   */
+  isAdmin?: boolean;
+};
+
+export function BottomTabBar({ isAdmin = false }: BottomTabBarProps) {
+  const t = useTranslations('layout.bottomTab');
+  const pathname = usePathname();
+  const [isMoreOpen, setIsMoreOpen] = useState(false);
+  // Lazy navigation transition — keeps the tab tap feeling instantaneous
+  // while the destination Server Component is fetched.
+  const [, startTransition] = useTransition();
+
+  const handleTabClick = useCallback(() => {
+    triggerHapticFeedback();
+  }, []);
+
+  const handleMoreClick = useCallback(() => {
+    triggerHapticFeedback();
+    setIsMoreOpen(true);
+  }, []);
+
+  const handleMoreClose = useCallback(() => {
+    setIsMoreOpen(false);
+  }, []);
+
+  return (
+    <>
+      {/*
+       * `fixed bottom-0` + `pb-[env(safe-area-inset-bottom)]` reserves the
+       * iPhone home indicator. `bg-background/85 backdrop-blur-xl` is the
+       * Liquid Glass effect — semi-opaque background + 24px blur so the
+       * cockpit content remains barely visible underneath while staying
+       * readable. `border-t border-border/40` is the hairline separator.
+       *
+       * `z-40` matches the sticky header (which is also z-40) — they never
+       * overlap on viewport because one is top-anchored and the other is
+       * bottom-anchored. Below z-50 (toast / modal stack) so the More sheet
+       * itself can climb above us when open.
+       */}
+      <nav
+        aria-label={t('label')}
+        data-testid="bottom-tab-bar"
+        className="bg-background/85 border-border/40 fixed right-0 bottom-0 left-0 z-40 border-t pb-[env(safe-area-inset-bottom)] backdrop-blur-xl md:hidden"
+      >
+        <div className="flex h-12 items-stretch">
+          {TABS.map((tab) => {
+            const Icon = tab.icon;
+            const active = isActive(pathname, tab);
+            return (
+              <Link
+                key={tab.id}
+                href={tab.href}
+                data-testid={`bottom-tab-${tab.id}`}
+                aria-current={active ? 'page' : undefined}
+                onClick={() => {
+                  handleTabClick();
+                  startTransition(() => {});
+                }}
+                className={[
+                  'focus-visible:ring-brand-600 flex flex-1 flex-col items-center justify-center gap-0.5 text-[10px] transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset',
+                  active
+                    ? 'text-foreground font-medium'
+                    : 'text-muted-foreground hover:text-foreground',
+                ].join(' ')}
+              >
+                <Icon className="h-5 w-5" aria-hidden="true" />
+                <span>{t(tab.labelKey)}</span>
+              </Link>
+            );
+          })}
+
+          <button
+            type="button"
+            data-testid="bottom-tab-more"
+            aria-haspopup="dialog"
+            aria-expanded={isMoreOpen}
+            aria-controls="more-sheet"
+            onClick={handleMoreClick}
+            className={[
+              'focus-visible:ring-brand-600 flex flex-1 flex-col items-center justify-center gap-0.5 text-[10px] transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset',
+              isMoreOpen
+                ? 'text-foreground font-medium'
+                : 'text-muted-foreground hover:text-foreground',
+            ].join(' ')}
+          >
+            <Menu className="h-5 w-5" aria-hidden="true" />
+            <span>{t('more')}</span>
+          </button>
+        </div>
+      </nav>
+
+      <MoreSheet isOpen={isMoreOpen} onClose={handleMoreClose} isAdmin={isAdmin} />
+    </>
+  );
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -10,7 +10,19 @@ export async function Footer() {
 
   return (
     <footer className="border-border bg-card border-t">
-      <div className="mx-auto flex max-w-6xl flex-col items-start justify-between gap-6 px-4 py-10 md:flex-row md:items-center md:px-6">
+      {/*
+       * PR-BETA-6 Hotfix Option A v3 (THI-277, 2026-05-25): when the
+       * persistent BottomTabBar is rendered for an authenticated mobile
+       * visitor (cf. `[locale]/layout.tsx`), it occupies `h-12` plus the
+       * iPhone safe-area-inset-bottom at the foot of the viewport. The
+       * footer's bottom links — including the `<CookiePreferencesLink />`
+       * required by GDPR art. 7(3) — would otherwise hide behind the bar
+       * on `/faq`, `/legal/*`, `/glossaire`. Reserve enough room for the
+       * bar (~3.5rem = 56px ≥ h-12) plus the safe-area inset on mobile;
+       * restore the original `pb-10` (40px) on `md:` where the bar is
+       * `md:hidden` and would never overlap.
+       */}
+      <div className="mx-auto flex max-w-6xl flex-col items-start justify-between gap-6 px-4 pt-10 pb-[calc(env(safe-area-inset-bottom)+3.5rem)] md:flex-row md:items-center md:px-6 md:pb-10">
         <div className="flex items-center gap-2">
           <BrandHomeLink ariaLabel={tCommon('homeAria')} logoClassName="h-7 w-auto" />
           <span className="text-muted-foreground text-sm">

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -3,10 +3,25 @@ import { getTranslations } from 'next-intl/server';
 import { Link } from '@/i18n/navigation';
 import { BrandHomeLink } from '@/components/brand/BrandHomeLink';
 import { CookiePreferencesLink } from '@/components/layout/CookiePreferencesLink';
+import { shouldMountBottomTabBar } from '@/lib/layout/bottom-tab-bar-state';
 
 export async function Footer() {
   const t = await getTranslations('footer');
   const tCommon = await getTranslations('common');
+
+  // PR-BETA-6 hotfix #4 (THI-277, 2026-05-25, @thierry iPhone smoke):
+  // when the persistent BottomTabBar is rendered for this request, the
+  // footer's link `<nav>` (CGU / Privacy / Cookies / FAQ / Cookie
+  // Preferences) is fully redundant with the More sheet — the visitor
+  // sees the same five entries twice on mobile. Hide the nav on the
+  // mobile breakpoint when the bar will mount; keep it on desktop
+  // (≥ md, where the bar is `md:hidden`). Anonymous mobile visitors
+  // and authenticated visitors on excluded routes (/login, /signup,
+  // /onboarding) keep the full footer because no bar competes.
+  const bottomTabBarMounted = await shouldMountBottomTabBar();
+  const footerNavClass = bottomTabBarMounted
+    ? 'hidden flex-wrap gap-4 text-sm md:flex'
+    : 'flex flex-wrap gap-4 text-sm';
 
   return (
     <footer className="border-border bg-card border-t">
@@ -29,7 +44,11 @@ export async function Footer() {
             {t('copyrightNotice', { year: new Date().getFullYear() })}
           </span>
         </div>
-        <nav aria-label={tCommon('nav.footerLabel')} className="flex flex-wrap gap-4 text-sm">
+        <nav
+          aria-label={tCommon('nav.footerLabel')}
+          data-testid="footer-nav"
+          className={footerNavClass}
+        >
           <Link href="/legal/cgu" className="text-muted-foreground hover:underline">
             {t('cgu')}
           </Link>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,13 +1,10 @@
-import { headers } from 'next/headers';
-
 import { getTranslations } from 'next-intl/server';
 import { Link } from '@/i18n/navigation';
 import { BrandHomeLink } from '@/components/brand/BrandHomeLink';
 import { Button } from '@/components/ui/button';
 import { isAdmin } from '@/lib/auth/is-admin';
 import { getOptionalUser } from '@/lib/auth/require-user';
-import { routing } from '@/i18n/routing';
-import { isExcludedRoute, stripLocalePrefix } from '@/components/layout/bottom-tab-bar.routes';
+import { shouldMountBottomTabBar } from '@/lib/layout/bottom-tab-bar-state';
 import { HeaderNav } from './HeaderNav';
 
 type HeaderProps = {
@@ -45,16 +42,11 @@ export async function Header({ variant = 'marketing', isAuthenticated }: HeaderP
   // tab bar — a 2026 mobile-first anti-pattern (Apple HIG single
   // navigation surface).
   //
-  // We mirror the exact same server-side condition as the bar mount
-  // (`isAuthenticated && !isExcludedRoute(unprefixedPathname)`) so the
-  // two surfaces are mutually exclusive. Anonymous visitors keep the
-  // marketing burger (no bar to compete with). Authenticated visitors
-  // on excluded routes (`/`, `/login`, `/signup`, etc.) also keep the
-  // burger because no bar will render.
-  const requestHeaders = await headers();
-  const rawPathname = requestHeaders.get('x-pathname') ?? '/';
-  const unprefixedPathname = stripLocalePrefix(rawPathname, routing.locales);
-  const hideMobileTrigger = resolvedAuth && !isExcludedRoute(unprefixedPathname);
+  // `shouldMountBottomTabBar()` is the single source of truth for this
+  // decision (wrapped in React `cache()` so all four consumers — this
+  // Header, the locale root mount, the Footer nav, the ScrollToTop FAB
+  // — share a single per-request computation).
+  const hideMobileTrigger = await shouldMountBottomTabBar();
 
   return (
     // PR-D5 mobile-iOS: extend the sticky header below the iPhone notch in

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,9 +1,13 @@
+import { headers } from 'next/headers';
+
 import { getTranslations } from 'next-intl/server';
 import { Link } from '@/i18n/navigation';
 import { BrandHomeLink } from '@/components/brand/BrandHomeLink';
 import { Button } from '@/components/ui/button';
 import { isAdmin } from '@/lib/auth/is-admin';
 import { getOptionalUser } from '@/lib/auth/require-user';
+import { routing } from '@/i18n/routing';
+import { isExcludedRoute, stripLocalePrefix } from '@/components/layout/bottom-tab-bar.routes';
 import { HeaderNav } from './HeaderNav';
 
 type HeaderProps = {
@@ -31,6 +35,26 @@ export async function Header({ variant = 'marketing', isAuthenticated }: HeaderP
   // mobile cockpit drawer mirrors the desktop admin link (parity, single
   // server round-trip).
   const showAdminLink = variant === 'app' && (await isAdmin());
+
+  // PR-BETA-6 hotfix #3 (THI-277, 2026-05-25) — duplicate-nav fix.
+  //
+  // When the persistent BottomTabBar will be rendered for this request
+  // (cf. `[locale]/layout.tsx` mount gate), the mobile hamburger trigger
+  // becomes a duplicate nav surface on `/faq`, `/glossaire`, `/legal/*`:
+  // the visitor sees BOTH the marketing burger top-right AND the bottom
+  // tab bar — a 2026 mobile-first anti-pattern (Apple HIG single
+  // navigation surface).
+  //
+  // We mirror the exact same server-side condition as the bar mount
+  // (`isAuthenticated && !isExcludedRoute(unprefixedPathname)`) so the
+  // two surfaces are mutually exclusive. Anonymous visitors keep the
+  // marketing burger (no bar to compete with). Authenticated visitors
+  // on excluded routes (`/`, `/login`, `/signup`, etc.) also keep the
+  // burger because no bar will render.
+  const requestHeaders = await headers();
+  const rawPathname = requestHeaders.get('x-pathname') ?? '/';
+  const unprefixedPathname = stripLocalePrefix(rawPathname, routing.locales);
+  const hideMobileTrigger = resolvedAuth && !isExcludedRoute(unprefixedPathname);
 
   return (
     // PR-D5 mobile-iOS: extend the sticky header below the iPhone notch in
@@ -130,7 +154,12 @@ export async function Header({ variant = 'marketing', isAuthenticated }: HeaderP
             </Button>
           )}
 
-          <HeaderNav variant={variant} isAuthenticated={resolvedAuth} isAdmin={showAdminLink} />
+          <HeaderNav
+            variant={variant}
+            isAuthenticated={resolvedAuth}
+            isAdmin={showAdminLink}
+            hideMobileTrigger={hideMobileTrigger}
+          />
         </div>
       </div>
     </header>

--- a/src/components/layout/HeaderNav.tsx
+++ b/src/components/layout/HeaderNav.tsx
@@ -405,30 +405,50 @@ export function HeaderNav({
     </>
   ) : null;
 
+  // PR-BETA-6 (THI-277) — the right-to-left hamburger drawer was replaced
+  // by the Apple-HIG Bottom Tab Bar on the `/app/*` surface (mobile only).
+  // For the `app` variant we therefore skip the hamburger trigger AND the
+  // portalled drawer entirely — the BottomTabBar's "More" sheet is the
+  // canonical secondary-nav surface for signed-in mobile users. The
+  // marketing variant keeps the legacy drawer (landing / FAQ / legal /
+  // glossary) until the marketing nav is reworked separately. Desktop
+  // (≥ lg) keeps the ThemeToggle + LocaleSwitcher pair for every variant
+  // — the bar is `md:hidden`, so it never overlaps the desktop chrome.
+  const isMarketing = variant === 'marketing';
+
   return (
     <>
-      {/* Hamburger menu - visible on mobile only.
-          PR-D5 a11y: native `<button>` with `aria-expanded` + `aria-controls`
-          replaces the old label+hidden-checkbox pattern (BUG-iOS-003). */}
-      <button
-        ref={triggerRef}
-        type="button"
-        onClick={() => setIsOpen((open) => !open)}
-        aria-expanded={isOpen}
-        aria-controls="mobile-nav-drawer"
-        aria-label={t('nav.menu')}
-        className="hover:bg-muted focus-visible:ring-brand-600 flex h-10 w-10 items-center justify-center rounded-md focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none lg:hidden"
-      >
-        {isOpen ? <X className="h-5 w-5" aria-hidden /> : <Menu className="h-5 w-5" aria-hidden />}
-      </button>
+      {isMarketing && (
+        <>
+          {/* Hamburger menu - visible on mobile only.
+              PR-D5 a11y: native `<button>` with `aria-expanded` + `aria-controls`
+              replaces the old label+hidden-checkbox pattern (BUG-iOS-003). */}
+          <button
+            ref={triggerRef}
+            type="button"
+            onClick={() => setIsOpen((open) => !open)}
+            aria-expanded={isOpen}
+            aria-controls="mobile-nav-drawer"
+            aria-label={t('nav.menu')}
+            data-testid="header-nav-trigger"
+            className="hover:bg-muted focus-visible:ring-brand-600 flex h-10 w-10 items-center justify-center rounded-md focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none lg:hidden"
+          >
+            {isOpen ? (
+              <X className="h-5 w-5" aria-hidden />
+            ) : (
+              <Menu className="h-5 w-5" aria-hidden />
+            )}
+          </button>
 
-      {/* Bug #4 (PR P0-V2): overlay + drawer rendered via React Portal into
-          <body> so they escape the parent <header sticky z-40 backdrop-blur>
-          stacking context. `isClient` guards SSR (document only exists
-          client-side). When the portal hasn't activated yet, the trigger
-          button above still works — clicking it sets isOpen = true; the
-          portal then appears on the next render after the store flips. */}
-      {isClient && isOpen && createPortal(drawerOverlayAndPanel, document.body)}
+          {/* Bug #4 (PR P0-V2): overlay + drawer rendered via React Portal into
+              <body> so they escape the parent <header sticky z-40 backdrop-blur>
+              stacking context. `isClient` guards SSR (document only exists
+              client-side). When the portal hasn't activated yet, the trigger
+              button above still works — clicking it sets isOpen = true; the
+              portal then appears on the next render after the store flips. */}
+          {isClient && isOpen && createPortal(drawerOverlayAndPanel, document.body)}
+        </>
+      )}
 
       {/* Desktop theme toggle + locale switcher - visible on desktop only */}
       <div className="hidden items-center gap-2 lg:flex">

--- a/src/components/layout/HeaderNav.tsx
+++ b/src/components/layout/HeaderNav.tsx
@@ -37,12 +37,22 @@ type HeaderNavProps = {
   // `Header.tsx`) so the client never trusts itself. Default `false`
   // keeps marketing call-sites unchanged.
   isAdmin?: boolean;
+  // PR-BETA-6 hotfix #3 (THI-277, 2026-05-25) — duplicate-nav fix on
+  // mobile. When `Header.tsx` knows the persistent BottomTabBar will
+  // render for this request (authenticated visitor on a non-excluded
+  // route), it passes `hideMobileTrigger={true}` so this component
+  // skips the hamburger button + drawer portal on every variant. The
+  // two surfaces stay mutually exclusive and the visitor sees a single
+  // mobile-nav affordance (the bottom tab bar), as required by Apple
+  // HIG / Material 3 mobile-first 2026.
+  hideMobileTrigger?: boolean;
 };
 
 export function HeaderNav({
   variant = 'marketing',
   isAuthenticated = false,
   isAdmin = false,
+  hideMobileTrigger = false,
 }: HeaderNavProps) {
   const t = useTranslations('common');
   // PR-UX-1 — marketing drawer reuses MktNav's link labels so the desktop
@@ -409,16 +419,20 @@ export function HeaderNav({
   // by the Apple-HIG Bottom Tab Bar on the `/app/*` surface (mobile only).
   // For the `app` variant we therefore skip the hamburger trigger AND the
   // portalled drawer entirely — the BottomTabBar's "More" sheet is the
-  // canonical secondary-nav surface for signed-in mobile users. The
-  // marketing variant keeps the legacy drawer (landing / FAQ / legal /
-  // glossary) until the marketing nav is reworked separately. Desktop
-  // (≥ lg) keeps the ThemeToggle + LocaleSwitcher pair for every variant
-  // — the bar is `md:hidden`, so it never overlaps the desktop chrome.
-  const isMarketing = variant === 'marketing';
+  // canonical secondary-nav surface for signed-in mobile users.
+  //
+  // PR-BETA-6 hotfix #3 (2026-05-25): also skip the hamburger when the
+  // parent Header signals that the persistent BottomTabBar will mount
+  // (`hideMobileTrigger={true}` — authenticated visitor on /faq /
+  // /glossaire / /legal/*). Two nav surfaces side-by-side is an Apple
+  // HIG / Material 3 mobile-first 2026 anti-pattern. Desktop (≥ lg)
+  // keeps the ThemeToggle + LocaleSwitcher pair for every variant —
+  // the bar is `md:hidden`, so it never overlaps the desktop chrome.
+  const shouldRenderMobileTrigger = variant === 'marketing' && !hideMobileTrigger;
 
   return (
     <>
-      {isMarketing && (
+      {shouldRenderMobileTrigger && (
         <>
           {/* Hamburger menu - visible on mobile only.
               PR-D5 a11y: native `<button>` with `aria-expanded` + `aria-controls`

--- a/src/components/layout/MoreSheet.tsx
+++ b/src/components/layout/MoreSheet.tsx
@@ -1,0 +1,324 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslations } from 'next-intl';
+import { Moon, Sun, X, LogOut } from 'lucide-react';
+
+import { Link } from '@/i18n/navigation';
+import { useIsClient } from '@/lib/hooks/useIsClient';
+import { logoutAction } from '@/lib/actions/auth';
+import { LocaleSwitcher } from './LocaleSwitcher';
+
+/**
+ * PR-BETA-6 — "More" sheet for the mobile Bottom Tab Bar (THI-277).
+ *
+ * Slide-up modal that surfaces every secondary navigation entry that does
+ * not fit in the 5-tab Apple HIG cap: Accounts, Settings, Admin (when
+ * privileged), FAQ, Glossary, Legal, ThemeToggle, LocaleSwitcher, Logout.
+ *
+ * Rendering & isolation: portalled into <body> like the legacy drawer so it
+ * escapes the parent stacking contexts (sticky header + bottom-tab-bar with
+ * `backdrop-blur`). Without the portal, the sheet's z-index is confined to
+ * the bar's painted region on iOS WebKit (same bug class as #119 fixed in
+ * the marketing drawer — see HeaderNav.tsx JSDoc).
+ *
+ * iOS scroll lock: pin <body> with `position: fixed` + captured scrollY.
+ * Vanilla `overflow: hidden` is ignored by iOS Safari rubber-band scroll
+ * (THI-250 history). Restore both styles AND scroll position on cleanup
+ * with `behavior: 'instant'` to override the global `data-scroll-behavior:
+ * smooth` set on <html>.
+ *
+ * Accessibility: real `role="dialog"` + `aria-modal` + focus trap on Tab /
+ * Shift+Tab. Esc closes and restores focus to the trigger (the More tab
+ * button on the bar). The backdrop tap also closes — equivalent to the
+ * Apple iOS sheet behaviour where dragging down dismisses (drag-to-dismiss
+ * is a follow-up; backdrop tap covers the same intent).
+ */
+
+function subscribeToTheme(callback: () => void) {
+  const observer = new MutationObserver(callback);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['data-theme'],
+  });
+  return () => observer.disconnect();
+}
+
+function getThemeSnapshot() {
+  return document.documentElement.getAttribute('data-theme') === 'dark';
+}
+
+function getServerThemeSnapshot() {
+  return false;
+}
+
+export type MoreSheetProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  isAdmin?: boolean;
+};
+
+export function MoreSheet({ isOpen, onClose, isAdmin = false }: MoreSheetProps) {
+  const t = useTranslations('layout.moreSheet');
+  const tLinks = useTranslations('layout.moreSheet.links');
+  const tSections = useTranslations('layout.moreSheet.sections');
+  const isClient = useIsClient();
+  const isDark = useSyncExternalStore(subscribeToTheme, getThemeSnapshot, getServerThemeSnapshot);
+  const sheetRef = useRef<HTMLDivElement>(null);
+
+  const handleClose = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  const toggleTheme = useCallback(() => {
+    if (typeof document === 'undefined') return;
+    const current = document.documentElement.getAttribute('data-theme');
+    const next = current === 'dark' ? 'light' : 'dark';
+    try {
+      if (next === 'dark') {
+        document.documentElement.setAttribute('data-theme', 'dark');
+      } else {
+        document.documentElement.removeAttribute('data-theme');
+      }
+      localStorage.setItem('theme', next);
+      document.cookie = `theme=${next}; path=/; max-age=31536000; SameSite=Lax`;
+    } catch {
+      // Safari private mode or quota exceeded — fall through.
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const { scrollY } = window;
+    document.body.style.position = 'fixed';
+    document.body.style.top = `-${scrollY}px`;
+    document.body.style.width = '100%';
+    document.body.style.overflow = 'hidden';
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        handleClose();
+        return;
+      }
+      if (e.key === 'Tab' && sheetRef.current) {
+        const focusableElements = sheetRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], select, input:not([type="hidden"]), [tabindex]:not([tabindex="-1"])',
+        );
+        if (focusableElements.length === 0) return;
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+
+        if (e.shiftKey && document.activeElement === firstElement) {
+          lastElement?.focus();
+          e.preventDefault();
+        } else if (!e.shiftKey && document.activeElement === lastElement) {
+          firstElement?.focus();
+          e.preventDefault();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    // Focus the close button when the sheet opens so screen readers and
+    // keyboard users land inside the dialog.
+    const closeBtn = sheetRef.current?.querySelector<HTMLElement>('[data-more-sheet-close]');
+    closeBtn?.focus();
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.position = '';
+      document.body.style.top = '';
+      document.body.style.width = '';
+      document.body.style.overflow = '';
+      window.scrollTo({ top: scrollY, left: 0, behavior: 'instant' });
+    };
+  }, [isOpen, handleClose]);
+
+  if (!isClient || !isOpen) return null;
+
+  const linkClass =
+    'text-foreground hover:bg-muted focus-visible:ring-brand-600 flex items-center justify-between rounded-md px-3 py-3 text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none';
+
+  const node = (
+    <>
+      <div
+        data-testid="more-sheet-backdrop"
+        className="bg-foreground/40 fixed inset-0 z-50 md:hidden"
+        onClick={handleClose}
+        aria-hidden="true"
+      />
+      <div
+        ref={sheetRef}
+        id="more-sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('title')}
+        data-testid="more-sheet"
+        className="bg-card border-border fixed right-0 bottom-0 left-0 z-50 max-h-[85vh] overflow-y-auto rounded-t-2xl border-t pb-[env(safe-area-inset-bottom)] shadow-xl md:hidden"
+      >
+        {/* Drag handle — visual affordance only. Real drag-to-dismiss is a
+            follow-up; for now the backdrop tap and the close button cover
+            the dismiss flows. */}
+        <div className="flex justify-center pt-2 pb-1">
+          <span aria-hidden="true" className="bg-muted-foreground/30 h-1 w-10 rounded-full" />
+        </div>
+
+        <div className="border-border flex items-center justify-between border-b px-4 pb-3">
+          <span className="text-foreground text-sm font-semibold">{t('title')}</span>
+          <button
+            type="button"
+            data-more-sheet-close
+            onClick={handleClose}
+            aria-label={t('close')}
+            className="hover:bg-muted focus-visible:ring-brand-600 flex h-8 w-8 items-center justify-center rounded-md focus-visible:ring-2 focus-visible:outline-none"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div className="space-y-4 p-4">
+          <section aria-labelledby="more-section-cockpit" className="space-y-1">
+            <h3
+              id="more-section-cockpit"
+              className="text-muted-foreground px-3 text-[11px] font-medium tracking-wider uppercase"
+            >
+              {tSections('cockpit')}
+            </h3>
+            <Link
+              href="/app/accounts"
+              onClick={handleClose}
+              data-testid="more-sheet-link-accounts"
+              className={linkClass}
+            >
+              <span>{tLinks('accounts')}</span>
+            </Link>
+            <Link
+              href="/app/settings"
+              onClick={handleClose}
+              data-testid="more-sheet-link-settings"
+              className={linkClass}
+            >
+              <span>{tLinks('settings')}</span>
+            </Link>
+            {isAdmin && (
+              <Link
+                href="/admin"
+                onClick={handleClose}
+                data-testid="more-sheet-link-admin"
+                aria-label={tLinks('adminAriaLabel')}
+                className={linkClass}
+              >
+                <span>{tLinks('admin')}</span>
+                {/* Same amber-700 marker as Header.tsx / HeaderNav.tsx — WCAG
+                    SC 1.4.11 contrast ≥ 3:1 in both themes. */}
+                <span
+                  aria-hidden="true"
+                  className="inline-block h-1.5 w-1.5 rounded-full bg-amber-700"
+                />
+              </Link>
+            )}
+          </section>
+
+          <section aria-labelledby="more-section-resources" className="space-y-1">
+            <h3
+              id="more-section-resources"
+              className="text-muted-foreground px-3 text-[11px] font-medium tracking-wider uppercase"
+            >
+              {tSections('resources')}
+            </h3>
+            <Link
+              href="/faq"
+              onClick={handleClose}
+              data-testid="more-sheet-link-faq"
+              className={linkClass}
+            >
+              <span>{tLinks('faq')}</span>
+            </Link>
+            <Link
+              href="/glossaire"
+              onClick={handleClose}
+              data-testid="more-sheet-link-glossary"
+              className={linkClass}
+            >
+              <span>{tLinks('glossary')}</span>
+            </Link>
+            <Link
+              href="/legal/cgu"
+              onClick={handleClose}
+              data-testid="more-sheet-link-legal-cgu"
+              className={linkClass}
+            >
+              <span>{tLinks('legalCgu')}</span>
+            </Link>
+            <Link
+              href="/legal/privacy"
+              onClick={handleClose}
+              data-testid="more-sheet-link-legal-privacy"
+              className={linkClass}
+            >
+              <span>{tLinks('legalPrivacy')}</span>
+            </Link>
+            <Link
+              href="/legal/cookies"
+              onClick={handleClose}
+              data-testid="more-sheet-link-legal-cookies"
+              className={linkClass}
+            >
+              <span>{tLinks('legalCookies')}</span>
+            </Link>
+          </section>
+
+          <section aria-labelledby="more-section-preferences" className="space-y-2">
+            <h3
+              id="more-section-preferences"
+              className="text-muted-foreground px-3 text-[11px] font-medium tracking-wider uppercase"
+            >
+              {tSections('preferences')}
+            </h3>
+            <button
+              type="button"
+              onClick={toggleTheme}
+              data-testid="more-sheet-theme-toggle"
+              className="bg-surface-muted text-foreground hover:bg-surface-muted/80 focus-visible:ring-brand-600 flex w-full items-center justify-between rounded-md px-3 py-3 text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none"
+              aria-label={isDark ? tLinks('lightMode') : tLinks('darkMode')}
+            >
+              <span className="dark:hidden">{tLinks('darkMode')}</span>
+              <span className="hidden dark:block">{tLinks('lightMode')}</span>
+              <div className="h-4 w-4">
+                <Moon className="h-4 w-4 dark:hidden" aria-hidden="true" />
+                <Sun className="hidden h-4 w-4 dark:block" aria-hidden="true" />
+              </div>
+            </button>
+            <div className="px-3 py-1">
+              <LocaleSwitcher />
+            </div>
+          </section>
+
+          <section aria-labelledby="more-section-account" className="space-y-1">
+            <h3
+              id="more-section-account"
+              className="text-muted-foreground px-3 text-[11px] font-medium tracking-wider uppercase"
+            >
+              {tSections('account')}
+            </h3>
+            <form action={logoutAction}>
+              <button
+                type="submit"
+                data-testid="more-sheet-logout"
+                className="text-foreground hover:bg-muted focus-visible:ring-brand-600 flex w-full items-center justify-between rounded-md px-3 py-3 text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none"
+              >
+                <span>{tLinks('logout')}</span>
+                <LogOut className="h-4 w-4" aria-hidden="true" />
+              </button>
+            </form>
+          </section>
+        </div>
+      </div>
+    </>
+  );
+
+  return createPortal(node, document.body);
+}

--- a/src/components/layout/MoreSheet.tsx
+++ b/src/components/layout/MoreSheet.tsx
@@ -9,6 +9,7 @@ import { Link } from '@/i18n/navigation';
 import { useIsClient } from '@/lib/hooks/useIsClient';
 import { logoutAction } from '@/lib/actions/auth';
 import { LocaleSwitcher } from './LocaleSwitcher';
+import { CookiePreferencesLink } from './CookiePreferencesLink';
 
 /**
  * PR-BETA-6 — "More" sheet for the mobile Bottom Tab Bar (THI-277).
@@ -294,6 +295,25 @@ export function MoreSheet({ isOpen, onClose, isAdmin = false }: MoreSheetProps) 
             </button>
             <div className="px-3 py-1">
               <LocaleSwitcher />
+            </div>
+            {/*
+             * PR-BETA-6 Hotfix Option A v3 (THI-277, 2026-05-25, GDPR
+             * addendum): mirror the footer's `<CookiePreferencesLink />`
+             * inside the More sheet. Once the persistent BottomTabBar is
+             * mounted, an authenticated mobile visitor scrolling to the
+             * bottom of `/faq` / `/legal/*` can have the footer link
+             * obscured by the bar. RGPD art. 7(3) requires that
+             * withdrawing consent be as easy as giving it, so we surface
+             * the same affordance through the canonical mobile-nav
+             * surface. `CookiePreferencesLink` is the same Client
+             * Component used in `Footer.tsx` — single source of truth
+             * for the reopen-consent contract.
+             */}
+            <div
+              data-testid="more-sheet-cookie-preferences"
+              className="hover:bg-muted focus-within:ring-brand-600 rounded-md px-3 py-3 transition-colors focus-within:ring-2 focus-within:ring-offset-0"
+            >
+              <CookiePreferencesLink />
             </div>
           </section>
 

--- a/src/components/layout/ScrollToTop.tsx
+++ b/src/components/layout/ScrollToTop.tsx
@@ -6,7 +6,21 @@ import { useTranslations } from 'next-intl';
 
 const THRESHOLD = 600;
 
-export function ScrollToTop() {
+export type ScrollToTopProps = {
+  /**
+   * PR-BETA-6 hotfix #4 (THI-277, 2026-05-25): when the persistent
+   * BottomTabBar is mounted for this request (cf.
+   * `shouldMountBottomTabBar()`), the FAB's default `bottom-4` puts it
+   * BEHIND the bar on iPhone Safari (smoke report @thierry 2026-05-25).
+   * Pass `liftedForBottomBar={true}` from the parent layout to push the
+   * FAB above the bar (h-12 + safe-area + a bit of air). The lift only
+   * matters on mobile — desktop (≥ md) keeps the original offset
+   * because the bar is `md:hidden`.
+   */
+  liftedForBottomBar?: boolean;
+};
+
+export function ScrollToTop({ liftedForBottomBar = false }: ScrollToTopProps) {
   const t = useTranslations('ui');
   const [visible, setVisible] = useState(false);
 
@@ -26,16 +40,26 @@ export function ScrollToTop() {
 
   if (!visible) return null;
 
+  // PR-D5 mobile-iOS: `bottom-4`/`bottom-6` overlapped the iPhone home
+  // indicator (~34px reserved area). `max(…,env(safe-area-inset-bottom))`
+  // lifts the FAB above the safe area on devices that report it.
+  //
+  // PR-BETA-6 hotfix #4: when the BottomTabBar mounts, add ~4.5rem (the
+  // bar's h-12 + visual breathing room) to the bottom offset so the FAB
+  // sits above the bar. Mobile lift only — `md:bottom-…` keeps the
+  // original desktop offset because the bar is `md:hidden`.
+  const mobileBottom = liftedForBottomBar
+    ? 'bottom-[calc(env(safe-area-inset-bottom)+4.5rem)]'
+    : 'bottom-[max(1rem,env(safe-area-inset-bottom))]';
+
   return (
     <button
       type="button"
       onClick={scrollToTop}
       aria-label={t('scrollToTop')}
-      // PR-D5 mobile-iOS: `bottom-4`/`bottom-6` overlapped the iPhone home
-      // indicator (~34px reserved area). `max(…,env(safe-area-inset-bottom))`
-      // lifts the FAB above the safe area on devices that report it, and
-      // falls back to the original 1rem/1.5rem on devices without insets.
-      className="bg-brand-700 hover:bg-brand-800 focus-visible:ring-brand-600 fixed right-4 bottom-[max(1rem,env(safe-area-inset-bottom))] z-40 inline-flex h-11 w-11 items-center justify-center rounded-full text-white shadow-lg transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none md:right-6 md:bottom-[max(1.5rem,env(safe-area-inset-bottom))]"
+      data-testid="scroll-to-top"
+      data-lifted-for-bottom-bar={String(liftedForBottomBar)}
+      className={`bg-brand-700 hover:bg-brand-800 focus-visible:ring-brand-600 ${mobileBottom} fixed right-4 z-40 inline-flex h-11 w-11 items-center justify-center rounded-full text-white shadow-lg transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none md:right-6 md:bottom-[max(1.5rem,env(safe-area-inset-bottom))]`}
     >
       <ArrowUp className="h-5 w-5" aria-hidden />
     </button>

--- a/src/components/layout/__tests__/BottomTabBar.test.tsx
+++ b/src/components/layout/__tests__/BottomTabBar.test.tsx
@@ -60,12 +60,12 @@ vi.mock('@/components/gdpr/ConsentBanner', () => ({
   reopenConsentBanner: vi.fn(),
 }));
 
+import { BottomTabBar } from '../BottomTabBar';
 import {
-  BottomTabBar,
   BOTTOM_TAB_BAR_EXCLUDED_ROUTES,
   isExcludedRoute,
   stripLocalePrefix,
-} from '../BottomTabBar';
+} from '../bottom-tab-bar.routes';
 
 beforeEach(() => {
   cleanup();

--- a/src/components/layout/__tests__/BottomTabBar.test.tsx
+++ b/src/components/layout/__tests__/BottomTabBar.test.tsx
@@ -56,7 +56,16 @@ vi.mock('@/lib/actions/auth', () => ({
   logoutAction: vi.fn(async () => undefined),
 }));
 
-import { BottomTabBar } from '../BottomTabBar';
+vi.mock('@/components/gdpr/ConsentBanner', () => ({
+  reopenConsentBanner: vi.fn(),
+}));
+
+import {
+  BottomTabBar,
+  BOTTOM_TAB_BAR_EXCLUDED_ROUTES,
+  isExcludedRoute,
+  stripLocalePrefix,
+} from '../BottomTabBar';
 
 beforeEach(() => {
   cleanup();
@@ -245,6 +254,81 @@ describe('<BottomTabBar /> — More sheet content', () => {
     render(<BottomTabBar />);
     await user.click(screen.getByTestId('bottom-tab-more'));
     expect(screen.queryByTestId('more-sheet-link-admin')).not.toBeInTheDocument();
+  });
+});
+
+describe('BOTTOM_TAB_BAR_EXCLUDED_ROUTES + isExcludedRoute (Hotfix Option A v3, mount gating)', () => {
+  // The root layout (`[locale]/layout.tsx`) reads `x-pathname`, strips the
+  // locale prefix, then calls `isExcludedRoute` to decide whether to render
+  // the bar. These specs lock the allow-list so a future PR can't widen the
+  // scope by accident.
+  it('excludes the canonical landing + auth + onboarding + offline routes', () => {
+    expect(isExcludedRoute('/')).toBe(true);
+    expect(isExcludedRoute('/login')).toBe(true);
+    expect(isExcludedRoute('/signup')).toBe(true);
+    expect(isExcludedRoute('/forgot-password')).toBe(true);
+    expect(isExcludedRoute('/reset-password')).toBe(true);
+    expect(isExcludedRoute('/callback')).toBe(true);
+    expect(isExcludedRoute('/offline')).toBe(true);
+    expect(isExcludedRoute('/onboarding')).toBe(true);
+  });
+
+  it('does NOT exclude in-app destinations or resources pages', () => {
+    // Fixes the "Admin sans retour" trap on iPhone smoke 2026-05-25.
+    expect(isExcludedRoute('/app')).toBe(false);
+    expect(isExcludedRoute('/app/charges')).toBe(false);
+    expect(isExcludedRoute('/admin')).toBe(false);
+    expect(isExcludedRoute('/admin/users')).toBe(false);
+    // Fixes the disjointed-UX bug on resource pages.
+    expect(isExcludedRoute('/faq')).toBe(false);
+    expect(isExcludedRoute('/glossaire')).toBe(false);
+    expect(isExcludedRoute('/legal/cgu')).toBe(false);
+    expect(isExcludedRoute('/legal/privacy')).toBe(false);
+    expect(isExcludedRoute('/legal/cookies')).toBe(false);
+  });
+
+  it('exposes the readonly route list so external auditors can lock the allow-list', () => {
+    expect(BOTTOM_TAB_BAR_EXCLUDED_ROUTES).toContain('/');
+    expect(BOTTOM_TAB_BAR_EXCLUDED_ROUTES).toContain('/login');
+    expect(BOTTOM_TAB_BAR_EXCLUDED_ROUTES).toContain('/signup');
+    expect(BOTTOM_TAB_BAR_EXCLUDED_ROUTES).toHaveLength(8);
+  });
+});
+
+describe('stripLocalePrefix — locale-aware exclusion (Hotfix Option A v3)', () => {
+  const locales = ['fr-BE', 'nl-BE', 'en', 'es-ES', 'de-DE'] as const;
+
+  it('strips a leading /<locale>/ prefix and preserves the tail', () => {
+    expect(stripLocalePrefix('/en/app', locales)).toBe('/app');
+    expect(stripLocalePrefix('/de-DE/admin/users', locales)).toBe('/admin/users');
+    expect(stripLocalePrefix('/nl-BE/faq', locales)).toBe('/faq');
+  });
+
+  it('collapses the bare locale path to root', () => {
+    expect(stripLocalePrefix('/en', locales)).toBe('/');
+    expect(stripLocalePrefix('/es-ES', locales)).toBe('/');
+  });
+
+  it('returns the input unchanged when no locale prefix is present (default fr-BE)', () => {
+    // `localePrefix: 'as-needed'` keeps the default locale unprefixed.
+    expect(stripLocalePrefix('/app', locales)).toBe('/app');
+    expect(stripLocalePrefix('/login', locales)).toBe('/login');
+    expect(stripLocalePrefix('/', locales)).toBe('/');
+  });
+
+  it('does NOT mistake a prefix-like segment for a locale (e.g. /enrollment)', () => {
+    expect(stripLocalePrefix('/enrollment', locales)).toBe('/enrollment');
+    // The leading slash + locale + non-slash boundary protects against the
+    // false positive: `/enrollment` is not `/en/rollment`.
+  });
+});
+
+describe('<MoreSheet /> — Cookie Preferences (Hotfix Option A v3 / GDPR art. 7(3))', () => {
+  it('exposes the CookiePreferencesLink inside the preferences section', async () => {
+    const user = userEvent.setup();
+    render(<BottomTabBar />);
+    await user.click(screen.getByTestId('bottom-tab-more'));
+    expect(screen.getByTestId('more-sheet-cookie-preferences')).toBeInTheDocument();
   });
 });
 

--- a/src/components/layout/__tests__/BottomTabBar.test.tsx
+++ b/src/components/layout/__tests__/BottomTabBar.test.tsx
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import frMessages from '../../../../messages/fr-BE.json';
+
+/**
+ * PR-BETA-6 (THI-277) — BottomTabBar + MoreSheet unit covers.
+ *
+ * Renders the bar under jsdom. next-intl / Link / usePathname / LocaleSwitcher
+ * / logoutAction are mocked so the bar can mount without a real provider
+ * tree. The mocked `usePathname` returns whatever value the test setter
+ * pushed into the controllable ref, which lets each spec exercise a
+ * different pathname (cockpit, bills, expenses, simulate, sub-route).
+ *
+ * The MoreSheet portal renders into `document.body` — testing-library
+ * sees it via `screen` queries because RTL's queries traverse the whole
+ * document, not just the rendered container.
+ */
+
+let currentPathname = '/app';
+
+vi.mock('@/i18n/navigation', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Link: ({ href, children, ...rest }: any) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+  usePathname: () => currentPathname,
+}));
+
+vi.mock('next-intl', () => ({
+  useTranslations: (namespace: string) => {
+    return (key: string) => {
+      // Walk the namespace.key path inside the fr-BE messages JSON.
+      const parts = `${namespace}.${key}`.split('.');
+      let value: unknown = frMessages;
+      for (const part of parts) {
+        if (typeof value === 'object' && value !== null && part in value) {
+          value = (value as Record<string, unknown>)[part];
+        } else {
+          return key;
+        }
+      }
+      return typeof value === 'string' ? value : key;
+    };
+  },
+}));
+
+vi.mock('../LocaleSwitcher', () => ({
+  LocaleSwitcher: () => <div data-testid="locale-switcher-mock" />,
+}));
+
+vi.mock('@/lib/actions/auth', () => ({
+  logoutAction: vi.fn(async () => undefined),
+}));
+
+import { BottomTabBar } from '../BottomTabBar';
+
+beforeEach(() => {
+  cleanup();
+  currentPathname = '/app';
+  document.body.style.position = '';
+  document.body.style.top = '';
+  document.body.style.width = '';
+  document.body.style.overflow = '';
+});
+
+describe('<BottomTabBar /> — 5 tabs, Apple HIG hard cap', () => {
+  it('renders the 4 destination tabs + the More trigger', () => {
+    render(<BottomTabBar />);
+    expect(screen.getByTestId('bottom-tab-cockpit')).toBeInTheDocument();
+    expect(screen.getByTestId('bottom-tab-bills')).toBeInTheDocument();
+    expect(screen.getByTestId('bottom-tab-expenses')).toBeInTheDocument();
+    expect(screen.getByTestId('bottom-tab-simulate')).toBeInTheDocument();
+    expect(screen.getByTestId('bottom-tab-more')).toBeInTheDocument();
+  });
+
+  it('uses the localised label set from layout.bottomTab', () => {
+    render(<BottomTabBar />);
+    expect(screen.getByText('Cockpit')).toBeInTheDocument();
+    expect(screen.getByText('Factures')).toBeInTheDocument();
+    expect(screen.getByText('Dépenses')).toBeInTheDocument();
+    expect(screen.getByText('Simuler')).toBeInTheDocument();
+    expect(screen.getByText('Plus')).toBeInTheDocument();
+  });
+
+  it('points each tab at the canonical /app sub-route', () => {
+    render(<BottomTabBar />);
+    expect(screen.getByTestId('bottom-tab-cockpit')).toHaveAttribute('href', '/app');
+    expect(screen.getByTestId('bottom-tab-bills')).toHaveAttribute('href', '/app/charges');
+    expect(screen.getByTestId('bottom-tab-expenses')).toHaveAttribute('href', '/app/expenses');
+    expect(screen.getByTestId('bottom-tab-simulate')).toHaveAttribute('href', '/app/simulator');
+  });
+
+  it('renders only one nav landmark with the localised aria-label', () => {
+    render(<BottomTabBar />);
+    const nav = screen.getByRole('navigation', { name: 'Navigation principale mobile' });
+    expect(nav).toBeInTheDocument();
+    expect(nav.getAttribute('data-testid')).toBe('bottom-tab-bar');
+  });
+});
+
+describe('<BottomTabBar /> — active tab detection', () => {
+  it('marks the cockpit tab as current when pathname === "/app" (exact match)', () => {
+    currentPathname = '/app';
+    render(<BottomTabBar />);
+    expect(screen.getByTestId('bottom-tab-cockpit')).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByTestId('bottom-tab-bills')).not.toHaveAttribute('aria-current');
+  });
+
+  it('does NOT mark cockpit as current when on a sub-route — bills wins for /app/charges', () => {
+    currentPathname = '/app/charges';
+    render(<BottomTabBar />);
+    expect(screen.getByTestId('bottom-tab-cockpit')).not.toHaveAttribute('aria-current');
+    expect(screen.getByTestId('bottom-tab-bills')).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('matches startsWith for nested sub-routes (e.g. /app/expenses/abc)', () => {
+    currentPathname = '/app/expenses/123';
+    render(<BottomTabBar />);
+    expect(screen.getByTestId('bottom-tab-expenses')).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByTestId('bottom-tab-bills')).not.toHaveAttribute('aria-current');
+  });
+
+  it('matches simulate at /app/simulator', () => {
+    currentPathname = '/app/simulator';
+    render(<BottomTabBar />);
+    expect(screen.getByTestId('bottom-tab-simulate')).toHaveAttribute('aria-current', 'page');
+  });
+});
+
+describe('<BottomTabBar /> — More sheet open/close', () => {
+  it('opens the More sheet on click and the close button restores focus', async () => {
+    const user = userEvent.setup();
+    render(<BottomTabBar />);
+
+    const moreButton = screen.getByTestId('bottom-tab-more');
+    expect(moreButton).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByTestId('more-sheet')).not.toBeInTheDocument();
+
+    await user.click(moreButton);
+
+    expect(moreButton).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('more-sheet')).toBeInTheDocument();
+    // The dialog is announced with the localised "Plus" title.
+    expect(screen.getByRole('dialog', { name: 'Plus' })).toBeInTheDocument();
+  });
+
+  it('closes the More sheet on backdrop click', async () => {
+    const user = userEvent.setup();
+    render(<BottomTabBar />);
+    await user.click(screen.getByTestId('bottom-tab-more'));
+    expect(screen.getByTestId('more-sheet')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('more-sheet-backdrop'));
+    expect(screen.queryByTestId('more-sheet')).not.toBeInTheDocument();
+  });
+
+  it('closes the More sheet on Escape', async () => {
+    const user = userEvent.setup();
+    render(<BottomTabBar />);
+    await user.click(screen.getByTestId('bottom-tab-more'));
+    expect(screen.getByTestId('more-sheet')).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+    expect(screen.queryByTestId('more-sheet')).not.toBeInTheDocument();
+  });
+
+  it('pins <body> with position:fixed while the sheet is open (iOS scroll lock parity)', async () => {
+    Object.defineProperty(window, 'scrollY', { value: 250, writable: true, configurable: true });
+    const user = userEvent.setup();
+    render(<BottomTabBar />);
+
+    await user.click(screen.getByTestId('bottom-tab-more'));
+    expect(document.body.style.position).toBe('fixed');
+    expect(document.body.style.top).toBe('-250px');
+    expect(document.body.style.width).toBe('100%');
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+});
+
+describe('<BottomTabBar /> — More sheet content', () => {
+  it('exposes the Accounts and Settings links inside the cockpit section', async () => {
+    const user = userEvent.setup();
+    render(<BottomTabBar />);
+    await user.click(screen.getByTestId('bottom-tab-more'));
+
+    expect(screen.getByTestId('more-sheet-link-accounts')).toHaveAttribute('href', '/app/accounts');
+    expect(screen.getByTestId('more-sheet-link-settings')).toHaveAttribute('href', '/app/settings');
+  });
+
+  it('exposes the FAQ / glossary / legal entries in the resources section', async () => {
+    const user = userEvent.setup();
+    render(<BottomTabBar />);
+    await user.click(screen.getByTestId('bottom-tab-more'));
+
+    expect(screen.getByTestId('more-sheet-link-faq')).toHaveAttribute('href', '/faq');
+    expect(screen.getByTestId('more-sheet-link-glossary')).toHaveAttribute('href', '/glossaire');
+    expect(screen.getByTestId('more-sheet-link-legal-cgu')).toHaveAttribute('href', '/legal/cgu');
+    expect(screen.getByTestId('more-sheet-link-legal-privacy')).toHaveAttribute(
+      'href',
+      '/legal/privacy',
+    );
+    expect(screen.getByTestId('more-sheet-link-legal-cookies')).toHaveAttribute(
+      'href',
+      '/legal/cookies',
+    );
+  });
+
+  it('renders the theme toggle and the LocaleSwitcher inside the preferences section', async () => {
+    const user = userEvent.setup();
+    render(<BottomTabBar />);
+    await user.click(screen.getByTestId('bottom-tab-more'));
+
+    expect(screen.getByTestId('more-sheet-theme-toggle')).toBeInTheDocument();
+    expect(screen.getByTestId('locale-switcher-mock')).toBeInTheDocument();
+  });
+
+  it('exposes the logout submit button wired to the server action', async () => {
+    const user = userEvent.setup();
+    render(<BottomTabBar />);
+    await user.click(screen.getByTestId('bottom-tab-more'));
+
+    const logoutBtn = screen.getByTestId('more-sheet-logout');
+    expect(logoutBtn).toBeInTheDocument();
+    expect(logoutBtn).toHaveAttribute('type', 'submit');
+    // The submit lives inside a <form> bound to the logoutAction server
+    // action — RTL surfaces it through the parent <form>.
+    expect(logoutBtn.closest('form')).not.toBeNull();
+  });
+
+  it('shows the Admin link when isAdmin=true', async () => {
+    const user = userEvent.setup();
+    render(<BottomTabBar isAdmin />);
+    await user.click(screen.getByTestId('bottom-tab-more'));
+
+    const adminLink = screen.getByTestId('more-sheet-link-admin');
+    expect(adminLink).toHaveAttribute('href', '/admin');
+  });
+
+  it('hides the Admin link when isAdmin is omitted (fail-closed default)', async () => {
+    const user = userEvent.setup();
+    render(<BottomTabBar />);
+    await user.click(screen.getByTestId('bottom-tab-more'));
+    expect(screen.queryByTestId('more-sheet-link-admin')).not.toBeInTheDocument();
+  });
+});
+
+describe('<BottomTabBar /> — accessibility contract', () => {
+  it('the nav landmark and the More button carry the aria-controls relationship', async () => {
+    const user = userEvent.setup();
+    render(<BottomTabBar />);
+    const moreButton = screen.getByTestId('bottom-tab-more');
+    expect(moreButton).toHaveAttribute('aria-controls', 'more-sheet');
+    expect(moreButton).toHaveAttribute('aria-haspopup', 'dialog');
+
+    await user.click(moreButton);
+    // The opened sheet matches the aria-controls id.
+    expect(screen.getByTestId('more-sheet').id).toBe('more-sheet');
+  });
+});

--- a/src/components/layout/__tests__/Footer.test.tsx
+++ b/src/components/layout/__tests__/Footer.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 import messages from '../../../../messages/fr-BE.json';
@@ -58,6 +58,19 @@ vi.mock('@/lib/actions/consent', () => ({
   COOKIE_CONSENT_VERSION: '1.0.0',
 }));
 
+// PR-BETA-6 hotfix #4 — Footer hides its `<nav>` on mobile when the
+// persistent BottomTabBar is mounted (the bar's More sheet already
+// surfaces those links — see MoreSheet.tsx). Mock the state helper so
+// each spec controls the visibility deterministically.
+const bottomTabBarMountedRef = { value: false };
+vi.mock('@/lib/layout/bottom-tab-bar-state', () => ({
+  shouldMountBottomTabBar: async () => bottomTabBarMountedRef.value,
+}));
+
+function setBottomTabBarMounted(value: boolean): void {
+  bottomTabBarMountedRef.value = value;
+}
+
 import { Footer } from '../Footer';
 
 async function renderFooter() {
@@ -66,6 +79,10 @@ async function renderFooter() {
 }
 
 describe('<Footer />', () => {
+  beforeEach(() => {
+    setBottomTabBarMounted(false);
+  });
+
   it('renders the four legal links (CGU, Privacy, Cookies, FAQ)', async () => {
     await renderFooter();
     // Footer-specific link labels come from the `footer` namespace
@@ -108,5 +125,36 @@ describe('<Footer />', () => {
     expect(
       screen.getByRole('button', { name: messages.footer.cookiePreferences }),
     ).toBeInTheDocument();
+  });
+
+  // PR-BETA-6 hotfix #4 (THI-277, 2026-05-25, @thierry iPhone smoke): the
+  // footer's link nav is fully redundant with the BottomTabBar More sheet
+  // once the bar is mounted (same five entries — CGU, Privacy, Cookies,
+  // FAQ, Cookie Preferences). Hide the nav on mobile when the bar is
+  // mounted; keep it on desktop (≥ md) because the bar is `md:hidden`.
+  describe('Hotfix #4 — redundant nav hidden on mobile when BottomTabBar mounts', () => {
+    it('renders the nav with `flex` (visible on every breakpoint) by default', async () => {
+      setBottomTabBarMounted(false);
+      await renderFooter();
+      const nav = screen.getByTestId('footer-nav');
+      expect(nav.className).toContain('flex');
+      expect(nav.className).not.toContain('hidden');
+    });
+
+    it('hides the nav on mobile (`hidden md:flex`) when the bar is mounted', async () => {
+      setBottomTabBarMounted(true);
+      await renderFooter();
+      const nav = screen.getByTestId('footer-nav');
+      expect(nav.className).toContain('hidden');
+      expect(nav.className).toContain('md:flex');
+    });
+
+    it('always keeps the BrandHomeLink + copyright (never hidden, legal info)', async () => {
+      setBottomTabBarMounted(true);
+      await renderFooter();
+      expect(screen.getByLabelText(messages.common.homeAria)).toBeInTheDocument();
+      const year = new Date().getFullYear();
+      expect(screen.getByText((c) => c.includes(String(year)))).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/layout/__tests__/Header.test.tsx
+++ b/src/components/layout/__tests__/Header.test.tsx
@@ -40,18 +40,33 @@ vi.mock('../HeaderNav', () => ({
     variant,
     isAuthenticated,
     isAdmin,
+    hideMobileTrigger,
   }: {
     variant: string;
     isAuthenticated?: boolean;
     isAdmin?: boolean;
+    hideMobileTrigger?: boolean;
   }) => (
     <div
       data-testid="header-nav-mock"
       data-variant={variant}
       data-is-authenticated={String(isAuthenticated ?? false)}
       data-is-admin={String(isAdmin ?? false)}
+      data-hide-mobile-trigger={String(hideMobileTrigger ?? false)}
     />
   ),
+}));
+
+// PR-BETA-6 hotfix #3 — Header reads the `x-pathname` request header to
+// decide whether to suppress the mobile hamburger (duplicate-nav fix
+// against the persistent BottomTabBar). Default to `/` so the existing
+// specs keep their pre-hotfix semantics; tests that need a different
+// route call `setPathname()` below.
+const pathnameRef = { value: '/' };
+vi.mock('next/headers', () => ({
+  headers: async () => ({
+    get: (name: string) => (name === 'x-pathname' ? pathnameRef.value : null),
+  }),
 }));
 
 // PR-SEC-ADMIN — `isAdmin()` reads env + Supabase session at runtime.
@@ -80,6 +95,10 @@ function setOptionalUser(value: null | { id: string }): void {
   optionalUserRef.value = value;
 }
 
+function setPathname(value: string): void {
+  pathnameRef.value = value;
+}
+
 async function renderHeader(props: Parameters<typeof Header>[0] = {}) {
   const ui = await Header(props);
   return render(ui);
@@ -89,6 +108,7 @@ describe('<Header />', () => {
   beforeEach(() => {
     setIsAdmin(false);
     setOptionalUser(null);
+    setPathname('/');
   });
 
   it('renders the marketing variant by default with login + signup CTAs', async () => {
@@ -210,6 +230,67 @@ describe('<Header />', () => {
     // Marketing pages are public — `showAdminLink` short-circuits before
     // calling isAdmin(), so the drawer always gets isAdmin=false.
     expect(screen.getByTestId('header-nav-mock')).toHaveAttribute('data-is-admin', 'false');
+  });
+
+  // PR-BETA-6 hotfix #3 — duplicate-nav fix on mobile. When the visitor is
+  // authenticated AND the route is NOT in `BOTTOM_TAB_BAR_EXCLUDED_ROUTES`
+  // (i.e. the persistent bar will mount), the Header must forward
+  // `hideMobileTrigger=true` so HeaderNav suppresses the hamburger.
+  describe('hideMobileTrigger forwarding (Hotfix #3 anti-duplicate-nav)', () => {
+    it('forwards hideMobileTrigger=true on /faq for an authenticated visitor', async () => {
+      setPathname('/faq');
+      await renderHeader({ variant: 'marketing', isAuthenticated: true });
+      expect(screen.getByTestId('header-nav-mock')).toHaveAttribute(
+        'data-hide-mobile-trigger',
+        'true',
+      );
+    });
+
+    it('forwards hideMobileTrigger=true on /legal/cgu for an authenticated visitor', async () => {
+      setPathname('/legal/cgu');
+      await renderHeader({ variant: 'marketing', isAuthenticated: true });
+      expect(screen.getByTestId('header-nav-mock')).toHaveAttribute(
+        'data-hide-mobile-trigger',
+        'true',
+      );
+    });
+
+    it('keeps hideMobileTrigger=false on the landing (excluded route)', async () => {
+      setPathname('/');
+      await renderHeader({ variant: 'marketing', isAuthenticated: true });
+      expect(screen.getByTestId('header-nav-mock')).toHaveAttribute(
+        'data-hide-mobile-trigger',
+        'false',
+      );
+    });
+
+    it('keeps hideMobileTrigger=false on /login (auth route excluded)', async () => {
+      setPathname('/login');
+      await renderHeader({ variant: 'marketing', isAuthenticated: true });
+      expect(screen.getByTestId('header-nav-mock')).toHaveAttribute(
+        'data-hide-mobile-trigger',
+        'false',
+      );
+    });
+
+    it('keeps hideMobileTrigger=false for anonymous visitor on /faq', async () => {
+      setPathname('/faq');
+      await renderHeader({ variant: 'marketing', isAuthenticated: false });
+      // No bar to compete with → marketing burger stays.
+      expect(screen.getByTestId('header-nav-mock')).toHaveAttribute(
+        'data-hide-mobile-trigger',
+        'false',
+      );
+    });
+
+    it('strips the locale prefix before checking exclusion (e.g. /en/faq)', async () => {
+      setPathname('/en/faq');
+      await renderHeader({ variant: 'marketing', isAuthenticated: true });
+      expect(screen.getByTestId('header-nav-mock')).toHaveAttribute(
+        'data-hide-mobile-trigger',
+        'true',
+      );
+    });
   });
 
   it('home link has the tactile press animation, gated on motion-safe (issue #95)', async () => {

--- a/src/components/layout/__tests__/Header.test.tsx
+++ b/src/components/layout/__tests__/Header.test.tsx
@@ -57,16 +57,17 @@ vi.mock('../HeaderNav', () => ({
   ),
 }));
 
-// PR-BETA-6 hotfix #3 — Header reads the `x-pathname` request header to
-// decide whether to suppress the mobile hamburger (duplicate-nav fix
-// against the persistent BottomTabBar). Default to `/` so the existing
-// specs keep their pre-hotfix semantics; tests that need a different
-// route call `setPathname()` below.
-const pathnameRef = { value: '/' };
-vi.mock('next/headers', () => ({
-  headers: async () => ({
-    get: (name: string) => (name === 'x-pathname' ? pathnameRef.value : null),
-  }),
+// PR-BETA-6 hotfix #3 + hotfix #4 — Header reads
+// `shouldMountBottomTabBar()` to decide whether to suppress the mobile
+// hamburger (duplicate-nav fix against the persistent BottomTabBar).
+// The helper itself reads `next/headers` + `getOptionalUser` + the
+// exclusion list; mocking it directly here keeps each spec deterministic
+// without re-deriving the gating logic in the test. Default to `false`
+// so the existing specs keep their pre-hotfix semantics; tests that
+// need the helper to return true call `setBottomTabBarMounted(true)`.
+const bottomTabBarMountedRef = { value: false };
+vi.mock('@/lib/layout/bottom-tab-bar-state', () => ({
+  shouldMountBottomTabBar: async () => bottomTabBarMountedRef.value,
 }));
 
 // PR-SEC-ADMIN — `isAdmin()` reads env + Supabase session at runtime.
@@ -95,8 +96,8 @@ function setOptionalUser(value: null | { id: string }): void {
   optionalUserRef.value = value;
 }
 
-function setPathname(value: string): void {
-  pathnameRef.value = value;
+function setBottomTabBarMounted(value: boolean): void {
+  bottomTabBarMountedRef.value = value;
 }
 
 async function renderHeader(props: Parameters<typeof Header>[0] = {}) {
@@ -108,7 +109,7 @@ describe('<Header />', () => {
   beforeEach(() => {
     setIsAdmin(false);
     setOptionalUser(null);
-    setPathname('/');
+    setBottomTabBarMounted(false);
   });
 
   it('renders the marketing variant by default with login + signup CTAs', async () => {
@@ -232,13 +233,16 @@ describe('<Header />', () => {
     expect(screen.getByTestId('header-nav-mock')).toHaveAttribute('data-is-admin', 'false');
   });
 
-  // PR-BETA-6 hotfix #3 — duplicate-nav fix on mobile. When the visitor is
-  // authenticated AND the route is NOT in `BOTTOM_TAB_BAR_EXCLUDED_ROUTES`
-  // (i.e. the persistent bar will mount), the Header must forward
-  // `hideMobileTrigger=true` so HeaderNav suppresses the hamburger.
+  // PR-BETA-6 hotfix #3 + hotfix #4 — duplicate-nav fix on mobile.
+  // Header forwards `hideMobileTrigger` by delegating to
+  // `shouldMountBottomTabBar()` (single source of truth shared with the
+  // bar mount in `[locale]/layout.tsx`, the Footer nav hiding, and the
+  // ScrollToTop FAB lift). Mock the helper directly so the spec proves
+  // the wiring without re-deriving the auth+pathname matrix here (those
+  // are covered in bottom-tab-bar-state.test.ts).
   describe('hideMobileTrigger forwarding (Hotfix #3 anti-duplicate-nav)', () => {
-    it('forwards hideMobileTrigger=true on /faq for an authenticated visitor', async () => {
-      setPathname('/faq');
+    it('forwards hideMobileTrigger=true when shouldMountBottomTabBar() → true', async () => {
+      setBottomTabBarMounted(true);
       await renderHeader({ variant: 'marketing', isAuthenticated: true });
       expect(screen.getByTestId('header-nav-mock')).toHaveAttribute(
         'data-hide-mobile-trigger',
@@ -246,49 +250,12 @@ describe('<Header />', () => {
       );
     });
 
-    it('forwards hideMobileTrigger=true on /legal/cgu for an authenticated visitor', async () => {
-      setPathname('/legal/cgu');
-      await renderHeader({ variant: 'marketing', isAuthenticated: true });
-      expect(screen.getByTestId('header-nav-mock')).toHaveAttribute(
-        'data-hide-mobile-trigger',
-        'true',
-      );
-    });
-
-    it('keeps hideMobileTrigger=false on the landing (excluded route)', async () => {
-      setPathname('/');
+    it('keeps hideMobileTrigger=false when shouldMountBottomTabBar() → false', async () => {
+      setBottomTabBarMounted(false);
       await renderHeader({ variant: 'marketing', isAuthenticated: true });
       expect(screen.getByTestId('header-nav-mock')).toHaveAttribute(
         'data-hide-mobile-trigger',
         'false',
-      );
-    });
-
-    it('keeps hideMobileTrigger=false on /login (auth route excluded)', async () => {
-      setPathname('/login');
-      await renderHeader({ variant: 'marketing', isAuthenticated: true });
-      expect(screen.getByTestId('header-nav-mock')).toHaveAttribute(
-        'data-hide-mobile-trigger',
-        'false',
-      );
-    });
-
-    it('keeps hideMobileTrigger=false for anonymous visitor on /faq', async () => {
-      setPathname('/faq');
-      await renderHeader({ variant: 'marketing', isAuthenticated: false });
-      // No bar to compete with → marketing burger stays.
-      expect(screen.getByTestId('header-nav-mock')).toHaveAttribute(
-        'data-hide-mobile-trigger',
-        'false',
-      );
-    });
-
-    it('strips the locale prefix before checking exclusion (e.g. /en/faq)', async () => {
-      setPathname('/en/faq');
-      await renderHeader({ variant: 'marketing', isAuthenticated: true });
-      expect(screen.getByTestId('header-nav-mock')).toHaveAttribute(
-        'data-hide-mobile-trigger',
-        'true',
       );
     });
   });

--- a/src/components/layout/__tests__/HeaderNav.test.tsx
+++ b/src/components/layout/__tests__/HeaderNav.test.tsx
@@ -90,15 +90,20 @@ describe('<HeaderNav /> mobile drawer — auth CTAs', () => {
     expect(screen.queryByTestId('drawer-cockpit-link')).not.toBeInTheDocument();
   });
 
-  it('app variant ignores isAuthenticated — drawer shows the in-app nav, not auth CTAs', async () => {
+  it('app variant no longer renders the hamburger drawer (PR-BETA-6 / THI-277)', () => {
+    // PR-BETA-6 (THI-277, 2026-05-25): the right-to-left drawer was replaced
+    // by the Apple-HIG Bottom Tab Bar on the `/app/*` surface. HeaderNav now
+    // short-circuits the trigger + portal for `variant="app"`. The Bottom
+    // Tab Bar's "More" sheet is the canonical secondary-nav surface for
+    // signed-in mobile users.
     render(<HeaderNav variant="app" isAuthenticated />);
-    await openDrawer();
 
-    expect(screen.queryByTestId('drawer-login-link')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('drawer-signup-link')).not.toBeInTheDocument();
+    // No hamburger trigger and therefore no drawer can be opened.
+    expect(screen.queryByTestId('header-nav-trigger')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Menu' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('dialog', { name: 'Navigation mobile' })).not.toBeInTheDocument();
     expect(screen.queryByTestId('drawer-cockpit-link')).not.toBeInTheDocument();
-    // In-app nav links are present
-    expect(screen.getByRole('link', { name: 'Tableau de bord' })).toHaveAttribute('href', '/app');
+    expect(screen.queryByTestId('drawer-login-link')).not.toBeInTheDocument();
   });
 });
 
@@ -223,21 +228,16 @@ describe('<HeaderNav /> mobile drawer — THI-251 safe-area inset on PWA standal
   });
 });
 
-describe('<HeaderNav /> mobile drawer — PR-UX-1 admin entry in app variant', () => {
-  it('app variant + isAdmin=true exposes the Admin link mirrors with the desktop marker', async () => {
+describe('<HeaderNav /> mobile drawer — PR-UX-1 / PR-BETA-6 admin entry handoff', () => {
+  // PR-BETA-6 (THI-277): admin entry handoff. The app-variant drawer no
+  // longer renders an Admin link because the drawer itself is short-
+  // circuited; the admin entry is now surfaced through the BottomTabBar's
+  // "More" sheet (see BottomTabBar.test.tsx / MoreSheet covers). These two
+  // assertions guarantee the drawer-side never re-grows the entry by
+  // mistake.
+  it('app variant: drawer never rendered, no Admin entry to assert', () => {
     render(<HeaderNav variant="app" isAuthenticated isAdmin />);
-    await openDrawer();
-
-    // aria-label carries the "founder only" context (parity with desktop).
-    const adminLink = screen.getByRole('link', { name: 'Espace admin (réservé fondateur)' });
-    expect(adminLink).toHaveAttribute('href', '/admin');
-    // Visible label is the short "Admin".
-    expect(adminLink).toHaveTextContent('Admin');
-  });
-
-  it('app variant + isAdmin omitted hides the Admin link (fail-closed default)', async () => {
-    render(<HeaderNav variant="app" isAuthenticated />);
-    await openDrawer();
+    expect(screen.queryByTestId('header-nav-trigger')).not.toBeInTheDocument();
     expect(
       screen.queryByRole('link', { name: 'Espace admin (réservé fondateur)' }),
     ).not.toBeInTheDocument();

--- a/src/components/layout/__tests__/HeaderNav.test.tsx
+++ b/src/components/layout/__tests__/HeaderNav.test.tsx
@@ -107,6 +107,29 @@ describe('<HeaderNav /> mobile drawer — auth CTAs', () => {
   });
 });
 
+describe('<HeaderNav /> hideMobileTrigger — PR-BETA-6 hotfix #3 duplicate-nav fix', () => {
+  // When the parent Header passes `hideMobileTrigger={true}` (authenticated
+  // visitor on a non-excluded route where the persistent BottomTabBar
+  // mounts), the hamburger trigger MUST be suppressed even for the
+  // marketing variant. Two mobile-nav surfaces side-by-side is an
+  // Apple HIG / Material 3 anti-pattern (THI-277 smoke 2026-05-25).
+  it('hides the hamburger trigger when hideMobileTrigger=true on marketing variant', () => {
+    render(<HeaderNav variant="marketing" isAuthenticated hideMobileTrigger />);
+    expect(screen.queryByTestId('header-nav-trigger')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Menu' })).not.toBeInTheDocument();
+  });
+
+  it('keeps the hamburger trigger by default (hideMobileTrigger=false) on marketing variant', () => {
+    render(<HeaderNav variant="marketing" isAuthenticated={false} />);
+    expect(screen.getByTestId('header-nav-trigger')).toBeInTheDocument();
+  });
+
+  it('app variant: hideMobileTrigger is redundant but does not regress (no trigger either way)', () => {
+    render(<HeaderNav variant="app" isAuthenticated hideMobileTrigger />);
+    expect(screen.queryByTestId('header-nav-trigger')).not.toBeInTheDocument();
+  });
+});
+
 describe('<HeaderNav /> mobile drawer — PR-UX-1 marketing parity with desktop MktNav', () => {
   it('exposes Product / Simulator / Pricing anchored at the canonical landing ids', async () => {
     render(<HeaderNav variant="marketing" isAuthenticated={false} />);

--- a/src/components/layout/__tests__/ScrollToTop.test.tsx
+++ b/src/components/layout/__tests__/ScrollToTop.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, act } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+import { ScrollToTop } from '../ScrollToTop';
+
+beforeEach(() => {
+  cleanup();
+  // The FAB only renders past the scroll threshold (600px); seed scrollY so
+  // the assertions below can target the rendered button.
+  Object.defineProperty(window, 'scrollY', { value: 800, writable: true, configurable: true });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('<ScrollToTop /> — PR-BETA-6 hotfix #4 lift-for-bottom-bar', () => {
+  it('uses the default safe-area bottom offset when liftedForBottomBar is omitted', () => {
+    render(<ScrollToTop />);
+    // Dispatch a scroll event so the component flips `visible` to true.
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+    const button = screen.getByTestId('scroll-to-top');
+    expect(button).toHaveAttribute('data-lifted-for-bottom-bar', 'false');
+    // Default mobile offset uses the safe-area inset only (no lift for bar).
+    expect(button.className).toContain('bottom-[max(1rem,env(safe-area-inset-bottom))]');
+  });
+
+  it('lifts the FAB above the bar height + safe-area when liftedForBottomBar=true', () => {
+    render(<ScrollToTop liftedForBottomBar />);
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+    const button = screen.getByTestId('scroll-to-top');
+    expect(button).toHaveAttribute('data-lifted-for-bottom-bar', 'true');
+    // Lifted: 4.5rem (bar h-12 + ~1rem air) + safe-area inset.
+    expect(button.className).toContain('bottom-[calc(env(safe-area-inset-bottom)+4.5rem)]');
+    // Mobile lift only — desktop md:bottom override is preserved either way.
+    expect(button.className).toContain('md:bottom-');
+  });
+});

--- a/src/components/layout/bottom-tab-bar.routes.ts
+++ b/src/components/layout/bottom-tab-bar.routes.ts
@@ -1,0 +1,67 @@
+/**
+ * BottomTabBar mounting contract — server-safe helpers.
+ *
+ * Extracted from `BottomTabBar.tsx` on 2026-05-25 (PR-BETA-6 hotfix #2):
+ * the component itself is a Client Component (`'use client'`), but the
+ * mount gating runs in the Server Component `[locale]/layout.tsx`. Under
+ * Next.js 16 + React 19 a Server Component cannot import non-component
+ * values from a `'use client'` module — the boundary mixer triggers a
+ * render error that takes down every page on the Vercel preview
+ * ("Quelque chose s'est cassé"). Moving the pure data + pure helpers
+ * here gives both sides a safe consumer.
+ *
+ * Contract:
+ *   - No `'use client'` directive: this module is server-safe.
+ *   - No React, no Next.js runtime imports: pure TS only.
+ *   - Pure functions, no side effects, deterministic given their inputs.
+ */
+
+/**
+ * Routes where the persistent BottomTabBar must NOT render even if the
+ * visitor is authenticated. Landing keeps its marketing chrome; auth and
+ * onboarding pages stay focused full-screen flows; `/offline` is the PWA
+ * fallback (no nav makes sense without network); `/callback` is the OAuth
+ * roundtrip (also stripped by the next-intl matcher, but belt-and-
+ * suspenders). Compare against the locale-stripped pathname.
+ */
+export const BOTTOM_TAB_BAR_EXCLUDED_ROUTES = [
+  '/',
+  '/login',
+  '/signup',
+  '/forgot-password',
+  '/reset-password',
+  '/callback',
+  '/offline',
+  '/onboarding',
+] as const;
+
+/**
+ * Strip the optional `localePrefix: 'as-needed'` segment from a pathname so
+ * the exclusion check works regardless of the visitor's locale (default
+ * `fr-BE` renders unprefixed; every other locale prefixes the URL).
+ *
+ * Exported so the root layout can compute the unprefixed path once and pass
+ * it to `isExcludedRoute`. Lives next to the routes constant for cohesion
+ * with the rest of the bar's mounting contract.
+ */
+export function stripLocalePrefix(pathname: string, locales: readonly string[]): string {
+  for (const locale of locales) {
+    if (pathname === `/${locale}`) return '/';
+    if (pathname.startsWith(`/${locale}/`)) {
+      return pathname.slice(`/${locale}`.length);
+    }
+  }
+  return pathname;
+}
+
+/**
+ * Returns `true` when the bar must NOT render for the given unprefixed
+ * pathname. Driven by the `BOTTOM_TAB_BAR_EXCLUDED_ROUTES` allow-list and
+ * an explicit exact-match — sub-routes (e.g. `/reset-password/xxx`, if
+ * ever added) would need their own entry, deliberately to avoid hiding
+ * the bar by accident on a deep cockpit URL that happens to share a
+ * prefix.
+ */
+export function isExcludedRoute(unprefixedPathname: string): boolean {
+  return (BOTTOM_TAB_BAR_EXCLUDED_ROUTES as readonly string[]).includes(unprefixedPathname);
+}

--- a/src/lib/layout/bottom-tab-bar-state.ts
+++ b/src/lib/layout/bottom-tab-bar-state.ts
@@ -1,0 +1,43 @@
+import { headers } from 'next/headers';
+
+import { getOptionalUser } from '@/lib/auth/require-user';
+import { routing } from '@/i18n/routing';
+import { isExcludedRoute, stripLocalePrefix } from '@/components/layout/bottom-tab-bar.routes';
+
+/**
+ * Single source of truth for "is the persistent BottomTabBar going to
+ * mount for this request?" — used by every Server Component that needs
+ * to mirror the bar's visibility to avoid duplicate-nav anti-patterns
+ * (Apple HIG / Material 3 mobile-first 2026):
+ *
+ *   - `src/app/[locale]/layout.tsx`        → mount the bar itself
+ *   - `src/components/layout/Header.tsx`   → suppress the marketing burger
+ *   - `src/components/layout/Footer.tsx`   → hide redundant link nav on mobile
+ *   - `src/app/[locale]/(public)/layout.tsx` → lift the ScrollToTop FAB
+ *
+ * Returns `true` when both gates pass:
+ *   1. An authenticated visitor (`getOptionalUser()` returns a user).
+ *   2. The unprefixed pathname is NOT in `BOTTOM_TAB_BAR_EXCLUDED_ROUTES`.
+ *
+ * The pathname is read from the `x-pathname` request header that
+ * `src/proxy.ts` sets BEFORE next-intl runs. `stripLocalePrefix` removes
+ * the optional `/<locale>/` segment so the exclusion list works whatever
+ * locale the visitor uses.
+ *
+ * Note on duplication: we accept the four call-sites each running the
+ * three-step pipeline (headers → user → exclusion) rather than wrap the
+ * function in React `cache()`. `cache()` memoises by argument identity
+ * and this helper takes no arguments, so under vitest jsdom (where
+ * `cache()` does not get scoped per "render request" the way it does in
+ * an RSC pipeline) the first test's result would leak into every
+ * subsequent test. Supabase already caches `auth.getUser()` per-request
+ * via cookies, so the only redundant work is the header read + string
+ * comparison — negligible.
+ */
+export async function shouldMountBottomTabBar(): Promise<boolean> {
+  const requestHeaders = await headers();
+  const rawPathname = requestHeaders.get('x-pathname') ?? '/';
+  const unprefixedPathname = stripLocalePrefix(rawPathname, routing.locales);
+  const user = await getOptionalUser();
+  return !!user && !isExcludedRoute(unprefixedPathname);
+}


### PR DESCRIPTION
## Summary

- Remplace le drawer right-to-left mobile par un **Bottom Tab Bar Apple HIG** sur `/app/*` (5 tabs : Cockpit / Factures / Dépenses / Simuler / Plus) + sheet « Plus » slide-up (Comptes, Paramètres, Admin, FAQ, Glossaire, Légal, Thème, Langue, Déconnexion).
- Le drawer marketing reste inchangé (landing / FAQ / glossary / legal) en attendant la passe BETA-5 sur la nav marketing.
- 24 clés i18n ajoutées au namespace `layout` dans les 5 locales (parity 24/24 vérifiée).
- 19 specs Vitest + 6 specs Playwright iPhone WebKit (iPhone 14 / 15 Pro Max / SE).

## Linkage Linear

Ferme **THI-277** — PR-BETA-6 Bottom Tab Bar mobile Apple HIG.

## Self-review — qualité

- `npm run lint` : 0 erreurs (6 warnings pré-existants, hors scope)
- `npm run lint:use-server` : 0 erreurs
- `npm run typecheck` : 0 erreurs
- `npm run test` : **1228 / 1228 tests pass** (100 files, 25.5 s)
- E2E Playwright : exécutés en CI (nécessitent Supabase service role key — auto-skip sinon)

## Self-review — sécurité / conformité

- `isAdmin` gating : flag flows server-side via `isAdmin()` dans `app/layout.tsx` → BottomTabBar (le client ne décide jamais)
- Aucun secret, aucune nouvelle dépendance, aucun nouveau token CSS (réutilisation stricte `bg-background`, `text-foreground`, `border-border`, `text-muted-foreground`, `bg-amber-700`)
- FSMA / GDPR : pas de copy nouveau côté finance (juste nav labels)
- Logout passe par le server action `logoutAction` existant (form action, pas de XHR client)

## Motivation

@thierry feedback iPhone réel 2026-05-24 : drawer right-to-left perturbant à l'usage. Doctrine Ankora = mobile-first + Apple HIG natif iOS. Le Bottom Tab Bar est un pattern mentalement intégré par 100% des users iPhone (Mail, Messages, Photos, Plans). Référence : `docs/reports/2026-05-24-reset-strategique-prod-vs-vision-cowork.md` §4.3.

## Evidence

### Fichiers ajoutés

- `src/components/layout/BottomTabBar.tsx`
- `src/components/layout/MoreSheet.tsx`
- `src/components/layout/__tests__/BottomTabBar.test.tsx` (19 specs)
- `e2e/mobile-ios/bottom-tab-bar.spec.ts` (6 specs iPhone WebKit)
- `docs/prs/PR-BETA-6-bottom-tab-bar-report.md` (rapport complet)

### Fichiers modifiés

- `src/app/[locale]/app/layout.tsx` (mount + `pb-24 md:py-12`)
- `src/components/layout/HeaderNav.tsx` (court-circuit variant=app)
- `src/components/layout/__tests__/HeaderNav.test.tsx` (assert drawer absence)
- `messages/{fr-BE,en,nl-BE,de-DE,es-ES}.json` (+24 keys × 5 locales)

### Patterns techniques

- **Scroll lock iOS** : `position: fixed` + scrollY snapshot/restore (parité THI-250)
- **Portal MoreSheet** : escape stacking contexts (sticky header + bar backdrop-blur)
- **Active tab** : `usePathname()` exact match `/app` + startsWith pour sub-routes
- **Safe area** : `pb-[env(safe-area-inset-bottom)]` sur la bar + `pb-24` sur main
- **Liquid Glass** : `bg-background/85 backdrop-blur-xl` (Apple HIG light)

## Test plan

- [ ] CI verts (Lint / Typecheck / Tests / E2E / Security / Build)
- [ ] Sourcery review silent sur dernier commit
- [ ] Preview Vercel : tester sur iPhone réel via QR code
- [ ] Smoke test iPhone réel (checklist 10 points dans le rapport)
  - [ ] 5 tabs visibles sur `/app`, hamburger absent
  - [ ] Active state switch correct entre tabs
  - [ ] More sheet ouvre/ferme (tap / backdrop / X / Escape)
  - [ ] safe-area-inset-bottom respecté (home indicator visible)
  - [ ] Drawer marketing toujours fonctionnel sur landing `/`
- [ ] Lighthouse mobile perf ≥ 95
- [ ] Pas de régression UI desktop (≥ 768px : bar `md:hidden`)

## Notes hors-scope (à traiter séparément)

- Sourcery warning `e2e/mobile-ios/dashboard.spec.ts:89` (use-object-destructuring) — fichier non modifié par BETA-6, ticket dédié
- Code mort `{variant === 'app' && …}` dans le drawer HeaderNav (inatteignable) — PR cleanup follow-up
- Drag-to-dismiss MoreSheet — backdrop tap + Escape suffisent pour BETA-6, follow-up Linear si feedback @thierry

🤖 Generated with [Claude Code](https://claude.com/claude-code)