### PR TITLE
chore(beta-cleanup): ROADMAP sync + dead drawer cleanup + bills badges align + i18n callback fix (THI-279)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,5 +1,14 @@
 # Roadmap — Ankora
 
+**Update 25 mai 2026** : Sprint Beta J-16 — **PR-BETA-1 et PR-BETA-6 mergées**.
+
+- PR-BETA-1 (THI-265, commit [`5232dda`](https://github.com/thierryvm/ankora/commit/5232dda), PR [#179](https://github.com/thierryvm/ankora/pull/179)) : refactor visuel `/app/charges` — grid desktop + cards mobile.
+- PR-BETA-6 (THI-277, commit [`0cdf924`](https://github.com/thierryvm/ankora/commit/0cdf924), PR [#182](https://github.com/thierryvm/ankora/pull/182)) : Apple HIG Bottom Tab Bar mobile + persistente authenticated cross-destinations (cockpit / admin / faq / glossaire / legal). 5 commits squashés : v1 + Option A v3 persistence + addendum GDPR Cookie/Footer + hotfix #2 server-client boundary + hotfix #3 anti-doublon nav burger ↔ bar + hotfix #4 Footer nav hidden mobile + ScrollToTop lift. Cf. [`docs/prs/PR-BETA-6-bottom-tab-bar-report.md`](./prs/PR-BETA-6-bottom-tab-bar-report.md).
+
+Sprint Beta restantes : **3 PR** — PR-BETA-3 (THI-267 Capacité tryptique ADR-009), PR-BETA-4 (THI-268 Dashboard 3 couches, dépend mockups Claude Design #3), PR-BETA-5 (THI-269 Landing nav refactor — **scope réduit** à LocaleToggle FR/EN + Auth-aware CTAs : le burger marketing duplicate-nav est déjà neutralisé conditionnellement par BETA-6 hotfix #3).
+
+**Backlog Beta** : THI-279 i18n callback OAuth (~30 min, P3 medium — bug pré-existant, non régression BETA-6, traité dans `chore/beta-cleanup-roadmap-polish`).
+
 **Update 24 mai 2026** : Sprint Beta J-17 — **PR-BETA-2 mergée** (commit [`011401f`](https://github.com/thierryvm/ankora/commit/011401f), PR [#181](https://github.com/thierryvm/ankora/pull/181)). Couvre THI-266 (i18n perf desktop : retrait `router.refresh()` redondant + landing FR/EN drift + 3 E2E unfixme'd) **+** THI-276 intégrée in-place (iPhone Safari RSC cache fix : `revalidatePath('/', 'layout')` server-side dans `setLocaleAction`). Sprint Beta restantes après ce merge : **3 PR** — PR-BETA-6 (THI-277 Bottom Tab Bar mobile + sheet "Plus"), puis PR-BETA-3 (THI-267 Capacité tryptique ADR-009), puis PR-BETA-4 (THI-268 Dashboard 3 couches). PR-BETA-5+7 (THI-269 Landing nav refactor) **différable v1.0** fin juin si débordement Beta. Cf. CHANGELOG.md §"2026-05-24 — PR-BETA-2" + [`docs/prs/PR-BETA-2-i18n-perf-phase-b-report.md`](./prs/PR-BETA-2-i18n-perf-phase-b-report.md).
 
 **Update 17 mai 2026** : pivot scope explicite — **Beta (10 juin) = MVP fonctionnel utilisable**, **V1.0 publique (fin juin) = cible Monarch Money level**, **V1.1 post-launch = parité Monarch complète si gap résiduel**. Voir [§Trois jalons](#trois-jalons-verrouillés--v11-post-launch) et nouvelle section [§PR-D6/D7 candidates](#pr-d6d7--dashboard-cockpit-v10-candidates-post-pr-d5-mobile-ios) (17 tickets Linear capturés, projet Ankora créé).

--- a/docs/prs/PR-BETA-CLEANUP-report.md
+++ b/docs/prs/PR-BETA-CLEANUP-report.md
@@ -1,0 +1,169 @@
+# PR-BETA-CLEANUP — Chore ROADMAP + Polish UI + Fix i18n callback
+
+**Linear** : THI-279 (closed at merge)
+**Branch** : `chore/beta-cleanup-roadmap-polish`
+**Date** : 2026-05-25 (J-16 Sprint Beta)
+**Pilote** : @cc-ankora (Claude Opus 4.7)
+**Demandeur** : @cowork brief 2026-05-25 — handoff @cc-ankora pour fermer le sillage post-BETA-6 propre
+
+---
+
+## TL;DR
+
+PR mini groupée — **4 items hygiène + polish** dans une seule branche pour gagner du temps CI :
+
+1. ROADMAP sync (PR-BETA-1 + PR-BETA-6 + THI-279 backlog)
+2. Cleanup code mort drawer `variant === 'app'` dans HeaderNav + prop `isAdmin` orpheline
+3. Fix alignement badges « Prochaines factures » via grid 3 colonnes
+4. Fix THI-279 i18n callback OAuth — préservation locale dans la redirect
+
+**1254/1254 vitest pass** (+8 vs PR-BETA-6) — lint 0 erreurs, typecheck 0, build OK.
+
+---
+
+## Item 1 — ROADMAP sync (commit `e738e9e`)
+
+Ajout d'un bloc « Update 25 mai 2026 » en tête de `docs/ROADMAP.md` :
+
+- PR-BETA-1 (THI-265, `5232dda`, #179) trackée comme mergée — refactor visuel `/app/charges`
+- PR-BETA-6 (THI-277, `0cdf924`, #182) trackée comme mergée — Apple HIG Bottom Tab Bar + 5 hotfix
+- Sprint Beta restantes annoncées : **3 PR** — PR-BETA-3 / PR-BETA-4 / PR-BETA-5 (scope réduit)
+- THI-279 i18n callback OAuth ajoutée au backlog Beta
+
+Aligne le repo sur la doctrine `CLAUDE.md` Ankora §"Synchronisation ROADMAP ↔ repo (règle durable)".
+
+## Item 2 — Cleanup HeaderNav (commit `25b6f52`)
+
+Depuis PR-BETA-6 hotfix #1, le `shouldRenderMobileTrigger` gate a rendu le bloc `{variant === 'app' && (…)}` du drawer **inatteignable** (le hamburger trigger + portail drawer ne sont plus rendus pour le variant app). Le bloc était du code mort doublonnant la BottomTabBar's More sheet.
+
+### Fichiers
+
+- ✏️ `src/components/layout/HeaderNav.tsx` : suppression du bloc (~70 lignes) + retrait de la prop `isAdmin` orpheline + JSDoc breadcrumb
+- ✏️ `src/components/layout/Header.tsx` : retrait du forward `isAdmin={showAdminLink}` (le desktop admin link continue d'utiliser `showAdminLink` directement)
+- ✏️ `src/components/layout/__tests__/Header.test.tsx` : retrait des 3 specs `data-is-admin` forwarding (couvert par MoreSheet test suite)
+- ✏️ `src/components/layout/__tests__/HeaderNav.test.tsx` : renommage describe + tightening des specs anti-régression
+
+**Diff** : 4 fichiers, +32 / −112 lignes.
+
+## Item 3 — Badge alignment Prochaines factures (commit `70f42cb`)
+
+### Bug
+
+Smoke iPhone @thierry 25/05 sur cockpit `/app` « THIS WEEK 15 bills » : les chips « In 7 days » dérivent horizontalement entre items adjacents. Cause = `flex justify-between` avec chip + amount dans un sibling `shrink-0` du label `min-w-0` → le X du chip varie avec la largeur du label adjacent.
+
+### Fix
+
+Refactor `<li>` en **grid 3 colonnes** :
+
+- Col 1 (label + date) : `minmax(0, 1fr)` — préserve la troncature
+- Col 2 (chip jour-count) : `auto` + `min-w-24` (6rem) → couvre tous les strings i18n (FR « En retard de 365 jours » ≈ 18 chars, EN « 365 days overdue » ≈ 16 chars) + `inline-flex justify-center` pour centrer
+- Col 3 (montant) : `auto` + `min-w-18` (4.5rem) + `text-right` → alignement à droite cohérent
+
+Les classes `tabular-nums` sont préservées sur les 2 blocs numériques pour la stabilité des chiffres.
+
+### Fichier
+
+- ✏️ `src/components/dashboard/ProchainesFacturesCard.tsx` : 1 fichier, +26 / −15 lignes
+
+**Pas de nouveau test** — changement visuel/contractuel, le `ProchainesFacturesCard.test.tsx` existant continue de passer (vérifié dans suite complète).
+
+## Item 4 — Fix THI-279 i18n callback OAuth (commit `e30b987`)
+
+### Bug
+
+Smoke @thierry 25/05 sur PR #182 preview : login OAuth Google depuis `/en` (ou autre locale non-default) → callback → URL collapse vers `/en?code=…` (raw landing avec le code OAuth toujours présent) au lieu de `/en/app`.
+
+### Cause root
+
+`src/app/auth/callback/route.ts` faisait `NextResponse.redirect(new URL('/app', request.url))` **sans aucune connaissance de la locale**. Le proxy next-intl tentait ensuite de rerouter `/app` mais le cookie/locale state était mal préservé pendant le bounce.
+
+### Fix
+
+Lecture du cookie `NEXT_LOCALE` (set par next-intl + `setLocaleAction` via LocaleSwitcher) au début du `GET` handler, validation contre `routing.locales`, et préfixe `/<locale>` sur **tous** les targets de redirect (sauf default `fr-BE` per `localePrefix: 'as-needed'`).
+
+Couvre :
+
+- `/app` et `/onboarding` (happy path)
+- `/login?error=missing_code` (pas de code)
+- `/login?error=exchange_failed` (Supabase code exchange error)
+- `/login` (post-exchange `getUser` returned null)
+- Le `?next=…` query param (target safe-redirect) est aussi préfixé, le guard same-origin existant préservé.
+
+### Fichiers
+
+- ✏️ `src/app/auth/callback/route.ts` : ajout `resolveLocale()` + `localiseTarget()` helpers + JSDoc complet, application sur les 5 paths de redirect
+- ➕ `src/app/auth/callback/__tests__/route.test.ts` : nouveau, **10 specs** couvrant la matrice complète (fr-BE unprefixed, EN/DE-DE prefixed, no cookie → default, spoofed cookie → default, onboarding branch, next-param prefix, protocol-relative next rejection, 3 error branches)
+
+**Diff** : 2 fichiers, +207 / −4 lignes.
+
+### Limite connue (à smoke test prod)
+
+Cette fix assume que l'OAuth roundtrip atteint bien `/auth/callback`. Si la **config Supabase Google OAuth Console** redirect URL pointe ailleurs (ex: `/`), le code ne tourne jamais — c'est un bug infra séparé. Smoke step ajoutée ci-dessous pour @thierry post-merge.
+
+---
+
+## Quality gates
+
+```text
+npm run lint              → 0 erreurs (6 warnings pré-existants hors scope)
+npm run lint:use-server   → 0 erreurs
+npm run typecheck         → 0 erreurs
+npm run test (1254 tests) → 100% pass — 102 files, 24.8 s
+npm run build             → succès, 0 erreur
+```
+
+**+8 tests Vitest** vs PR-BETA-6 livré (10 callback specs − 2 specs admin forwarding retirées).
+
+---
+
+## Smoke test à faire @thierry POST-merge sur preview Vercel
+
+### Visual
+
+- [ ] Cockpit `/app` (mobile iPhone réel) → assert badges chip alignés verticalement (« In 7 days » sous « In 3 days » sous « Today » → même X)
+- [ ] Montants alignés à droite cohérents (« €1,234.00 » sous « €56.00 » alignés sur le edge droit)
+
+### i18n callback OAuth
+
+- [ ] Login depuis `/en` → après OAuth Google → assert URL = `/en/app` (PAS `/en?code=…`)
+- [ ] Login depuis `/` (FR default) → après OAuth → assert URL = `/app` (sans préfixe)
+- [ ] Login depuis `/de-DE` → après OAuth → assert URL = `/de-DE/app`
+- [ ] First-time signup → onboarding flow respecte la locale (`/en/onboarding`)
+
+### ⚠️ Si callback fix ne marche pas en prod
+
+Vérifier la config **Supabase Dashboard → Authentication → URL Configuration** :
+
+- Site URL : `https://ankora.be`
+- Redirect URLs : doit contenir `https://ankora.be/auth/callback` (PAS `https://ankora.be/*`)
+
+Si la config est `/*` ou `/`, le bug persiste — la fix code-side est sans effet. Ticket infra séparé requis.
+
+---
+
+## DoD 5/5
+
+| #   | Critère          | Status | Preuve                                                   |
+| --- | ---------------- | ------ | -------------------------------------------------------- |
+| 1   | CI verts         | ⏳     | À vérifier sur PR ouverte (lint/typecheck/test local ✅) |
+| 2   | Sourcery silent  | ⏳     | À vérifier post-push                                     |
+| 3   | Reviews approved | ⏳     | @thierry valide                                          |
+| 4   | 0 conflit main   | ✅     | Branche basée sur `0cdf924` (HEAD main 25/05)            |
+| 5   | Rapport livré    | ✅     | Ce fichier                                               |
+
+---
+
+## Linkage Linear
+
+- **THI-279** i18n callback OAuth → **Done** au merge (livré item #4)
+- **THI-265** PR-BETA-1 → déjà Done (trackée maintenant dans ROADMAP item #1)
+- **THI-277** PR-BETA-6 → déjà Done (trackée maintenant dans ROADMAP item #1)
+
+---
+
+## Refs
+
+- Rapport CC Ankora 25/05 sur PR-BETA-6 §"Dette doctrinale + Dette technique"
+- Prompt @cowork PR-BETA-CLEANUP 2026-05-25 13:55
+- Capture @thierry badges désalignés cockpit `/app` (25/05)
+- Smoke @thierry langue switch après OAuth (25/05)

--- a/src/app/auth/callback/__tests__/route.test.ts
+++ b/src/app/auth/callback/__tests__/route.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * PR-BETA-CLEANUP (THI-279, 2026-05-25) — callback locale preservation.
+ *
+ * Specs lock the contract that the OAuth redirect URL carries the locale
+ * prefix the visitor was on before clicking "Sign in". Without it, a
+ * visitor coming from `/en` lands back on the landing (`/en?code=…`) after
+ * Supabase Google OAuth instead of `/en/app`, because `NextResponse.redirect`
+ * has no implicit locale awareness — see incident smoke @thierry on
+ * PR #182 preview (2026-05-25).
+ *
+ * Cookies / Supabase / Next types are all stubbed so the route can be
+ * exercised without a real Supabase instance. Each spec controls:
+ *   - `NEXT_LOCALE` cookie value via `setLocaleCookie()`
+ *   - Supabase session + profile state via `setSupabaseFixtures()`
+ *   - Query string (`code`, `next`) via the input URL
+ */
+
+const cookieRef = { value: undefined as string | undefined };
+
+vi.mock('next/headers', () => ({
+  cookies: async () => ({
+    get: (name: string) =>
+      name === 'NEXT_LOCALE' && cookieRef.value ? { value: cookieRef.value } : undefined,
+  }),
+}));
+
+// Stub Supabase to fully control the auth flow without env / network.
+type SupabaseFixtures = {
+  exchangeError: { message: string } | null;
+  userId: string | null;
+  onboardedAt: string | null;
+};
+
+const supabaseRef: SupabaseFixtures = {
+  exchangeError: null,
+  userId: 'user-thierry',
+  onboardedAt: '2026-04-23T00:00:00.000Z',
+};
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: async () => ({
+    auth: {
+      exchangeCodeForSession: vi.fn(async () => ({ error: supabaseRef.exchangeError })),
+      getUser: vi.fn(async () => ({
+        data: { user: supabaseRef.userId ? { id: supabaseRef.userId } : null },
+      })),
+    },
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => ({
+            data: supabaseRef.onboardedAt ? { onboarded_at: supabaseRef.onboardedAt } : null,
+          }),
+        }),
+      }),
+    }),
+  }),
+}));
+
+import { GET } from '../route';
+
+function setLocaleCookie(locale: string | undefined): void {
+  cookieRef.value = locale;
+}
+
+function setSupabaseFixtures(fixtures: Partial<SupabaseFixtures>): void {
+  Object.assign(supabaseRef, fixtures);
+}
+
+function buildRequest(search: string): import('next/server').NextRequest {
+  // Minimal NextRequest shim — the route handler only uses `request.url`.
+  return { url: `https://ankora.be/auth/callback${search}` } as import('next/server').NextRequest;
+}
+
+beforeEach(() => {
+  cookieRef.value = undefined;
+  Object.assign(supabaseRef, {
+    exchangeError: null,
+    userId: 'user-thierry',
+    onboardedAt: '2026-04-23T00:00:00.000Z',
+  } satisfies SupabaseFixtures);
+});
+
+describe('auth/callback — locale preservation (PR-BETA-CLEANUP / THI-279)', () => {
+  it('redirects to /app (unprefixed) when the visitor was on the default locale fr-BE', async () => {
+    setLocaleCookie('fr-BE');
+    const response = await GET(buildRequest('?code=test-code'));
+    expect(response.headers.get('location')).toBe('https://ankora.be/app');
+  });
+
+  it('redirects to /en/app when the visitor was on EN before OAuth', async () => {
+    setLocaleCookie('en');
+    const response = await GET(buildRequest('?code=test-code'));
+    expect(response.headers.get('location')).toBe('https://ankora.be/en/app');
+  });
+
+  it('redirects to /de-DE/app when the visitor was on DE before OAuth', async () => {
+    setLocaleCookie('de-DE');
+    const response = await GET(buildRequest('?code=test-code'));
+    expect(response.headers.get('location')).toBe('https://ankora.be/de-DE/app');
+  });
+
+  it('falls back to the default locale fr-BE (unprefixed) when no cookie is present', async () => {
+    setLocaleCookie(undefined);
+    const response = await GET(buildRequest('?code=test-code'));
+    expect(response.headers.get('location')).toBe('https://ankora.be/app');
+  });
+
+  it('rejects a spoofed locale cookie and falls back to fr-BE', async () => {
+    setLocaleCookie('zz-ZZ');
+    const response = await GET(buildRequest('?code=test-code'));
+    expect(response.headers.get('location')).toBe('https://ankora.be/app');
+  });
+
+  it('prefixes the /onboarding target for a fresh non-onboarded user', async () => {
+    setLocaleCookie('en');
+    setSupabaseFixtures({ onboardedAt: null });
+    const response = await GET(buildRequest('?code=test-code'));
+    expect(response.headers.get('location')).toBe('https://ankora.be/en/onboarding');
+  });
+
+  it('honours the safe `next` query param and prefixes it with the locale', async () => {
+    setLocaleCookie('en');
+    const response = await GET(buildRequest('?code=test-code&next=/app/settings'));
+    expect(response.headers.get('location')).toBe('https://ankora.be/en/app/settings');
+  });
+
+  it('rejects a protocol-relative `next` and falls back to /app', async () => {
+    setLocaleCookie('en');
+    const response = await GET(buildRequest('?code=test-code&next=//evil.example.com'));
+    expect(response.headers.get('location')).toBe('https://ankora.be/en/app');
+  });
+
+  it('prefixes the /login error redirect when the code is missing', async () => {
+    setLocaleCookie('en');
+    const response = await GET(buildRequest(''));
+    expect(response.headers.get('location')).toBe('https://ankora.be/en/login?error=missing_code');
+  });
+
+  it('prefixes the /login redirect when the Supabase code exchange fails', async () => {
+    setLocaleCookie('en');
+    setSupabaseFixtures({ exchangeError: { message: 'invalid_grant' } });
+    const response = await GET(buildRequest('?code=bad-code'));
+    expect(response.headers.get('location')).toBe(
+      'https://ankora.be/en/login?error=exchange_failed',
+    );
+  });
+
+  it('prefixes the /login redirect when getUser returns null', async () => {
+    setLocaleCookie('en');
+    setSupabaseFixtures({ userId: null });
+    const response = await GET(buildRequest('?code=test-code'));
+    expect(response.headers.get('location')).toBe('https://ankora.be/en/login');
+  });
+});

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,22 +1,68 @@
+import { cookies } from 'next/headers';
 import { NextResponse, type NextRequest } from 'next/server';
 
 import { createClient } from '@/lib/supabase/server';
+import { routing, type Locale } from '@/i18n/routing';
+
+/**
+ * Resolve the locale to apply on the post-OAuth redirect.
+ *
+ * Reads the `NEXT_LOCALE` cookie (set by next-intl + by `setLocaleAction`
+ * via the LocaleSwitcher). The Supabase OAuth roundtrip preserves browser
+ * cookies (the Google redirect URL stays on the same eTLD+1 and the cookie
+ * is `SameSite=Lax` — see `src/i18n/routing.ts`), so the locale the visitor
+ * picked BEFORE clicking "Sign in" survives the external hop.
+ *
+ * Falls back to `routing.defaultLocale` (fr-BE) if the cookie is missing or
+ * carries an unknown value. The TS type guard rules out a spoofed cookie.
+ */
+async function resolveLocale(): Promise<Locale> {
+  const cookieStore = await cookies();
+  const raw = cookieStore.get('NEXT_LOCALE')?.value;
+  const candidates: readonly string[] = routing.locales;
+  if (raw && candidates.includes(raw)) {
+    return raw as Locale;
+  }
+  return routing.defaultLocale;
+}
+
+/**
+ * Apply the `localePrefix: 'as-needed'` rule for the redirect target.
+ *
+ * `routing.defaultLocale` (fr-BE) renders unprefixed (`/app`, `/onboarding`).
+ * Every other locale receives an explicit `/<locale>` prefix
+ * (`/en/app`, `/de-DE/onboarding`, …) so the next-intl proxy resolves the
+ * right page without bouncing through a 302 that strips/repaints the locale
+ * cookie mid-flight. Cf. THI-279 (PR-BETA-CLEANUP, 2026-05-25): without
+ * this prefix the post-login URL collapsed to `/en?code=…` when the
+ * visitor signed in from an EN landing — the bar mount and the cockpit
+ * never reached the browser.
+ */
+function localiseTarget(locale: Locale, target: string): string {
+  if (locale === routing.defaultLocale) return target;
+  return `/${locale}${target}`;
+}
 
 export async function GET(request: NextRequest) {
   const url = new URL(request.url);
   const code = url.searchParams.get('code');
   const rawNext = url.searchParams.get('next');
   const next = rawNext && rawNext.startsWith('/') && !rawNext.startsWith('//') ? rawNext : '/app';
+  const locale = await resolveLocale();
 
   if (!code) {
-    return NextResponse.redirect(new URL('/login?error=missing_code', request.url));
+    return NextResponse.redirect(
+      new URL(localiseTarget(locale, '/login?error=missing_code'), request.url),
+    );
   }
 
   const supabase = await createClient();
   const { error } = await supabase.auth.exchangeCodeForSession(code);
 
   if (error) {
-    return NextResponse.redirect(new URL('/login?error=exchange_failed', request.url));
+    return NextResponse.redirect(
+      new URL(localiseTarget(locale, '/login?error=exchange_failed'), request.url),
+    );
   }
 
   const {
@@ -24,7 +70,7 @@ export async function GET(request: NextRequest) {
   } = await supabase.auth.getUser();
 
   if (!user) {
-    return NextResponse.redirect(new URL('/login', request.url));
+    return NextResponse.redirect(new URL(localiseTarget(locale, '/login'), request.url));
   }
 
   const { data: profile } = await supabase
@@ -34,5 +80,5 @@ export async function GET(request: NextRequest) {
     .maybeSingle();
 
   const target = profile?.onboarded_at ? next : '/onboarding';
-  return NextResponse.redirect(new URL(target, request.url));
+  return NextResponse.redirect(new URL(localiseTarget(locale, target), request.url));
 }

--- a/src/components/dashboard/ProchainesFacturesCard.tsx
+++ b/src/components/dashboard/ProchainesFacturesCard.tsx
@@ -190,11 +190,24 @@ function Bucket({
           {formatCurrency(total, locale)}
         </p>
       </header>
+      {/*
+       * PR-BETA-CLEANUP (THI-279, 2026-05-25): switched the row layout
+       * from `flex items-center justify-between` to a 3-column grid so
+       * the day-count chip and the amount line up vertically across
+       * every row. With the old flex layout, both the chip and the
+       * amount were `shrink-0` siblings of the `min-w-0` label block,
+       * so their X position drifted by the width of the surrounding
+       * content (long label vs short label, "In 365 days" vs "Today",
+       * "€9,999.00" vs "€12.50"). Smoke iPhone @thierry 2026-05-25
+       * showed visible mis-alignment on the cockpit /app "this week
+       * 15 bills" list. Fixed columns + min-w on chip + right-aligned
+       * amount lock the visual rhythm regardless of content width.
+       */}
       <ul className="divide-border divide-y rounded-md border">
         {items.map((item) => (
           <li
             key={`${item.charge.id}-${item.dueDateIso}`}
-            className="flex items-center justify-between gap-3 px-3 py-2"
+            className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-3 px-3 py-2"
             data-testid={`prochaines-factures-row-${item.charge.id}`}
           >
             <div className="min-w-0">
@@ -203,20 +216,18 @@ function Bucket({
                 {formatDate(item.dueDateIso, locale, 'medium')}
               </p>
             </div>
-            <div className="flex shrink-0 items-center gap-2">
-              <span
-                className={`rounded-full px-2 py-0.5 text-[10px] font-semibold tabular-nums ${classes.chip}`}
-              >
-                {item.daysUntilDue < 0
-                  ? t('daysOverdue', { days: Math.abs(item.daysUntilDue) })
-                  : item.daysUntilDue === 0
-                    ? t('dueToday')
-                    : t('daysUntil', { days: item.daysUntilDue })}
-              </span>
-              <span className="text-foreground text-sm font-semibold tabular-nums">
-                {formatCurrency(item.charge.amount, locale)}
-              </span>
-            </div>
+            <span
+              className={`inline-flex min-w-24 justify-center rounded-full px-2 py-0.5 text-[10px] font-semibold tabular-nums ${classes.chip}`}
+            >
+              {item.daysUntilDue < 0
+                ? t('daysOverdue', { days: Math.abs(item.daysUntilDue) })
+                : item.daysUntilDue === 0
+                  ? t('dueToday')
+                  : t('daysUntil', { days: item.daysUntilDue })}
+            </span>
+            <span className="text-foreground min-w-18 text-right text-sm font-semibold tabular-nums">
+              {formatCurrency(item.charge.amount, locale)}
+            </span>
           </li>
         ))}
       </ul>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -146,10 +146,14 @@ export async function Header({ variant = 'marketing', isAuthenticated }: HeaderP
             </Button>
           )}
 
+          {/* PR-BETA-CLEANUP (THI-279, 2026-05-25): `isAdmin` no longer
+              flows into HeaderNav — the prop only fed the dead `variant
+              === 'app'` block of the drawer that BETA-6 hotfix #1 made
+              unreachable. The desktop admin link above still uses
+              `showAdminLink` directly. */}
           <HeaderNav
             variant={variant}
             isAuthenticated={resolvedAuth}
-            isAdmin={showAdminLink}
             hideMobileTrigger={hideMobileTrigger}
           />
         </div>

--- a/src/components/layout/HeaderNav.tsx
+++ b/src/components/layout/HeaderNav.tsx
@@ -32,11 +32,6 @@ type HeaderNavProps = {
   // visitor already has a session — keeps the mobile UX consistent with
   // the desktop CTAs.
   isAuthenticated?: boolean;
-  // PR-UX-1 — surfaces the admin link inside the cockpit drawer when the
-  // signed-in user is an admin. Server-resolved upstream (`isAdmin()` in
-  // `Header.tsx`) so the client never trusts itself. Default `false`
-  // keeps marketing call-sites unchanged.
-  isAdmin?: boolean;
   // PR-BETA-6 hotfix #3 (THI-277, 2026-05-25) — duplicate-nav fix on
   // mobile. When `Header.tsx` knows the persistent BottomTabBar will
   // render for this request (authenticated visitor on a non-excluded
@@ -51,7 +46,6 @@ type HeaderNavProps = {
 export function HeaderNav({
   variant = 'marketing',
   isAuthenticated = false,
-  isAdmin = false,
   hideMobileTrigger = false,
 }: HeaderNavProps) {
   const t = useTranslations('common');
@@ -318,73 +312,17 @@ export function HeaderNav({
             </>
           )}
 
-          {variant === 'app' && (
-            <>
-              <Link
-                href="/app"
-                onClick={handleDrawerClose}
-                className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-              >
-                {t('nav.dashboard')}
-              </Link>
-              <Link
-                href="/app/accounts"
-                onClick={handleDrawerClose}
-                className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-              >
-                {t('nav.accounts')}
-              </Link>
-              <Link
-                href="/app/charges"
-                onClick={handleDrawerClose}
-                className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-              >
-                {t('nav.charges')}
-              </Link>
-              <Link
-                href="/app/expenses"
-                onClick={handleDrawerClose}
-                className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-              >
-                {t('nav.expenses')}
-              </Link>
-              <Link
-                href="/app/simulator"
-                onClick={handleDrawerClose}
-                className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-              >
-                {t('nav.simulator')}
-              </Link>
-              <Link
-                href="/app/settings"
-                onClick={handleDrawerClose}
-                className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 block rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-              >
-                {t('nav.settings')}
-              </Link>
-              {/* PR-UX-1 — admin entry mirrors the desktop cockpit nav
-                    (Header.tsx). Route is `/admin` (not `/app/admin`).
-                    Amber dot uses `bg-amber-700` for WCAG SC 1.4.11 parity
-                    in both themes (≈ 4.46:1 light, ≈ 3.32:1 dark). Bumped
-                    from amber-600 (failed AA in light mode at ≈ 2.91:1).
-                    `aria-label` carries the "founder only" context so AT
-                    users get the same hint as desktop. */}
-              {isAdmin && (
-                <Link
-                  href="/admin"
-                  onClick={handleDrawerClose}
-                  aria-label={t('nav.adminAriaLabel')}
-                  className="text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-brand-600 flex items-center justify-between rounded-md px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-                >
-                  <span>{t('nav.admin')}</span>
-                  <span
-                    aria-hidden="true"
-                    className="inline-block h-1.5 w-1.5 rounded-full bg-amber-700"
-                  />
-                </Link>
-              )}
-            </>
-          )}
+          {/*
+           * PR-BETA-CLEANUP (THI-279, 2026-05-25): the previous
+           * `{variant === 'app' && (…)}` block that mirrored the cockpit
+           * nav (Dashboard / Accounts / Charges / Expenses / Simulator /
+           * Settings / Admin) inside this drawer has been removed. Since
+           * PR-BETA-6 hotfix #1 the drawer + hamburger trigger are
+           * short-circuited for the app variant (`shouldRenderMobileTrigger`
+           * above), so this block was unreachable. The canonical
+           * authenticated mobile-nav surface is the persistent
+           * BottomTabBar + its More sheet — both live elsewhere.
+           */}
         </div>
 
         {/* Drawer footer - theme toggle + locale switcher.

--- a/src/components/layout/__tests__/Header.test.tsx
+++ b/src/components/layout/__tests__/Header.test.tsx
@@ -39,19 +39,16 @@ vi.mock('../HeaderNav', () => ({
   HeaderNav: ({
     variant,
     isAuthenticated,
-    isAdmin,
     hideMobileTrigger,
   }: {
     variant: string;
     isAuthenticated?: boolean;
-    isAdmin?: boolean;
     hideMobileTrigger?: boolean;
   }) => (
     <div
       data-testid="header-nav-mock"
       data-variant={variant}
       data-is-authenticated={String(isAuthenticated ?? false)}
-      data-is-admin={String(isAdmin ?? false)}
       data-hide-mobile-trigger={String(hideMobileTrigger ?? false)}
     />
   ),
@@ -208,30 +205,12 @@ describe('<Header />', () => {
     expect(screen.queryByRole('link', { name: /Admin/ })).not.toBeInTheDocument();
   });
 
-  // PR-UX-1 — admin parity desktop ↔ mobile drawer: Header must forward the
-  // server-resolved `isAdmin` flag into HeaderNav so the cockpit drawer
-  // mirrors the desktop admin link without a duplicate server round-trip.
-  it('app variant + isAdmin=true forwards isAdmin to HeaderNav (mobile drawer parity)', async () => {
-    setIsAdmin(true);
-    await renderHeader({ variant: 'app', isAuthenticated: true });
-    const drawer = screen.getByTestId('header-nav-mock');
-    expect(drawer).toHaveAttribute('data-variant', 'app');
-    expect(drawer).toHaveAttribute('data-is-admin', 'true');
-  });
-
-  it('app variant + isAdmin=false forwards isAdmin=false to HeaderNav', async () => {
-    setIsAdmin(false);
-    await renderHeader({ variant: 'app', isAuthenticated: true });
-    expect(screen.getByTestId('header-nav-mock')).toHaveAttribute('data-is-admin', 'false');
-  });
-
-  it('marketing variant never forwards isAdmin=true (server skips the check)', async () => {
-    setIsAdmin(true);
-    await renderHeader({ variant: 'marketing', isAuthenticated: true });
-    // Marketing pages are public — `showAdminLink` short-circuits before
-    // calling isAdmin(), so the drawer always gets isAdmin=false.
-    expect(screen.getByTestId('header-nav-mock')).toHaveAttribute('data-is-admin', 'false');
-  });
+  // PR-BETA-CLEANUP (THI-279, 2026-05-25): the `isAdmin` prop forwarding to
+  // HeaderNav was removed — its sole consumer was the dead `variant === 'app'`
+  // drawer block (unreachable since BETA-6 hotfix #1). The desktop admin
+  // link covered above is now the only Header.tsx surface that needs
+  // `showAdminLink`; the mobile admin entry lives in the BottomTabBar's
+  // More sheet (`MoreSheet.test.tsx` / `more-sheet-link-admin`).
 
   // PR-BETA-6 hotfix #3 + hotfix #4 — duplicate-nav fix on mobile.
   // Header forwards `hideMobileTrigger` by delegating to

--- a/src/components/layout/__tests__/HeaderNav.test.tsx
+++ b/src/components/layout/__tests__/HeaderNav.test.tsx
@@ -251,23 +251,22 @@ describe('<HeaderNav /> mobile drawer — THI-251 safe-area inset on PWA standal
   });
 });
 
-describe('<HeaderNav /> mobile drawer — PR-UX-1 / PR-BETA-6 admin entry handoff', () => {
-  // PR-BETA-6 (THI-277): admin entry handoff. The app-variant drawer no
-  // longer renders an Admin link because the drawer itself is short-
-  // circuited; the admin entry is now surfaced through the BottomTabBar's
-  // "More" sheet (see BottomTabBar.test.tsx / MoreSheet covers). These two
-  // assertions guarantee the drawer-side never re-grows the entry by
-  // mistake.
-  it('app variant: drawer never rendered, no Admin entry to assert', () => {
-    render(<HeaderNav variant="app" isAuthenticated isAdmin />);
+describe('<HeaderNav /> — PR-BETA-CLEANUP admin entry no longer in drawer', () => {
+  // PR-BETA-CLEANUP (THI-279, 2026-05-25): the `isAdmin` prop and the
+  // dead `variant === 'app'` drawer block were removed — the persistent
+  // BottomTabBar's More sheet is now the single mobile surface for the
+  // admin entry (MoreSheet.test.tsx covers it). These specs guarantee
+  // the drawer-side never re-grows the entry by mistake.
+  it('app variant: drawer never rendered (no trigger, no admin link)', () => {
+    render(<HeaderNav variant="app" isAuthenticated />);
     expect(screen.queryByTestId('header-nav-trigger')).not.toBeInTheDocument();
     expect(
       screen.queryByRole('link', { name: 'Espace admin (réservé fondateur)' }),
     ).not.toBeInTheDocument();
   });
 
-  it('marketing variant never exposes the Admin link, even if isAdmin=true', async () => {
-    render(<HeaderNav variant="marketing" isAuthenticated isAdmin />);
+  it('marketing variant drawer never exposes the Admin link', async () => {
+    render(<HeaderNav variant="marketing" isAuthenticated />);
     await openDrawer();
     expect(
       screen.queryByRole('link', { name: 'Espace admin (réservé fondateur)' }),


### PR DESCRIPTION
## Summary

- **Item 1 — ROADMAP sync** : track PR-BETA-1 (`5232dda`, #179) + PR-BETA-6 (`0cdf924`, #182) mergées + THI-279 backlog. Doctrine `CLAUDE.md` §"Synchronisation ROADMAP ↔ repo" respectée.
- **Item 2 — HeaderNav cleanup** : suppression du bloc dead `variant === 'app'` du drawer (inatteignable depuis BETA-6 hotfix #1) + retrait prop orpheline `isAdmin` (4 fichiers, +32 / −112 lignes).
- **Item 3 — Bills badges alignment** : refactor `<li>` en grid 3 colonnes (`minmax(0,1fr)_auto_auto`) + `min-w-24` chip + `min-w-18` montant right-aligned. Fixe smoke iPhone @thierry 25/05 « THIS WEEK 15 bills » dérive horizontale.
- **Item 4 — Fix THI-279 i18n callback OAuth** : lecture cookie `NEXT_LOCALE` + préfixe `/<locale>` sur les 5 paths de redirect (`/app`, `/onboarding`, 3 variantes `/login`). +10 specs Vitest (matrice locale complète).

Closes **THI-279**.

## Linkage Linear

- THI-279 — i18n callback OAuth → Done au merge
- THI-265 (PR-BETA-1) + THI-277 (PR-BETA-6) → tracking ROADMAP rattrapé

## Self-review qualité

```text
npm run lint              → 0 erreurs (6 warnings pré-existants hors scope)
npm run lint:use-server   → 0 erreurs
npm run typecheck         → 0 erreurs
npm run test (1254 tests) → 100% pass — 102 files, 24.8s
npm run build             → succès, 0 erreur
```

**+8 tests Vitest** vs main (10 nouveaux callback specs − 2 admin forwarding retirés).

## Self-review sécurité

- Callback locale fix : validation stricte cookie contre `routing.locales` (rejet d'un cookie spoofé `zz-ZZ` → fallback fr-BE)
- `?next=…` query param : guard same-origin préservé (rejet protocol-relative `//evil.example.com`)
- Pas de nouvelle dépendance, pas de nouveau secret, pas de nouveau token CSS

## Motivation

Brief @cowork 2026-05-25 — fermer le sillage post-BETA-6 propre avant d'attaquer la prochaine grosse pièce (PR-B1 Bug reporting MVP ou Voie D Dashboard cockpit complet, arbitrage @cowork pending).

## Evidence

5 commits conventional dans cette branche :
1. `e738e9e` docs(roadmap)
2. `25b6f52` chore(layout): remove dead app drawer code from HeaderNav
3. `70f42cb` fix(dashboard): align bills badges using grid layout
4. `e30b987` fix(i18n): preserve locale on OAuth callback redirect (THI-279)
5. `a592a90` docs(prs): add PR-BETA-CLEANUP report

## Test plan

- [ ] CI verts (Lint + Typecheck + Tests + E2E + Security + Build)
- [ ] Sourcery silent sur dernier commit
- [ ] Preview Vercel déployée
- [ ] **Smoke iPhone @thierry** (post-merge) :
  - [ ] Cockpit `/app` mobile : badges « In X days » alignés verticalement entre rows
  - [ ] Montants alignés à droite cohérent
  - [ ] Login depuis `/en` → après OAuth Google → URL = `/en/app` (pas `/en?code=…`)
  - [ ] Login depuis `/` (FR default) → après OAuth → URL = `/app`
- [ ] Pas de régression desktop (badges + nav + footer)

## Limite connue THI-279

Cette fix assume que l'OAuth roundtrip atteint bien `/auth/callback`. **Si le bug i18n persiste post-merge**, vérifier la config Supabase Dashboard → Authentication → URL Configuration :
- Site URL : `https://ankora.be`
- Redirect URLs doit contenir `https://ankora.be/auth/callback` (PAS `/*` ou `/`)

Si config infra incorrecte → ticket séparé infra (hors scope code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)