### PR TITLE
feat(dashboard): Capacité Épargne Réelle tryptique ADR-009 amendement (THI-267, PR-BETA-3)

### DIFF
--- a/docs/prs/PR-BETA-3-capacite-tryptique-report.md
+++ b/docs/prs/PR-BETA-3-capacite-tryptique-report.md
@@ -1,0 +1,244 @@
+# PR-BETA-3 — Capacité d'Épargne Réelle tryptique (ADR-009 amendement)
+
+**Linear** : THI-267 — PR-BETA-3 Capacité tryptique ADR-009 amendement 09/05
+**Branch** : `feat/pr-beta-3-capacite-tryptique-adr-009`
+**Date** : 2026-05-26
+**Pilote** : @cc-ankora (Claude Opus 4.7)
+**Demandeur** : @thierry via @cowork prompt — ADR-009 amendement 2026-05-09 non implémenté en prod après reset stratégique 24/05.
+
+---
+
+## Pourquoi cette PR
+
+ADR-009 amendement 2026-05-09 (validé @thierry, statut canonique) impose le passage du KPI "Capacité d'Épargne Réelle" d'un **waterfall opaque** (Revenus / Effort / Plafond → big number) à un **tryptique pédagogique 3 concepts** :
+
+1. **Reste disponible** = Revenus − Effort financier lissé (avant la vie courante)
+2. **Reste à vivre** = budget vie courante saisi par l'user (ajustable mois par mois — R-10)
+3. **Capacité d'épargne réelle** = Reste disponible − Reste à vivre
+
+C'est le **différenciateur NORTH_STAR n°1** d'Ankora. Aucun concurrent (Monarch, YNAB, Lunch Money, Linxo, Bankin') ne calcule cette valeur. Critique pour la Beta vendable.
+
+---
+
+## Scope livré
+
+### 1. Migration SQL `workspace_settings`
+
+`supabase/migrations/20260526000001_pr_beta_3_reste_a_vivre.sql` — ajoute :
+
+- `reste_a_vivre_default numeric(12,2) NOT NULL DEFAULT 500.00`
+- `reste_a_vivre_overrides jsonb NOT NULL DEFAULT '{}'`
+- CHECK constraint `0 ≤ reste_a_vivre_default ≤ 100000` (cohérent avec Zod app-level)
+- COMMENT sur chaque colonne avec la sémantique JSONB
+
+Lookup runtime : `overrides[currentYYYYMM] ?? reste_a_vivre_default`. Pas de modif RLS — les policies table-level héritent automatiquement.
+
+### 2. Domain `capaciteEpargneReelle()` étendu
+
+`src/lib/domain/cockpit/capacite-epargne-reelle.ts` — expose désormais sur l'output :
+
+- `resteDisponible: Decimal` (= revenus − effort)
+- `resteAVivre: Decimal` (passthrough de l'input pour symétrie)
+- `capacite: Decimal` (= resteDisponible − resteAVivre)
+- Plus l'`effortFinancierLisse` et `isPositive` existants.
+
+API publique : le param `plafondQuotidien` est renommé `resteAVivre`. Le type legacy `CapaciteEpargneReelleInputLegacy` est gardé pour back-compat pendant la transition (tests existants + call-sites en marge passent toujours).
+
+### 3. Server Action `updateResteAVivreOverrideAction`
+
+`src/lib/actions/reste-a-vivre.ts` — couche complète :
+
+- `requireUserWithWorkspace()` (auth + workspace lookup)
+- `rateLimit('mutation', user:${userId})` (Upstash sliding window)
+- Zod schema `resteAVivreMonthOverrideSchema` (`monthYYYYMM` regex `\d{4}-(0[1-9]|1[0-2])`, `montant 0..100000`)
+- Read-modify-write JSONB merge (préserve les overrides des autres mois)
+- `logAuditEvent(WORKSPACE_RESTE_A_VIVRE_UPDATED, ctx, { period_yyyymm })` — **AUCUN montant** dans la metadata (PII-adjacent, même règle que `charge_payments` qui exclut `paid_amount`)
+- `revalidateDashboard()` pour refresh server-side
+
+Nouveau `AuditEvent.WORKSPACE_RESTE_A_VIVRE_UPDATED = 'workspace.reste_a_vivre_updated'` (constante TypeScript only, pas de migration DB car `audit_log.event_type` est `text` sans CHECK).
+
+### 4. Refactor `CapaciteEpargneCard`
+
+`src/components/dashboard/CapaciteEpargneCard.tsx` — refonte tryptique :
+
+```
+┌─────────────────────────────────────────────────┐
+│ Capacité d'épargne réelle  [CheckCircle2]       │
+│                                                 │
+│ + 162 €  [Info-tooltip]                         │
+│ « Tu peux mettre +162 € de côté ce mois en plus │
+│   de tes virements automatiques. Tu décides     │
+│   combien tu y mets vraiment. »                 │
+│ ──────────────────────────────────────────────  │
+│ Reste dispo  │ Reste à vivre │ Capacité épargne │
+│  662 €       │  500 € [Adj]  │ + 162 €          │
+└─────────────────────────────────────────────────┘
+```
+
+- Hero number + tooltip explicatif (au hover/focus, `aria-label` accessible)
+- Lede pédagogique interpolé (`{amount}` signed) — anti-culpabilisation R-06 respectée
+- 3 sub-stats `grid-cols-1 sm:grid-cols-3`
+- Bouton "Ajuster ce mois" inline dans le sub-stat "Reste à vivre"
+- **Waterfall PR-D3-bis supprimé** (redondant avec sub-stats + EffortFinancierCard voisine)
+
+### 5. Composant `AjusterResteAVivreDrawer`
+
+`src/components/dashboard/AjusterResteAVivreDrawer.tsx` — Client Component dédié :
+
+- Slide-from-right desktop, full-screen mobile (`h-dvh` + `sm:max-w-md`)
+- Reset draft state **synchroniquement** dans `openDrawer()` (pas dans un effet — react-hooks/set-state-in-effect satisfait)
+- Input `inputMode="decimal"` accepte virgule décimale FR (`'425,50'` → `425.5`)
+- **Helper text adaptatif** selon ratio resteAVivre/revenus :
+  - `< 15 %` → "Estimation basse. Tu peux ajuster plus tard si besoin."
+  - `> 50 %` → "Estimation haute. Ankora respecte ton budget — pas de jugement."
+  - sinon → "Estimation cohérente avec un budget belge typique."
+- ESC ferme, backdrop ferme, body scroll-lock pendant ouverture
+- Toast d'erreur sur échec Server Action (`useActionErrorTranslator`)
+- `router.refresh()` sur succès
+
+### 6. Snapshot wiring
+
+`src/lib/data/workspace-snapshot.ts` :
+
+- SELECT enrichi de `reste_a_vivre_default, reste_a_vivre_overrides`
+- Résolution `overrides[YYYY-MM] ?? default` côté snapshot (single round-trip, pas de query extra dans le page component)
+- Champ `resteAVivre: number` ajouté à `WorkspaceSnapshot`
+- `Math.max(0, …)` defensive sur la valeur finale (cohérent avec contrainte DB)
+
+### 7. i18n parity 5 locales
+
+Namespace `dashboard.capacite` étendu sur `fr-BE`, `en`, `nl-BE`, `de-DE`, `es-ES` :
+
+- `subStats.{resteDisponible, resteAVivre, capaciteEpargne, ajusterCeMois}`
+- `ledePositif` (interpolation `{amount}`)
+- `ledeNegatif`
+- `tooltip` (interpolation `{resteAVivre}`)
+- `drawer.{title, inputLabel, inputHint, helperCoherent, helperBas, helperHaut, save, cancel, errorGeneric}`
+
+Test parity exhaustif (assert présence + placeholders attendus) intégré au test file `CapaciteEpargneCard.test.tsx`.
+
+---
+
+## Tests
+
+### Unitaires Vitest (1281 tests passent globalement, dont les nouveaux)
+
+- `capacite-epargne-reelle.test.ts` — 6 nouveaux tests (resteDisponible exposé, persona @thierry, legacy alias back-compat, edge cases zero/negative, precision Decimal.js sur lissage)
+- `reste-a-vivre.test.ts` (Server Action) — 14 tests : rate-limit, Zod validation (regex YYYYMM, négatif, > 100k, zéro OK), happy path (merge JSONB, premier override, row missing, audit log sans montant, revalidate), DB read/write failures
+- `CapaciteEpargneCard.test.tsx` — réécriture complète : 3 sub-stats, fixture @thierry (662/500/162), trigger "Ajuster ce mois" rendered, lede interpolé, ledeNegatif sans culpabilisation, tooltip accessible, parity 5 locales
+- `AjusterResteAVivreDrawer.test.tsx` — 14 tests : trigger, open state, prefill, helper adaptatif (coherent/bas/haut/fallback null), live update, submit flow (Server Action call, close on success, toast on failure, disabled when invalid, comma decimal), ESC dismiss
+
+### E2E Playwright
+
+- `dashboard-cockpit-bloc2.spec.ts` mis à jour (waterfall → sub-stats, `rose` → `text-danger`)
+- `dashboard-capacite-tryptique.spec.ts` (nouveau) — 3 tests : fixture @thierry (3 sub-stats avec bonnes valeurs), drawer open + override persisté, mobile viewport 375×667 stack vertical
+
+Les E2E sont gated par `adminClientOrNull()` (skip si pas de Supabase remote configuré — pattern repo standard).
+
+---
+
+## Quality gates ✅
+
+```
+npm run lint            ✅ 0 errors (6 warnings pré-existants)
+npm run lint:use-server ✅ All files compliant
+npm run typecheck       ✅ 0 errors
+npm run test            ✅ 1281 tests passing (104 files)
+npm run build           ✅ Production build OK
+```
+
+---
+
+## Décisions techniques et arbitrages
+
+| Sujet                             | Décision                                                                                               | Justification                                                                                                                                                                                                                                          |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Signature `logAuditEvent`         | Vraie API repo `(event: AuditEventType, ctx, metadata?)` — pas la signature obsolète du prompt @cowork | Le pattern dans `settings.ts` et 16 autres call-sites le confirme. Le prompt @cowork avait une signature périmée                                                                                                                                       |
+| Suppression du waterfall          | Retiré (pas conservé en expandable)                                                                    | Redondant : `Reste disponible = Revenus − Effort` est déjà le sub-stat #1 + la card `EffortFinancierCard` voisine montre le détail effort. Garder les deux noyait l'utilisateur. ADR-009 amendement file le tryptique en remplacement, pas en addition |
+| Drawer dédié vs `EditDrawer` atom | Dédié (`AjusterResteAVivreDrawer.tsx`)                                                                 | L'atom `EditDrawer` ne modèle pas le helper text adaptatif par ratio — c'est un Field renderer générique. Forker l'atom serait pollution. Un seul cas d'usage justifie un composant dédié                                                              |
+| Reset state du draft              | Synchrone dans `openDrawer()`, pas dans `useEffect`                                                    | React 19 + `react-hooks/set-state-in-effect` lint rule bloque l'effet. Le reset au moment du clic trigger est équivalent et idiomatique                                                                                                                |
+| `resteAVivre` source              | `workspace_settings.reste_a_vivre_default` + overrides JSONB                                           | Le prompt @cowork le demande explicitement, séparé de `workspaces.vie_courante_monthly_transfer`. Concept distinct (budget vie courante ≠ montant transféré). Pour Thierry les deux valent 500€ donc UX identique pour lui                             |
+| Audit metadata                    | `{ period_yyyymm }` seul, pas de montant                                                               | Doctrine repo : amounts = PII-adjacent en financial software. Même règle que `charge_payments` qui exclut `paid_amount`                                                                                                                                |
+| Supabase types                    | Patch manuel + comment "until supabase:types is re-run"                                                | Pas d'accès local Supabase dans cette session. `npm run supabase:types` à relancer post-merge contre le projet remote                                                                                                                                  |
+| Onboarding step 3 saisie initiale | **Hors-scope** PR-BETA-3                                                                               | Le prompt @cowork l'exclut explicitement (= PR-D5 onboarding séparée). Users existants ajusteront via bouton "Ajuster ce mois"                                                                                                                         |
+| Compatibilité E2E existant        | Tests existants mis à jour                                                                             | Le test `dashboard-cockpit-bloc2.spec.ts` checkait `capacite-epargne-breakdown` (waterfall) + classe `rose` (déjà périmée depuis PR-D5). Patches correctifs inclus dans cette PR                                                                       |
+
+---
+
+## DoD 5/5 (à compléter post-merge)
+
+1. ⏳ CI verts (Lint, Typecheck, Tests, E2E gated, Security, Build) — à valider sur la PR ouverte
+2. ⏳ Sourcery silent sur dernier commit
+3. ⏳ Reviews approved (humain @thierry)
+4. ⏳ 0 conflit main
+5. ✅ Rapport `docs/prs/PR-BETA-3-capacite-tryptique-report.md` (ce fichier)
+
+---
+
+## Notes pour @thierry (post-merge)
+
+### Smoke iPhone à faire après merge
+
+1. Login sur preview Vercel
+2. Cockpit doit afficher 3 sub-stats (Reste dispo / Reste à vivre / Capacité épargne)
+3. Pour Thierry : valeurs attendues **662 / 500 / 162** (si workspace cohérent avec les charges du persona)
+4. Tap "Ajuster ce mois" → drawer slide-up sur iPhone
+5. Modifier 500 → 450 → Enregistrer → la sub-stat "Reste à vivre" affiche 450 et "Capacité épargne" passe à 212
+6. Re-tap "Ajuster" → re-modifier 450 → 500 → revient à 162
+
+### Migration Supabase à appliquer
+
+```bash
+supabase db push --linked
+# OU via SQL editor remote, le contenu de :
+# supabase/migrations/20260526000001_pr_beta_3_reste_a_vivre.sql
+```
+
+Idempotent (`if not exists` sur les colonnes, CHECK constraint nommé donc retry-safe).
+
+### Régénération types post-migration
+
+```bash
+npm run supabase:types
+git diff src/lib/supabase/types.ts
+```
+
+Si le diff ne montre que le retrait des commentaires "PR-BETA-3 patched manually", c'est qu'on est sync. Sinon investiguer (probablement d'autres colonnes drift).
+
+### Suivi backlog
+
+- ❓ `/glossaire/capacite-epargne-reelle` — à vérifier s'il existe déjà ; sinon ticket Linear post-Beta (hors-scope PR-BETA-3)
+- 📋 PR-D5 onboarding step 3 "saisie initiale reste à vivre" — Voie D séparée
+- 📋 PR-D8 Simulateur d'Action couplage avec resteAVivre — Voie D séparée
+- 📋 Historique 12 mois du KPI — v1.1 post-launch (cf. ADR-009 Risque 4)
+
+---
+
+## Files
+
+### Nouveaux (7)
+
+- `supabase/migrations/20260526000001_pr_beta_3_reste_a_vivre.sql`
+- `src/lib/schemas/reste-a-vivre.ts`
+- `src/lib/actions/reste-a-vivre.ts`
+- `src/lib/actions/__tests__/reste-a-vivre.test.ts`
+- `src/components/dashboard/AjusterResteAVivreDrawer.tsx`
+- `src/components/dashboard/__tests__/AjusterResteAVivreDrawer.test.tsx`
+- `e2e/dashboard-capacite-tryptique.spec.ts`
+
+### Modifiés (10)
+
+- `src/lib/domain/cockpit/capacite-epargne-reelle.ts` — exposition `resteDisponible` + renaming
+- `src/lib/domain/cockpit/__tests__/capacite-epargne-reelle.test.ts` — +6 tests tryptique
+- `src/lib/data/workspace-snapshot.ts` — SELECT + résolution `resteAVivre`
+- `src/lib/security/audit-log.ts` — `WORKSPACE_RESTE_A_VIVRE_UPDATED` + `period_yyyymm` safe key
+- `src/lib/supabase/types.ts` — patch manuel `workspace_settings` row/insert/update
+- `src/components/dashboard/CapaciteEpargneCard.tsx` — refonte complète tryptique
+- `src/components/dashboard/__tests__/CapaciteEpargneCard.test.tsx` — réécriture tests
+- `src/app/[locale]/app/page.tsx` — call-site `CapaciteEpargneCard` (props renommées)
+- `e2e/dashboard-cockpit-bloc2.spec.ts` — mise à jour waterfall → sub-stats, rose → danger
+- `messages/{fr-BE,en,nl-BE,de-DE,es-ES}.json` — namespace `dashboard.capacite.*` étendu
+
+### Auto-régénéré au build
+
+- `public/llms-full.txt` — date stamp 2026-05-25 → 2026-05-26

--- a/e2e/dashboard-capacite-tryptique.spec.ts
+++ b/e2e/dashboard-capacite-tryptique.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect } from './helpers/test';
+import { adminClientOrNull, deleteSeededUser, seedOnboardedUser } from './helpers/seed';
+
+const admin = adminClientOrNull();
+
+/**
+ * PR-BETA-3 (THI-267) — Capacité d'Épargne Réelle tryptique.
+ *
+ * Verifies the ADR-009 amendement 2026-05-09 contract end-to-end:
+ *   - 3 sub-stats rendered (reste disponible / reste à vivre / capacité)
+ *   - "Ajuster ce mois" affordance opens the drawer
+ *   - Saving an override updates the card on the next request
+ */
+test.describe('PR-BETA-3 — Capacité tryptique (ADR-009 amendement)', () => {
+  test.skip(!admin, 'Needs real Supabase (NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY).');
+
+  test('renders the 3 sub-stats with the @thierry canonical fixture', async ({ page }) => {
+    if (!admin) return;
+    const user = await seedOnboardedUser(admin, [
+      { label: 'Loyer', amount: 1500, frequency: 'monthly', dueMonth: 1, paidFrom: 'principal' },
+      {
+        label: 'Assurances',
+        amount: 338,
+        frequency: 'monthly',
+        dueMonth: 1,
+        paidFrom: 'principal',
+      },
+    ]);
+    await admin
+      .from('workspaces')
+      .update({ monthly_income: 2500, vie_courante_monthly_transfer: 500 })
+      .eq('id', user.workspaceId);
+    // PR-BETA-3 source of truth for the tryptique is workspace_settings.
+    await admin
+      .from('workspace_settings')
+      .update({ reste_a_vivre_default: 500 })
+      .eq('workspace_id', user.workspaceId);
+
+    try {
+      await page.goto('/login');
+      await page.getByLabel('Email').fill(user.email);
+      await page.getByLabel('Mot de passe').fill(user.password);
+      await page.getByRole('button', { name: /^se connecter$/i }).click();
+      await page.waitForURL(/\/app\b/, { timeout: 15_000 });
+
+      const substats = page.getByTestId('capacite-epargne-substats');
+      await expect(substats).toBeVisible();
+
+      const resteDispo = page.getByTestId('substat-reste-disponible');
+      await expect(resteDispo).toContainText('Reste disponible');
+      await expect(resteDispo).toContainText(/662/);
+
+      const resteAVivre = page.getByTestId('substat-reste-a-vivre');
+      await expect(resteAVivre).toContainText('Reste à vivre');
+      await expect(resteAVivre).toContainText(/500/);
+
+      const capacite = page.getByTestId('substat-capacite');
+      await expect(capacite).toContainText('Capacité épargne');
+      await expect(capacite).toContainText(/162/);
+    } finally {
+      await deleteSeededUser(admin, user.userId);
+    }
+  });
+
+  test('the "Ajuster ce mois" drawer opens and persists a new override', async ({ page }) => {
+    if (!admin) return;
+    const user = await seedOnboardedUser(admin, [
+      { label: 'Loyer', amount: 1500, frequency: 'monthly', dueMonth: 1, paidFrom: 'principal' },
+    ]);
+    await admin
+      .from('workspaces')
+      .update({ monthly_income: 2500, vie_courante_monthly_transfer: 500 })
+      .eq('id', user.workspaceId);
+    await admin
+      .from('workspace_settings')
+      .update({ reste_a_vivre_default: 500 })
+      .eq('workspace_id', user.workspaceId);
+
+    try {
+      await page.goto('/login');
+      await page.getByLabel('Email').fill(user.email);
+      await page.getByLabel('Mot de passe').fill(user.password);
+      await page.getByRole('button', { name: /^se connecter$/i }).click();
+      await page.waitForURL(/\/app\b/, { timeout: 15_000 });
+
+      // Open the drawer.
+      await page.getByTestId('reste-a-vivre-trigger').first().click();
+      await expect(page.getByTestId('reste-a-vivre-drawer')).toBeVisible();
+
+      // Override to 450 and save.
+      const input = page.getByTestId('reste-a-vivre-input');
+      await input.fill('450');
+      await page.getByTestId('reste-a-vivre-save').click();
+
+      // The drawer closes and the sub-stat updates.
+      await expect(page.getByTestId('reste-a-vivre-drawer')).toBeHidden();
+      await expect(page.getByTestId('substat-reste-a-vivre')).toContainText(/450/);
+    } finally {
+      await deleteSeededUser(admin, user.userId);
+    }
+  });
+
+  test('renders 3 sub-stats stacked on iPhone viewport (mobile-first)', async ({ page }) => {
+    if (!admin) return;
+    const user = await seedOnboardedUser(admin, [
+      { label: 'Loyer', amount: 1000, frequency: 'monthly', dueMonth: 1, paidFrom: 'principal' },
+    ]);
+    await admin
+      .from('workspaces')
+      .update({ monthly_income: 2500, vie_courante_monthly_transfer: 500 })
+      .eq('id', user.workspaceId);
+    await admin
+      .from('workspace_settings')
+      .update({ reste_a_vivre_default: 500 })
+      .eq('workspace_id', user.workspaceId);
+
+    await page.setViewportSize({ width: 375, height: 667 });
+    try {
+      await page.goto('/login');
+      await page.getByLabel('Email').fill(user.email);
+      await page.getByLabel('Mot de passe').fill(user.password);
+      await page.getByRole('button', { name: /^se connecter$/i }).click();
+      await page.waitForURL(/\/app\b/, { timeout: 15_000 });
+
+      const resteDispo = page.getByTestId('substat-reste-disponible');
+      const resteAVivre = page.getByTestId('substat-reste-a-vivre');
+      const capacite = page.getByTestId('substat-capacite');
+
+      await expect(resteDispo).toBeVisible();
+      await expect(resteAVivre).toBeVisible();
+      await expect(capacite).toBeVisible();
+
+      // Mobile layout: the 3 sub-stats stack vertically (each .top > previous).
+      const dispoBox = await resteDispo.boundingBox();
+      const aVivreBox = await resteAVivre.boundingBox();
+      const capaciteBox = await capacite.boundingBox();
+      expect(dispoBox).not.toBeNull();
+      expect(aVivreBox).not.toBeNull();
+      expect(capaciteBox).not.toBeNull();
+      if (dispoBox && aVivreBox && capaciteBox) {
+        expect(aVivreBox.y).toBeGreaterThan(dispoBox.y);
+        expect(capaciteBox.y).toBeGreaterThan(aVivreBox.y);
+      }
+    } finally {
+      await deleteSeededUser(admin, user.userId);
+    }
+  });
+});

--- a/e2e/dashboard-cockpit-bloc2.spec.ts
+++ b/e2e/dashboard-cockpit-bloc2.spec.ts
@@ -30,14 +30,14 @@ test.describe('PR-D3 — Bloc 2 hero radar (Effort Lissé + Capacité Réelle)',
       const card = page.getByTestId('capacite-epargne-card');
       await expect(card).toHaveAttribute('data-positive', 'true');
 
-      // PR-D3-bis — the waterfall breakdown must be visible alongside the
-      // big number so a new user understands the calculation at first
-      // glance. Assert all three rows render their localised labels.
-      const breakdown = page.getByTestId('capacite-epargne-breakdown');
-      await expect(breakdown).toBeVisible();
-      await expect(breakdown).toContainText('Revenus');
-      await expect(breakdown).toContainText('Effort financier lissé');
-      await expect(breakdown).toContainText('Plafond quotidien');
+      // PR-BETA-3 — the PR-D3-bis waterfall was replaced by the explicit
+      // tryptique (ADR-009 amendement 2026-05-09). Assert the 3 sub-stats
+      // render with their localised labels.
+      const substats = page.getByTestId('capacite-epargne-substats');
+      await expect(substats).toBeVisible();
+      await expect(substats).toContainText('Reste disponible');
+      await expect(substats).toContainText('Reste à vivre');
+      await expect(substats).toContainText('Capacité épargne');
     } finally {
       await deleteSeededUser(admin, user.userId);
     }
@@ -135,9 +135,11 @@ test.describe('PR-D3 — Bloc 2 hero radar (Effort Lissé + Capacité Réelle)',
       await expect(card).toBeVisible();
       await expect(card).toHaveAttribute('data-positive', 'false');
       const value = page.getByTestId('capacite-epargne-value');
-      // The value class string must include the rose accent.
+      // PR-D5 (2026-05-17) migrated `rose-*` raw Tailwind colours to the
+      // semantic `text-danger` token. PR-BETA-3 keeps this contract.
       const className = await value.getAttribute('class');
-      expect(className ?? '').toMatch(/rose/);
+      expect(className ?? '').toMatch(/text-danger/);
+      expect(className ?? '').not.toMatch(/rose/);
     } finally {
       await deleteSeededUser(admin, user.userId);
     }

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -964,6 +964,26 @@
         "revenus": "Einkommen",
         "effort": "Geglätteter finanzieller Aufwand",
         "plafond": "Tägliches Limit"
+      },
+      "subStats": {
+        "resteDisponible": "Verfügbar",
+        "resteAVivre": "Lebenshaltung",
+        "capaciteEpargne": "Sparkapazität",
+        "ajusterCeMois": "Diesen Monat anpassen"
+      },
+      "ledePositif": "Du kannst diesen Monat {amount} zusätzlich zu deinen automatischen Überweisungen zur Seite legen. Du entscheidest, wie viel du wirklich sparst.",
+      "ledeNegatif": "Dein Lebensstil übersteigt diesen Monat dein Einkommen. Wir können gemeinsam schauen, was angepasst werden kann.",
+      "tooltip": "Dieser Wert zieht deine Fixkosten, deine jährlich geglätteten Rückstellungen und dein geschätztes Lebenshaltungsbudget ({resteAVivre}) ab. Es ist das, was du zusätzlich sparen kannst.",
+      "drawer": {
+        "title": "Lebenshaltungsbudget für diesen Monat anpassen",
+        "inputLabel": "Wie viel gibst du diesen Monat fürs Leben aus?",
+        "inputHint": "Einkäufe, Ausgehen, Freizeit, Vergnügen, alltägliche Überraschungen",
+        "helperCoherent": "Schätzung, die zu einem typisch belgischen Budget passt.",
+        "helperBas": "Niedrige Schätzung. Du kannst sie später anpassen, falls nötig.",
+        "helperHaut": "Hohe Schätzung. Ankora respektiert dein Budget — kein Urteil.",
+        "save": "Speichern",
+        "cancel": "Abbrechen",
+        "errorGeneric": "Die Anpassung konnte nicht gespeichert werden. Bitte versuche es gleich erneut."
       }
     },
     "daily": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -964,6 +964,26 @@
         "revenus": "Income",
         "effort": "Smoothed financial effort",
         "plafond": "Daily allowance"
+      },
+      "subStats": {
+        "resteDisponible": "Available leftover",
+        "resteAVivre": "Daily living budget",
+        "capaciteEpargne": "Saving capacity",
+        "ajusterCeMois": "Adjust this month"
+      },
+      "ledePositif": "You can set aside {amount} this month on top of your automatic transfers. You decide how much you actually save.",
+      "ledeNegatif": "Your lifestyle exceeds your income this month. We can look at what can be adjusted together.",
+      "tooltip": "This figure subtracts your fixed bills, your yearly-smoothed provisions, and your estimated daily living budget ({resteAVivre}). It is what you can choose to save on top of the rest.",
+      "drawer": {
+        "title": "Adjust the daily living budget for this month",
+        "inputLabel": "How much will you spend on day-to-day living this month?",
+        "inputHint": "Groceries, going out, leisure, fun, daily surprises",
+        "helperCoherent": "Estimate consistent with a typical Belgian budget.",
+        "helperBas": "Low estimate. You can adjust later if needed.",
+        "helperHaut": "High estimate. Ankora respects your budget — no judgement.",
+        "save": "Save",
+        "cancel": "Cancel",
+        "errorGeneric": "The adjustment couldn't be saved. Please try again in a moment."
       }
     },
     "daily": {

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -964,6 +964,26 @@
         "revenus": "Ingresos",
         "effort": "Esfuerzo financiero suavizado",
         "plafond": "Límite diario"
+      },
+      "subStats": {
+        "resteDisponible": "Disponible",
+        "resteAVivre": "Presupuesto vital",
+        "capaciteEpargne": "Capacidad de ahorro",
+        "ajusterCeMois": "Ajustar este mes"
+      },
+      "ledePositif": "Puedes apartar {amount} este mes además de tus transferencias automáticas. Tú decides cuánto ahorras realmente.",
+      "ledeNegatif": "Tu nivel de vida supera tus ingresos este mes. Podemos mirar juntos qué se puede ajustar.",
+      "tooltip": "Esta cifra resta tus gastos fijos, tus provisiones suavizadas a lo largo del año y tu presupuesto vital estimado ({resteAVivre}). Es lo que puedes elegir ahorrar además del resto.",
+      "drawer": {
+        "title": "Ajustar el presupuesto vital de este mes",
+        "inputLabel": "¿Cuánto vas a gastar para vivir este mes?",
+        "inputHint": "Compra, salidas, ocio, placer, imprevistos diarios",
+        "helperCoherent": "Estimación coherente con un presupuesto belga típico.",
+        "helperBas": "Estimación baja. Puedes ajustarla más adelante si lo necesitas.",
+        "helperHaut": "Estimación alta. Ankora respeta tu presupuesto — sin juicios.",
+        "save": "Guardar",
+        "cancel": "Cancelar",
+        "errorGeneric": "El ajuste no se ha podido guardar. Inténtalo de nuevo dentro de un momento."
       }
     },
     "daily": {

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -964,6 +964,26 @@
         "revenus": "Revenus",
         "effort": "Effort financier lissé",
         "plafond": "Plafond quotidien"
+      },
+      "subStats": {
+        "resteDisponible": "Reste disponible",
+        "resteAVivre": "Reste à vivre",
+        "capaciteEpargne": "Capacité épargne",
+        "ajusterCeMois": "Ajuster ce mois"
+      },
+      "ledePositif": "Tu peux mettre {amount} de côté ce mois en plus de tes virements automatiques. Tu décides combien tu y mets vraiment.",
+      "ledeNegatif": "Ton train de vie dépasse tes revenus ce mois. On peut regarder ensemble ce qui peut être ajusté.",
+      "tooltip": "Cette valeur soustrait tes charges fixes, tes provisions lissées sur l'année, ET ton estimation de vie courante ({resteAVivre}). C'est ce que tu peux choisir d'épargner en plus.",
+      "drawer": {
+        "title": "Ajuster le reste à vivre pour ce mois",
+        "inputLabel": "Combien tu dépenses pour vivre ce mois ?",
+        "inputHint": "Courses, sorties, loisirs, plaisir, imprévus quotidiens",
+        "helperCoherent": "Estimation cohérente avec un budget belge typique.",
+        "helperBas": "Estimation basse. Tu peux ajuster plus tard si besoin.",
+        "helperHaut": "Estimation haute. Ankora respecte ton budget — pas de jugement.",
+        "save": "Enregistrer",
+        "cancel": "Annuler",
+        "errorGeneric": "L'ajustement n'a pas pu être enregistré. Réessaye dans un instant."
       }
     },
     "daily": {

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -964,6 +964,26 @@
         "revenus": "Inkomen",
         "effort": "Vereffende financiële inspanning",
         "plafond": "Dagelijks plafond"
+      },
+      "subStats": {
+        "resteDisponible": "Beschikbaar saldo",
+        "resteAVivre": "Leefbudget",
+        "capaciteEpargne": "Spaarcapaciteit",
+        "ajusterCeMois": "Deze maand aanpassen"
+      },
+      "ledePositif": "Je kan deze maand {amount} opzij zetten bovenop je automatische overschrijvingen. Je beslist zelf hoeveel je echt spaart.",
+      "ledeNegatif": "Je levensstijl overschrijdt deze maand je inkomen. We kunnen samen kijken wat aangepast kan worden.",
+      "tooltip": "Dit bedrag trekt je vaste lasten, je over het jaar uitgesmeerde provisies en je geraamde leefbudget ({resteAVivre}) af. Het is wat je extra kan kiezen te sparen.",
+      "drawer": {
+        "title": "Leefbudget voor deze maand aanpassen",
+        "inputLabel": "Hoeveel ga je deze maand uitgeven om te leven?",
+        "inputHint": "Boodschappen, uitgaan, vrije tijd, plezier, dagelijkse onverwachte uitgaven",
+        "helperCoherent": "Schatting die past bij een typisch Belgisch budget.",
+        "helperBas": "Lage schatting. Je kan dit later aanpassen als nodig.",
+        "helperHaut": "Hoge schatting. Ankora respecteert je budget — geen oordeel.",
+        "save": "Opslaan",
+        "cancel": "Annuleren",
+        "errorGeneric": "De aanpassing kon niet worden opgeslagen. Probeer het zo opnieuw."
       }
     },
     "daily": {

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,6 +1,6 @@
 # ankora.be — Full content export for LLMs
 
-Last generated: 2026-05-25
+Last generated: 2026-05-26
 Canonical URL: https://ankora.be
 License: content available for citation with attribution. Code is proprietary.
 

--- a/src/app/[locale]/app/page.tsx
+++ b/src/app/[locale]/app/page.tsx
@@ -116,7 +116,8 @@ export default async function DashboardPage() {
         <CapaciteEpargneCard
           revenus={monthlyIncome}
           charges={cockpitCharges}
-          plafondQuotidien={vieCouranteTransferAmount}
+          resteAVivre={money(snapshot.resteAVivre)}
+          currentMonthYYYYMM={`${snapshot.currentPeriod.year}-${String(snapshot.currentPeriod.month).padStart(2, '0')}`}
           locale={locale}
         />
       </section>

--- a/src/components/dashboard/AjusterResteAVivreDrawer.tsx
+++ b/src/components/dashboard/AjusterResteAVivreDrawer.tsx
@@ -1,0 +1,244 @@
+'use client';
+
+import { useEffect, useId, useMemo, useRef, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { Pencil, X } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+import { updateResteAVivreOverrideAction } from '@/lib/actions/reste-a-vivre';
+import { useActionErrorTranslator } from '@/lib/i18n/action-errors';
+import { toast } from '@/components/ui/toast';
+import { cn } from '@/lib/utils';
+
+type Props = {
+  currentMonthYYYYMM: string;
+  initialResteAVivre: number;
+  monthlyIncome: number | null;
+  triggerLabel?: string;
+};
+
+/**
+ * PR-BETA-3 (THI-267) — "Ajuster ce mois" drawer.
+ *
+ * Slide-in panel that lets the user override the reste-à-vivre for the
+ * current month. The drawer reuses the same visual idiom as the EditDrawer
+ * atom (slide-from-right on desktop, full-screen on mobile) but stays
+ * standalone because it needs the adaptive helper text — a per-field rule
+ * the generic EditDrawer doesn't model.
+ *
+ * R-06 anti-culpabilisation contract: helper text never says "you spend too
+ * much" or "you should save X €". It either confirms the estimate is
+ * coherent, low, or high, without judgement.
+ */
+export function AjusterResteAVivreDrawer({
+  currentMonthYYYYMM,
+  initialResteAVivre,
+  monthlyIncome,
+  triggerLabel,
+}: Props) {
+  const t = useTranslations('dashboard.capacite');
+  const translateError = useActionErrorTranslator();
+  const router = useRouter();
+  const inputId = useId();
+  const titleId = useId();
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const [open, setOpen] = useState(false);
+  const [draftStr, setDraftStr] = useState(initialResteAVivre.toFixed(2));
+  const [isPending, startTransition] = useTransition();
+
+  // Autofocus the input when the drawer opens. The draft state is reset
+  // imperatively in `openDrawer()` (not via an effect) to avoid the
+  // cascading-render anti-pattern flagged by react-hooks/set-state-in-effect.
+  useEffect(() => {
+    if (!open) return;
+    const id = requestAnimationFrame(() => inputRef.current?.focus());
+    return () => cancelAnimationFrame(id);
+  }, [open]);
+
+  function openDrawer() {
+    setDraftStr(initialResteAVivre.toFixed(2));
+    setOpen(true);
+  }
+
+  // ESC to close.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setOpen(false);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
+
+  // Lock body scroll when open (mobile fullscreen UX).
+  useEffect(() => {
+    if (!open) return;
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, [open]);
+
+  const parsedDraft = useMemo(() => {
+    const cleaned = draftStr.replace(',', '.').trim();
+    const num = Number(cleaned);
+    if (cleaned === '' || !Number.isFinite(num) || num < 0 || num > 100000) {
+      return null;
+    }
+    return num;
+  }, [draftStr]);
+
+  const adaptiveHelper = useMemo(() => {
+    if (parsedDraft === null || !monthlyIncome || monthlyIncome <= 0) {
+      return t('drawer.helperCoherent');
+    }
+    const ratio = parsedDraft / monthlyIncome;
+    if (ratio < 0.15) return t('drawer.helperBas');
+    if (ratio > 0.5) return t('drawer.helperHaut');
+    return t('drawer.helperCoherent');
+  }, [parsedDraft, monthlyIncome, t]);
+
+  function submit() {
+    if (parsedDraft === null) {
+      inputRef.current?.focus();
+      return;
+    }
+    startTransition(async () => {
+      const result = await updateResteAVivreOverrideAction({
+        monthYYYYMM: currentMonthYYYYMM,
+        montant: parsedDraft,
+      });
+      if (result.ok) {
+        setOpen(false);
+        router.refresh();
+      } else {
+        toast.error(translateError(result.errorCode) || t('drawer.errorGeneric'));
+      }
+    });
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={openDrawer}
+        className="text-muted-foreground hover:text-foreground focus-visible:ring-brand-700 inline-flex items-center gap-1 rounded-md px-1 py-0.5 text-xs underline underline-offset-2 transition-colors focus-visible:ring-2 focus-visible:outline-none"
+        data-testid="reste-a-vivre-trigger"
+        aria-label={triggerLabel ?? t('subStats.ajusterCeMois')}
+      >
+        <Pencil className="h-3 w-3" strokeWidth={1.75} aria-hidden />
+        <span>{triggerLabel ?? t('subStats.ajusterCeMois')}</span>
+      </button>
+
+      {open && (
+        <div
+          ref={dialogRef}
+          className="fixed inset-0 z-50 flex items-end justify-end sm:items-stretch"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={titleId}
+          data-testid="reste-a-vivre-drawer"
+        >
+          <button
+            type="button"
+            aria-label={t('drawer.cancel')}
+            className="bg-foreground/40 absolute inset-0 backdrop-blur-sm"
+            onClick={() => setOpen(false)}
+          />
+          <aside
+            className={cn(
+              'bg-card text-foreground border-border relative flex w-full flex-col border shadow-xl',
+              // Mobile: full-screen, slide from bottom (iOS Settings pattern).
+              'h-dvh max-h-dvh',
+              // Desktop: slide from right, fixed width.
+              'sm:h-full sm:max-w-md sm:border-l',
+            )}
+          >
+            <header className="border-border flex items-center justify-between gap-3 border-b px-5 py-4">
+              <h2 id={titleId} className="text-lg font-semibold tracking-tight">
+                {t('drawer.title')}
+              </h2>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="text-muted-foreground hover:text-foreground focus-visible:ring-brand-700 -mr-1 rounded-md p-2 focus-visible:ring-2 focus-visible:outline-none"
+                aria-label={t('drawer.cancel')}
+              >
+                <X className="h-5 w-5" aria-hidden />
+              </button>
+            </header>
+
+            <div className="flex flex-1 flex-col gap-5 overflow-y-auto px-5 py-6">
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor={inputId} className="text-sm font-medium">
+                  {t('drawer.inputLabel')}
+                </label>
+                <p className="text-muted-foreground text-xs">{t('drawer.inputHint')}</p>
+              </div>
+
+              <div className="relative">
+                <input
+                  ref={inputRef}
+                  id={inputId}
+                  type="text"
+                  inputMode="decimal"
+                  value={draftStr}
+                  onChange={(e) => setDraftStr(e.target.value.replace(/[^0-9.,]/g, ''))}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      submit();
+                    }
+                  }}
+                  className="border-border bg-background focus-visible:ring-brand-700 w-full rounded-md border px-3 py-3 pr-10 text-2xl font-semibold tabular-nums focus-visible:ring-2 focus-visible:outline-none"
+                  aria-describedby={`${inputId}-helper`}
+                  data-testid="reste-a-vivre-input"
+                />
+                <span
+                  className="text-muted-foreground pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 text-base"
+                  aria-hidden
+                >
+                  €
+                </span>
+              </div>
+
+              <p
+                id={`${inputId}-helper`}
+                className="text-muted-foreground text-sm leading-relaxed"
+                data-testid="reste-a-vivre-helper"
+              >
+                {adaptiveHelper}
+              </p>
+            </div>
+
+            <footer className="border-border bg-card flex items-center justify-end gap-2 border-t px-5 py-4">
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="text-foreground hover:bg-muted focus-visible:ring-brand-700 rounded-md border border-transparent px-4 py-2 text-sm font-medium focus-visible:ring-2 focus-visible:outline-none"
+                disabled={isPending}
+              >
+                {t('drawer.cancel')}
+              </button>
+              <button
+                type="button"
+                onClick={submit}
+                className="bg-brand-700 hover:bg-brand-800 focus-visible:ring-brand-700 inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-semibold text-white focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={isPending || parsedDraft === null}
+                data-testid="reste-a-vivre-save"
+              >
+                {t('drawer.save')}
+              </button>
+            </footer>
+          </aside>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/dashboard/CapaciteEpargneCard.tsx
+++ b/src/components/dashboard/CapaciteEpargneCard.tsx
@@ -1,5 +1,5 @@
 import Decimal from 'decimal.js';
-import { AlertCircle, CheckCircle2 } from 'lucide-react';
+import { AlertCircle, CheckCircle2, Info } from 'lucide-react';
 import { getTranslations } from 'next-intl/server';
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -7,51 +7,52 @@ import { capaciteEpargneReelle } from '@/lib/domain/cockpit';
 import type { CockpitCharge } from '@/lib/domain/cockpit/types';
 import { formatCurrency } from '@/lib/i18n/formatters';
 import type { Locale } from '@/i18n/routing';
+import { AjusterResteAVivreDrawer } from './AjusterResteAVivreDrawer';
 
 type Props = {
   revenus: Decimal;
   charges: readonly CockpitCharge[];
-  plafondQuotidien: Decimal;
+  resteAVivre: Decimal;
+  /** ISO `YYYY-MM` for the current month — drives the drawer override key. */
+  currentMonthYYYYMM: string;
   locale: Locale;
 };
 
 /**
- * Capacité d'Épargne Réelle — radar card #2 of cockpit Bloc 2 (ADR-009).
+ * Capacité d'Épargne Réelle — Bloc 2 hero radar #2 (ADR-009 + amendement
+ * 2026-05-09 — tryptique pédagogique).
  *
- * THE differentiating KPI: `revenus - effortFinancierLisse - plafondQuotidien`.
- * Stable mois-après-mois (the lissage absorbs the volatility of periodic
- * bills) and honest about whether the user's lifestyle fits inside their
- * income on a true annual basis. No competitor (Monarch, YNAB, Lunch Money,
- * Linxo, Bankin') ships this calculation.
+ * THE differentiating KPI of Ankora: `revenus − effortFinancierLisse −
+ * resteAVivre`. No competitor (Monarch, YNAB, Lunch Money, Linxo, Bankin')
+ * ships this calculation.
  *
- * PR-D3-bis pedagogy update — the bare big number that PR-D3 shipped was
- * opaque to anyone but @thierry: "+124 €" with no audit trail. We now
- * always show the waterfall breakdown above the big number so a new user
- * understands the calculation at first glance:
+ * PR-BETA-3 refactor: replaced the PR-D3-bis opaque waterfall by an explicit
+ * 3-concept tryptique surfaced under the hero number:
  *
- *     Revenus            2 500 €
- *   − Effort lissé     −1 876 €
- *   − Plafond quotidien  −500 €
- *   ────────────────────────
- *   Capacité réelle    +124 € ✓
+ *   ┌────────────────┬────────────────┬────────────────┐
+ *   │ Reste dispo    │ Reste à vivre  │ Capacité       │
+ *   │  662 €         │  500 € [Adj]   │  162 €         │
+ *   └────────────────┴────────────────┴────────────────┘
  *
- * Visual semantics:
- *  - emerald accent + CheckCircle2 + positive message when capacité ≥ 0
- *  - rose accent + AlertCircle + warning message when capacité < 0
- *  - decorative glow blob bottom-right matching the state colour
- *
- * Server Component (math + i18n only).
+ * Why kill the waterfall:
+ *   - "Revenus − Effort" was already implicit (the Effort card sits beside
+ *     this one on the dashboard and shows the breakdown).
+ *   - Three concepts collapsed into one "opaque big number" was the exact
+ *     pain ADR-009 amendement 2026-05-09 was filed to fix.
+ *   - The tryptique surfaces each concept distinctly and exposes the
+ *     "Ajuster ce mois" R-10 affordance inline.
  */
-export async function CapaciteEpargneCard({ revenus, charges, plafondQuotidien, locale }: Props) {
+export async function CapaciteEpargneCard({
+  revenus,
+  charges,
+  resteAVivre,
+  currentMonthYYYYMM,
+  locale,
+}: Props) {
   const t = await getTranslations('dashboard.capacite');
-  const result = capaciteEpargneReelle({ revenus, charges, plafondQuotidien });
+  const result = capaciteEpargneReelle({ revenus, charges, resteAVivre });
   const fmt = (value: Parameters<typeof formatCurrency>[0]) => formatCurrency(value, locale);
 
-  // PR-D5 tokens: replaced raw Tailwind palette (`emerald-*`, `rose-*`) +
-  // `dark:text-*` hacks (which bypassed our `[data-theme="dark"]` custom
-  // variant) by the semantic tokens `--color-success` / `--color-danger`.
-  // The card now follows the design system end-to-end and the dark variant
-  // is handled by the token layer rather than per-component overrides.
   const accent = result.isPositive
     ? {
         ringColor: 'ring-success/15',
@@ -60,7 +61,7 @@ export async function CapaciteEpargneCard({ revenus, charges, plafondQuotidien, 
         glowColor: 'bg-success/20',
         gradientFrom: 'from-success/8',
         Icon: CheckCircle2,
-        message: t('message_positive'),
+        lede: t('ledePositif', { amount: fmt(result.capacite) }),
       }
     : {
         ringColor: 'ring-danger/15',
@@ -69,7 +70,7 @@ export async function CapaciteEpargneCard({ revenus, charges, plafondQuotidien, 
         glowColor: 'bg-danger/20',
         gradientFrom: 'from-danger/8',
         Icon: AlertCircle,
-        message: t('message_negative'),
+        lede: t('ledeNegatif'),
       };
 
   // Force "+12,34 €" prefix on positive values so the affirmative framing is
@@ -77,32 +78,7 @@ export async function CapaciteEpargneCard({ revenus, charges, plafondQuotidien, 
   // default. Zero stays unsigned (still positive per `isPositive`).
   const formatted = fmt(result.capacite);
   const signed = result.capacite.gt(0) ? `+${formatted}` : formatted;
-
-  // The waterfall row data — order matches the ADR-009 formula left-to-right
-  // so the math is reconstructible by a reader who has never seen the app.
-  const showPlafondRow = plafondQuotidien.gt(0);
-  const breakdownRows: Array<{
-    key: string;
-    label: string;
-    value: string;
-    operator: '+' | '−';
-  }> = [
-    { key: 'revenus', label: t('breakdown.revenus'), value: fmt(revenus), operator: '+' },
-    {
-      key: 'effort',
-      label: t('breakdown.effort'),
-      value: fmt(result.effortFinancierLisse),
-      operator: '−',
-    },
-  ];
-  if (showPlafondRow) {
-    breakdownRows.push({
-      key: 'plafond',
-      label: t('breakdown.plafond'),
-      value: fmt(plafondQuotidien),
-      operator: '−',
-    });
-  }
+  const tooltipText = t('tooltip', { resteAVivre: fmt(result.resteAVivre) });
 
   return (
     <Card
@@ -128,36 +104,84 @@ export async function CapaciteEpargneCard({ revenus, charges, plafondQuotidien, 
           className={`h-6 w-6 shrink-0 ${accent.iconColor}`}
         />
       </CardHeader>
-      <CardContent className="relative">
-        <dl
-          className="text-muted-foreground mb-3 flex flex-col gap-1.5 text-sm"
-          data-testid="capacite-epargne-breakdown"
-        >
-          {breakdownRows.map((row) => (
-            <div key={row.key} className="flex items-baseline justify-between gap-3">
-              <dt className="flex items-center gap-2">
-                <span
-                  aria-hidden
-                  className="text-muted-foreground/70 inline-flex w-4 justify-center font-medium"
-                >
-                  {row.operator}
-                </span>
-                <span>{row.label}</span>
-              </dt>
-              <dd className="text-foreground/80 font-medium tabular-nums">{row.value}</dd>
-            </div>
-          ))}
-        </dl>
-        <div className="border-border/60 border-t pt-3">
+
+      <CardContent className="relative flex flex-col gap-4">
+        {/* Hero number + tooltip affordance */}
+        <div className="flex flex-col gap-2">
+          <div className="flex items-start gap-2">
+            <p
+              className={`text-4xl font-bold tracking-tight tabular-nums ${accent.valueColor}`}
+              data-testid="capacite-epargne-value"
+            >
+              {signed}
+            </p>
+            <span
+              className="text-muted-foreground/70 hover:text-foreground inline-flex h-6 w-6 shrink-0 cursor-help items-center justify-center rounded-full transition-colors"
+              title={tooltipText}
+              aria-label={tooltipText}
+              data-testid="capacite-epargne-tooltip"
+              tabIndex={0}
+            >
+              <Info className="h-4 w-4" strokeWidth={1.5} aria-hidden />
+            </span>
+          </div>
           <p
-            className={`text-4xl font-bold tracking-tight tabular-nums ${accent.valueColor}`}
-            data-testid="capacite-epargne-value"
+            className="text-muted-foreground text-sm leading-relaxed"
+            data-testid="capacite-epargne-lede"
           >
-            {signed}
+            {accent.lede}
           </p>
-          <p className="text-muted-foreground mt-3 text-sm leading-relaxed">{accent.message}</p>
         </div>
+
+        {/* Tryptique sub-stats — ADR-009 amendement 2026-05-09 */}
+        <dl
+          className="border-border/60 grid grid-cols-1 gap-3 border-t pt-4 sm:grid-cols-3 sm:gap-2"
+          data-testid="capacite-epargne-substats"
+        >
+          <SubStat
+            label={t('subStats.resteDisponible')}
+            value={fmt(result.resteDisponible)}
+            testId="substat-reste-disponible"
+          />
+          <SubStat
+            label={t('subStats.resteAVivre')}
+            value={fmt(result.resteAVivre)}
+            testId="substat-reste-a-vivre"
+            secondary={
+              <AjusterResteAVivreDrawer
+                currentMonthYYYYMM={currentMonthYYYYMM}
+                initialResteAVivre={result.resteAVivre.toNumber()}
+                monthlyIncome={revenus.toNumber()}
+                triggerLabel={t('subStats.ajusterCeMois')}
+              />
+            }
+          />
+          <SubStat
+            label={t('subStats.capaciteEpargne')}
+            value={signed}
+            valueClassName={accent.valueColor}
+            testId="substat-capacite"
+          />
+        </dl>
       </CardContent>
     </Card>
+  );
+}
+
+type SubStatProps = {
+  label: string;
+  value: string;
+  valueClassName?: string;
+  secondary?: React.ReactNode;
+  testId?: string;
+};
+
+function SubStat({ label, value, valueClassName, secondary, testId }: SubStatProps) {
+  return (
+    <div className="flex flex-col gap-0.5" data-testid={testId}>
+      <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">{label}</dt>
+      <dd className={`text-lg font-semibold tabular-nums ${valueClassName ?? ''}`}>{value}</dd>
+      {secondary}
+    </div>
   );
 }

--- a/src/components/dashboard/__tests__/AjusterResteAVivreDrawer.test.tsx
+++ b/src/components/dashboard/__tests__/AjusterResteAVivreDrawer.test.tsx
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+
+import messages from '../../../../messages/fr-BE.json';
+
+const updateMock = vi.hoisted(() => vi.fn());
+const toastErrorMock = vi.hoisted(() => vi.fn());
+const routerRefreshMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/actions/reste-a-vivre', () => ({
+  updateResteAVivreOverrideAction: updateMock,
+}));
+
+vi.mock('@/components/ui/toast', () => ({
+  toast: { error: toastErrorMock, success: vi.fn() },
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: routerRefreshMock, push: vi.fn(), replace: vi.fn() }),
+}));
+
+import { AjusterResteAVivreDrawer } from '../AjusterResteAVivreDrawer';
+
+function renderWithIntl(ui: React.ReactNode) {
+  return render(
+    <NextIntlClientProvider locale="fr-BE" messages={messages} timeZone="Europe/Brussels">
+      {ui}
+    </NextIntlClientProvider>,
+  );
+}
+
+const baseProps = {
+  currentMonthYYYYMM: '2026-05',
+  initialResteAVivre: 500,
+  monthlyIncome: 2500,
+};
+
+describe('<AjusterResteAVivreDrawer /> — closed state', () => {
+  beforeEach(() => {
+    updateMock.mockReset();
+    toastErrorMock.mockReset();
+    routerRefreshMock.mockReset();
+  });
+
+  it('renders the trigger button labelled "Ajuster ce mois"', () => {
+    renderWithIntl(<AjusterResteAVivreDrawer {...baseProps} />);
+    const trigger = screen.getByTestId('reste-a-vivre-trigger');
+    expect(trigger).toBeInTheDocument();
+    expect(trigger.textContent ?? '').toContain(messages.dashboard.capacite.subStats.ajusterCeMois);
+  });
+
+  it('does not show the dialog until the trigger is clicked', () => {
+    renderWithIntl(<AjusterResteAVivreDrawer {...baseProps} />);
+    expect(screen.queryByTestId('reste-a-vivre-drawer')).toBeNull();
+  });
+});
+
+describe('<AjusterResteAVivreDrawer /> — open state', () => {
+  beforeEach(() => {
+    updateMock.mockReset();
+    toastErrorMock.mockReset();
+    routerRefreshMock.mockReset();
+  });
+
+  it('opens the dialog with the input pre-filled with initialResteAVivre', async () => {
+    renderWithIntl(<AjusterResteAVivreDrawer {...baseProps} />);
+    fireEvent.click(screen.getByTestId('reste-a-vivre-trigger'));
+    const input = await screen.findByTestId('reste-a-vivre-input');
+    expect(input).toHaveValue('500.00');
+  });
+
+  it('renders the drawer title from i18n', async () => {
+    renderWithIntl(<AjusterResteAVivreDrawer {...baseProps} />);
+    fireEvent.click(screen.getByTestId('reste-a-vivre-trigger'));
+    expect(await screen.findByText(messages.dashboard.capacite.drawer.title)).toBeInTheDocument();
+  });
+
+  it('shows the helperCoherent text when ratio is ≈ 20% of income', async () => {
+    renderWithIntl(<AjusterResteAVivreDrawer {...baseProps} />);
+    fireEvent.click(screen.getByTestId('reste-a-vivre-trigger'));
+    const helper = await screen.findByTestId('reste-a-vivre-helper');
+    // 500 / 2500 = 20% → coherent
+    expect(helper.textContent ?? '').toBe(messages.dashboard.capacite.drawer.helperCoherent);
+  });
+
+  it('switches to helperBas when ratio < 15%', async () => {
+    renderWithIntl(<AjusterResteAVivreDrawer {...baseProps} initialResteAVivre={200} />);
+    fireEvent.click(screen.getByTestId('reste-a-vivre-trigger'));
+    const helper = await screen.findByTestId('reste-a-vivre-helper');
+    // 200 / 2500 = 8% → low
+    expect(helper.textContent ?? '').toBe(messages.dashboard.capacite.drawer.helperBas);
+  });
+
+  it('switches to helperHaut when ratio > 50%', async () => {
+    renderWithIntl(<AjusterResteAVivreDrawer {...baseProps} initialResteAVivre={1500} />);
+    fireEvent.click(screen.getByTestId('reste-a-vivre-trigger'));
+    const helper = await screen.findByTestId('reste-a-vivre-helper');
+    // 1500 / 2500 = 60% → high
+    expect(helper.textContent ?? '').toBe(messages.dashboard.capacite.drawer.helperHaut);
+  });
+
+  it('helper falls back to coherent when monthlyIncome is null', async () => {
+    renderWithIntl(<AjusterResteAVivreDrawer {...baseProps} monthlyIncome={null} />);
+    fireEvent.click(screen.getByTestId('reste-a-vivre-trigger'));
+    const helper = await screen.findByTestId('reste-a-vivre-helper');
+    expect(helper.textContent ?? '').toBe(messages.dashboard.capacite.drawer.helperCoherent);
+  });
+
+  it('updates the helper live when the user edits the input', async () => {
+    renderWithIntl(<AjusterResteAVivreDrawer {...baseProps} />);
+    fireEvent.click(screen.getByTestId('reste-a-vivre-trigger'));
+    const input = await screen.findByTestId('reste-a-vivre-input');
+    fireEvent.change(input, { target: { value: '1400' } });
+    const helper = screen.getByTestId('reste-a-vivre-helper');
+    // 1400 / 2500 = 56% → high
+    expect(helper.textContent ?? '').toBe(messages.dashboard.capacite.drawer.helperHaut);
+  });
+});
+
+describe('<AjusterResteAVivreDrawer /> — submit flow', () => {
+  beforeEach(() => {
+    updateMock.mockReset();
+    toastErrorMock.mockReset();
+    routerRefreshMock.mockReset();
+  });
+
+  it('calls the Server Action with the parsed amount and current monthYYYYMM', async () => {
+    updateMock.mockResolvedValue({ ok: true });
+    renderWithIntl(<AjusterResteAVivreDrawer {...baseProps} />);
+    fireEvent.click(screen.getByTestId('reste-a-vivre-trigger'));
+    const input = await screen.findByTestId('reste-a-vivre-input');
+    fireEvent.change(input, { target: { value: '450' } });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('reste-a-vivre-save'));
+    });
+    await waitFor(() => {
+      expect(updateMock).toHaveBeenCalledWith({
+        monthYYYYMM: '2026-05',
+        montant: 450,
+      });
+    });
+    expect(routerRefreshMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the drawer on success', async () => {
+    updateMock.mockResolvedValue({ ok: true });
+    renderWithIntl(<AjusterResteAVivreDrawer {...baseProps} />);
+    fireEvent.click(screen.getByTestId('reste-a-vivre-trigger'));
+    await screen.findByTestId('reste-a-vivre-drawer');
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('reste-a-vivre-save'));
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId('reste-a-vivre-drawer')).toBeNull();
+    });
+  });
+
+  it('shows a toast error and stays open on failure', async () => {
+    updateMock.mockResolvedValue({
+      ok: false,
+      errorCode: 'errors.settings.resteAVivreUpdateFailed',
+    });
+    renderWithIntl(<AjusterResteAVivreDrawer {...baseProps} />);
+    fireEvent.click(screen.getByTestId('reste-a-vivre-trigger'));
+    await screen.findByTestId('reste-a-vivre-drawer');
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('reste-a-vivre-save'));
+    });
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByTestId('reste-a-vivre-drawer')).toBeInTheDocument();
+    expect(routerRefreshMock).not.toHaveBeenCalled();
+  });
+
+  it('disables the Save button when the input is invalid (empty/negative)', async () => {
+    renderWithIntl(<AjusterResteAVivreDrawer {...baseProps} />);
+    fireEvent.click(screen.getByTestId('reste-a-vivre-trigger'));
+    const input = await screen.findByTestId('reste-a-vivre-input');
+    fireEvent.change(input, { target: { value: '' } });
+    const save = screen.getByTestId('reste-a-vivre-save');
+    expect(save).toBeDisabled();
+  });
+
+  it('accepts decimal comma input (French locale convention)', async () => {
+    updateMock.mockResolvedValue({ ok: true });
+    renderWithIntl(<AjusterResteAVivreDrawer {...baseProps} />);
+    fireEvent.click(screen.getByTestId('reste-a-vivre-trigger'));
+    const input = await screen.findByTestId('reste-a-vivre-input');
+    fireEvent.change(input, { target: { value: '425,50' } });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('reste-a-vivre-save'));
+    });
+    await waitFor(() => {
+      expect(updateMock).toHaveBeenCalledWith({
+        monthYYYYMM: '2026-05',
+        montant: 425.5,
+      });
+    });
+  });
+});
+
+describe('<AjusterResteAVivreDrawer /> — keyboard + dismiss', () => {
+  beforeEach(() => {
+    updateMock.mockReset();
+    toastErrorMock.mockReset();
+    routerRefreshMock.mockReset();
+  });
+
+  it('closes the drawer on Escape without calling the Server Action', async () => {
+    renderWithIntl(<AjusterResteAVivreDrawer {...baseProps} />);
+    fireEvent.click(screen.getByTestId('reste-a-vivre-trigger'));
+    await screen.findByTestId('reste-a-vivre-drawer');
+    fireEvent.keyDown(window, { key: 'Escape' });
+    await waitFor(() => {
+      expect(screen.queryByTestId('reste-a-vivre-drawer')).toBeNull();
+    });
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/dashboard/__tests__/CapaciteEpargneCard.test.tsx
+++ b/src/components/dashboard/__tests__/CapaciteEpargneCard.test.tsx
@@ -15,11 +15,27 @@ vi.mock('next-intl/server', () => ({
         return undefined;
       }, root);
     const sub = walk(messages, namespace.split('.'));
-    return (key: string) => {
+    return (key: string, params?: Record<string, string | number>) => {
       const value = walk(sub, key.split('.'));
-      return typeof value === 'string' ? value : key;
+      if (typeof value !== 'string') return key;
+      if (!params) return value;
+      return Object.entries(params).reduce(
+        (acc, [k, v]) => acc.replace(new RegExp(`\\{${k}\\}`, 'g'), String(v)),
+        value,
+      );
     };
   },
+}));
+
+// Stub the AjusterResteAVivreDrawer (Client Component using next-intl client,
+// useRouter, etc.) so the Card tests stay narrowly focused on the Server
+// Component output.
+vi.mock('../AjusterResteAVivreDrawer', () => ({
+  AjusterResteAVivreDrawer: (props: { triggerLabel?: string }) => (
+    <button type="button" data-testid="reste-a-vivre-trigger-stub">
+      {props.triggerLabel ?? 'adjust'}
+    </button>
+  ),
 }));
 
 import { CapaciteEpargneCard } from '../CapaciteEpargneCard';
@@ -38,18 +54,22 @@ const charge = (over: Partial<CockpitCharge>): CockpitCharge => ({
 const renderCard = async (input: {
   revenus: Decimal;
   charges: CockpitCharge[];
-  plafondQuotidien: Decimal;
+  resteAVivre: Decimal;
 }) => {
-  const ui = await CapaciteEpargneCard({ ...input, locale: 'fr-BE' });
+  const ui = await CapaciteEpargneCard({
+    ...input,
+    currentMonthYYYYMM: '2026-05',
+    locale: 'fr-BE',
+  });
   return render(ui);
 };
 
-describe('<CapaciteEpargneCard /> (PR-D3 Bloc 2 radar #2 — KPI hero)', () => {
+describe('<CapaciteEpargneCard /> — hero number (PR-BETA-3 tryptique)', () => {
   it('renders the FR title from the dashboard.capacite namespace', async () => {
     await renderCard({
       revenus: new Decimal(2000),
       charges: [],
-      plafondQuotidien: new Decimal(0),
+      resteAVivre: new Decimal(0),
     });
     expect(screen.getByText(messages.dashboard.capacite.title)).toBeInTheDocument();
   });
@@ -58,182 +78,119 @@ describe('<CapaciteEpargneCard /> (PR-D3 Bloc 2 radar #2 — KPI hero)', () => {
     await renderCard({
       revenus: new Decimal(2500),
       charges: [charge({ amount: new Decimal(1500), frequency: 'monthly' })],
-      plafondQuotidien: new Decimal(500),
+      resteAVivre: new Decimal(500),
     });
     const card = screen.getByTestId('capacite-epargne-card');
     expect(card.getAttribute('data-positive')).toBe('true');
     const value = screen.getByTestId('capacite-epargne-value');
     expect(value.textContent ?? '').toMatch(/^\+/);
-    // PR-D5 (2026-05-17): raw `emerald-*` + `dark:text-emerald-*` hacks
-    // replaced by the semantic `text-success` token. Asserts the new
-    // contract; raw Tailwind colour names must NOT leak back in.
     expect(value.className).toContain('text-success');
     expect(value.className).not.toContain('emerald');
-    expect(screen.getByText(messages.dashboard.capacite.message_positive)).toBeInTheDocument();
   });
 
-  it('renders the negative variant with danger token colour and warning message', async () => {
+  it('renders the negative variant with danger token colour', async () => {
     await renderCard({
       revenus: new Decimal(1000),
       charges: [charge({ amount: new Decimal(1500), frequency: 'monthly' })],
-      plafondQuotidien: new Decimal(0),
+      resteAVivre: new Decimal(0),
     });
     const card = screen.getByTestId('capacite-epargne-card');
     expect(card.getAttribute('data-positive')).toBe('false');
     const value = screen.getByTestId('capacite-epargne-value');
-    // PR-D5 (2026-05-17): raw `rose-*` + `dark:text-rose-*` hacks replaced
-    // by the semantic `text-danger` token.
     expect(value.className).toContain('text-danger');
     expect(value.className).not.toContain('rose');
-    expect(screen.getByText(messages.dashboard.capacite.message_negative)).toBeInTheDocument();
   });
 
   it('treats capacité = 0 as positive (≥ 0 contract)', async () => {
     await renderCard({
       revenus: new Decimal(1000),
       charges: [],
-      plafondQuotidien: new Decimal(1000),
+      resteAVivre: new Decimal(1000),
     });
     const card = screen.getByTestId('capacite-epargne-card');
     expect(card.getAttribute('data-positive')).toBe('true');
-    // Zero stays unsigned (no leading "+")
     const value = screen.getByTestId('capacite-epargne-value');
     expect(value.textContent ?? '').not.toMatch(/^\+/);
   });
-
-  it('handles revenus = 0 with massive negative output', async () => {
-    await renderCard({
-      revenus: new Decimal(0),
-      charges: [charge({ amount: new Decimal(100), frequency: 'monthly' })],
-      plafondQuotidien: new Decimal(50),
-    });
-    const card = screen.getByTestId('capacite-epargne-card');
-    expect(card.getAttribute('data-positive')).toBe('false');
-    const value = screen.getByTestId('capacite-epargne-value');
-    expect(value.textContent ?? '').toMatch(/-150/);
-  });
-
-  it('keeps decimal precision across many lissed charges', async () => {
-    // 12 × Dashlane (53 € annual) = 12 × 4.4166… = 53 exactly.
-    const charges = Array.from({ length: 12 }, () =>
-      charge({ amount: new Decimal(53), frequency: 'annual', paymentMonths: [4] }),
-    );
-    await renderCard({
-      revenus: new Decimal(0),
-      charges,
-      plafondQuotidien: new Decimal(0),
-    });
-    const value = screen.getByTestId('capacite-epargne-value');
-    expect(value.textContent ?? '').toMatch(/-53[,.]00/);
-  });
-
-  it('handles the @thierry mixed-frequency fixture (negative case)', async () => {
-    const charges = [
-      charge({ amount: new Decimal(1500), frequency: 'monthly' }),
-      charge({ amount: new Decimal(53), frequency: 'annual', paymentMonths: [4] }),
-      charge({ amount: new Decimal(45), frequency: 'quarterly', paymentMonths: [1, 4, 7, 10] }),
-      charge({ amount: new Decimal(300), frequency: 'annual', paymentMonths: [6] }),
-      charge({ amount: new Decimal(120), frequency: 'annual', paymentMonths: [3] }),
-      charge({ amount: new Decimal(55), frequency: 'annual', paymentMonths: [3] }),
-      charge({ amount: new Decimal(600), frequency: 'semiannual', paymentMonths: [2, 8] }),
-    ];
-    await renderCard({
-      revenus: new Decimal(2000),
-      charges,
-      plafondQuotidien: new Decimal(500),
-    });
-    // capacité = 2000 - 1659 - 500 = -159
-    const card = screen.getByTestId('capacite-epargne-card');
-    expect(card.getAttribute('data-positive')).toBe('false');
-    const value = screen.getByTestId('capacite-epargne-value');
-    expect(value.textContent ?? '').toMatch(/-159/);
-  });
 });
 
-describe('<CapaciteEpargneCard /> — waterfall breakdown (PR-D3-bis)', () => {
-  it('renders the 3-row waterfall when plafond > 0 (revenus / effort / plafond)', async () => {
+describe('<CapaciteEpargneCard /> — tryptique sub-stats (PR-BETA-3)', () => {
+  it('renders 3 sub-stats with the @thierry canonical fixture (662 / 500 / 162)', async () => {
     await renderCard({
       revenus: new Decimal(2500),
+      charges: [charge({ amount: new Decimal(1838), frequency: 'monthly' })],
+      resteAVivre: new Decimal(500),
+    });
+    const substats = screen.getByTestId('capacite-epargne-substats');
+    expect(substats).toBeInTheDocument();
+
+    const resteDispo = screen.getByTestId('substat-reste-disponible');
+    expect(resteDispo.textContent ?? '').toContain(
+      messages.dashboard.capacite.subStats.resteDisponible,
+    );
+    expect(resteDispo.textContent ?? '').toMatch(/662/);
+
+    const resteAVivre = screen.getByTestId('substat-reste-a-vivre');
+    expect(resteAVivre.textContent ?? '').toContain(
+      messages.dashboard.capacite.subStats.resteAVivre,
+    );
+    expect(resteAVivre.textContent ?? '').toMatch(/500/);
+
+    const capacite = screen.getByTestId('substat-capacite');
+    expect(capacite.textContent ?? '').toContain(
+      messages.dashboard.capacite.subStats.capaciteEpargne,
+    );
+    expect(capacite.textContent ?? '').toMatch(/\+\s?162/);
+  });
+
+  it('renders the "Ajuster ce mois" trigger inside the reste-à-vivre sub-stat', async () => {
+    await renderCard({
+      revenus: new Decimal(2500),
+      charges: [],
+      resteAVivre: new Decimal(500),
+    });
+    const trigger = screen.getByTestId('reste-a-vivre-trigger-stub');
+    expect(trigger).toBeInTheDocument();
+    expect(trigger.textContent ?? '').toContain(messages.dashboard.capacite.subStats.ajusterCeMois);
+  });
+
+  it('renders the pedagogical lede with the formatted amount interpolated', async () => {
+    await renderCard({
+      revenus: new Decimal(2500),
+      charges: [charge({ amount: new Decimal(1838), frequency: 'monthly' })],
+      resteAVivre: new Decimal(500),
+    });
+    const lede = screen.getByTestId('capacite-epargne-lede');
+    expect(lede.textContent ?? '').toMatch(/162/);
+    // Anti-culpabilisation contract — must NEVER use blame language.
+    expect(lede.textContent ?? '').not.toMatch(/dépenses trop|tu dois|devrais/i);
+  });
+
+  it('renders the negative lede when capacite < 0 (no judgement language)', async () => {
+    await renderCard({
+      revenus: new Decimal(1000),
       charges: [charge({ amount: new Decimal(1500), frequency: 'monthly' })],
-      plafondQuotidien: new Decimal(500),
+      resteAVivre: new Decimal(0),
     });
-    const breakdown = screen.getByTestId('capacite-epargne-breakdown');
-    expect(breakdown).toBeInTheDocument();
-    expect(breakdown.textContent ?? '').toContain(messages.dashboard.capacite.breakdown.revenus);
-    expect(breakdown.textContent ?? '').toContain(messages.dashboard.capacite.breakdown.effort);
-    expect(breakdown.textContent ?? '').toContain(messages.dashboard.capacite.breakdown.plafond);
-    // Three rows of dt/dd pairs.
-    const rows = breakdown.querySelectorAll('dt');
-    expect(rows.length).toBe(3);
+    const lede = screen.getByTestId('capacite-epargne-lede');
+    expect(lede.textContent ?? '').toBe(messages.dashboard.capacite.ledeNegatif);
   });
 
-  it('omits the plafond row when plafondQuotidien is zero (no noise for unconfigured users)', async () => {
+  it('exposes a tooltip with the explanatory text including resteAVivre', async () => {
     await renderCard({
       revenus: new Decimal(2500),
-      charges: [charge({ amount: new Decimal(1000), frequency: 'monthly' })],
-      plafondQuotidien: new Decimal(0),
+      charges: [charge({ amount: new Decimal(1838), frequency: 'monthly' })],
+      resteAVivre: new Decimal(500),
     });
-    const breakdown = screen.getByTestId('capacite-epargne-breakdown');
-    expect(breakdown.textContent ?? '').toContain(messages.dashboard.capacite.breakdown.revenus);
-    expect(breakdown.textContent ?? '').toContain(messages.dashboard.capacite.breakdown.effort);
-    expect(breakdown.textContent ?? '').not.toContain(
-      messages.dashboard.capacite.breakdown.plafond,
-    );
-    const rows = breakdown.querySelectorAll('dt');
-    expect(rows.length).toBe(2);
-  });
-
-  it('shows the formatted revenus and effort values in the breakdown rows', async () => {
-    await renderCard({
-      revenus: new Decimal(2500),
-      charges: [charge({ amount: new Decimal(1876), frequency: 'monthly' })],
-      plafondQuotidien: new Decimal(500),
-    });
-    const breakdown = screen.getByTestId('capacite-epargne-breakdown');
-    // Match the @thierry empirical fixture from the post-PR-D3 handoff:
-    // revenus = 2500, effort = 1876, plafond = 500.
-    expect(breakdown.textContent ?? '').toMatch(/2\s?500/);
-    expect(breakdown.textContent ?? '').toMatch(/1\s?876/);
-    expect(breakdown.textContent ?? '').toMatch(/500/);
-  });
-
-  it('keeps the big number visible above the message after the breakdown', async () => {
-    await renderCard({
-      revenus: new Decimal(2500),
-      charges: [charge({ amount: new Decimal(1876), frequency: 'monthly' })],
-      plafondQuotidien: new Decimal(500),
-    });
-    // The hero number must remain present and addressable for both visual
-    // primacy and the existing E2E selectors that PR-D3 introduced.
-    const value = screen.getByTestId('capacite-epargne-value');
-    expect(value).toBeInTheDocument();
-    expect(value.textContent ?? '').toMatch(/^\+/);
-    expect(value.textContent ?? '').toMatch(/124/);
+    const tooltip = screen.getByTestId('capacite-epargne-tooltip');
+    const text = tooltip.getAttribute('aria-label') ?? '';
+    expect(text).toMatch(/500/);
   });
 });
 
-describe('dashboard.capacite.breakdown — i18n parity (5 locales)', () => {
+describe('dashboard.capacite — i18n parity (5 locales, tryptique keys)', () => {
   it.each(['fr-BE', 'en', 'de-DE', 'es-ES', 'nl-BE'] as const)(
-    'locale %s exposes breakdown.{revenus,effort,plafond}',
-    async (locale) => {
-      const m = (await import(`../../../../messages/${locale}.json`)).default as {
-        dashboard: {
-          capacite: {
-            breakdown?: { revenus?: string; effort?: string; plafond?: string };
-          };
-        };
-      };
-      expect(m.dashboard.capacite.breakdown?.revenus).toBeTypeOf('string');
-      expect((m.dashboard.capacite.breakdown?.revenus ?? '').length).toBeGreaterThan(0);
-      expect(m.dashboard.capacite.breakdown?.effort).toBeTypeOf('string');
-      expect(m.dashboard.capacite.breakdown?.plafond).toBeTypeOf('string');
-    },
-  );
-});
-
-describe('dashboard.capacite — i18n parity (5 locales)', () => {
-  it.each(['fr-BE', 'en', 'de-DE', 'es-ES', 'nl-BE'] as const)(
-    'locale %s exposes title + message_positive + message_negative',
+    'locale %s exposes the PR-BETA-3 keys (subStats + ledePositif + ledeNegatif + tooltip + drawer.*)',
     async (locale) => {
       const m = (await import(`../../../../messages/${locale}.json`)).default as {
         dashboard: {
@@ -241,13 +198,52 @@ describe('dashboard.capacite — i18n parity (5 locales)', () => {
             title?: string;
             message_positive?: string;
             message_negative?: string;
+            subStats?: {
+              resteDisponible?: string;
+              resteAVivre?: string;
+              capaciteEpargne?: string;
+              ajusterCeMois?: string;
+            };
+            ledePositif?: string;
+            ledeNegatif?: string;
+            tooltip?: string;
+            drawer?: {
+              title?: string;
+              inputLabel?: string;
+              inputHint?: string;
+              helperCoherent?: string;
+              helperBas?: string;
+              helperHaut?: string;
+              save?: string;
+              cancel?: string;
+              errorGeneric?: string;
+            };
           };
         };
       };
+      // Pre-existing keys still present.
       expect(m.dashboard.capacite.title).toBeTypeOf('string');
-      expect((m.dashboard.capacite.title ?? '').length).toBeGreaterThan(0);
       expect(m.dashboard.capacite.message_positive).toBeTypeOf('string');
       expect(m.dashboard.capacite.message_negative).toBeTypeOf('string');
+      // PR-BETA-3 sub-stats.
+      expect(m.dashboard.capacite.subStats?.resteDisponible).toBeTypeOf('string');
+      expect(m.dashboard.capacite.subStats?.resteAVivre).toBeTypeOf('string');
+      expect(m.dashboard.capacite.subStats?.capaciteEpargne).toBeTypeOf('string');
+      expect(m.dashboard.capacite.subStats?.ajusterCeMois).toBeTypeOf('string');
+      // Pedagogical lede must include the {amount} placeholder.
+      expect(m.dashboard.capacite.ledePositif ?? '').toContain('{amount}');
+      expect(m.dashboard.capacite.ledeNegatif).toBeTypeOf('string');
+      // Tooltip must include the {resteAVivre} placeholder.
+      expect(m.dashboard.capacite.tooltip ?? '').toContain('{resteAVivre}');
+      // Drawer namespace complete.
+      expect(m.dashboard.capacite.drawer?.title).toBeTypeOf('string');
+      expect(m.dashboard.capacite.drawer?.inputLabel).toBeTypeOf('string');
+      expect(m.dashboard.capacite.drawer?.helperCoherent).toBeTypeOf('string');
+      expect(m.dashboard.capacite.drawer?.helperBas).toBeTypeOf('string');
+      expect(m.dashboard.capacite.drawer?.helperHaut).toBeTypeOf('string');
+      expect(m.dashboard.capacite.drawer?.save).toBeTypeOf('string');
+      expect(m.dashboard.capacite.drawer?.cancel).toBeTypeOf('string');
+      expect(m.dashboard.capacite.drawer?.errorGeneric).toBeTypeOf('string');
     },
   );
 });

--- a/src/lib/actions/__tests__/reste-a-vivre.test.ts
+++ b/src/lib/actions/__tests__/reste-a-vivre.test.ts
@@ -1,0 +1,349 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type TerminalResult =
+  | { data: unknown; error: null }
+  | { data: null; error: { code?: string; message: string } };
+
+type ScriptedQueue = {
+  table: string;
+  op: 'select' | 'update';
+  result: TerminalResult;
+};
+
+const { supa, requireUserSpy, auditSpy, rateLimitSpy, revalidateSpy } = vi.hoisted(() => {
+  const queue: ScriptedQueue[] = [];
+  let lastUpdate: Record<string, unknown> | undefined;
+
+  function takeResult(table: string, op: ScriptedQueue['op']): TerminalResult {
+    const idx = queue.findIndex((q) => q.table === table && q.op === op);
+    if (idx === -1) {
+      throw new Error(
+        `supabase-mock: no scripted result for ${table}.${op}() — queue=${JSON.stringify(queue)}`,
+      );
+    }
+    const [entry] = queue.splice(idx, 1);
+    return entry!.result;
+  }
+
+  function buildBuilder(table: string) {
+    let currentOp: ScriptedQueue['op'] = 'select';
+    const builder: Record<string, unknown> = {
+      select: vi.fn(() => {
+        currentOp = 'select';
+        return builder;
+      }),
+      update: vi.fn((payload: Record<string, unknown>) => {
+        currentOp = 'update';
+        lastUpdate = payload;
+        return builder;
+      }),
+      eq: vi.fn(() => builder),
+      maybeSingle: vi.fn(async () => takeResult(table, currentOp)),
+      then: (onFulfilled: (v: TerminalResult) => unknown) => {
+        const result = takeResult(table, currentOp);
+        return Promise.resolve(result).then(onFulfilled);
+      },
+    };
+    return builder;
+  }
+
+  const client = {
+    from: vi.fn((table: string) => buildBuilder(table)),
+  };
+
+  return {
+    supa: {
+      get client() {
+        return client;
+      },
+      program: (entry: ScriptedQueue) => queue.push(entry),
+      reset: () => {
+        queue.length = 0;
+        lastUpdate = undefined;
+        client.from.mockClear();
+      },
+      lastUpdatePayload: () => lastUpdate,
+    },
+    requireUserSpy: vi.fn(async () => ({
+      user: { id: 'user-1', email: 'u@a.test' },
+      workspaceId: 'ws-1',
+      role: 'owner' as const,
+    })),
+    auditSpy: vi.fn(async () => {}),
+    rateLimitSpy: vi.fn(async () => ({ success: true, limit: 60, remaining: 59 })),
+    revalidateSpy: vi.fn(),
+  };
+});
+
+vi.mock('@/lib/env', () => ({
+  env: {
+    NODE_ENV: 'test',
+    NEXT_PUBLIC_APP_URL: 'http://localhost:3000',
+    NEXT_PUBLIC_APP_ENV: 'development',
+    NEXT_PUBLIC_SUPABASE_URL: 'http://localhost:54321',
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: 'anon',
+    SUPABASE_SERVICE_ROLE_KEY: 'service',
+    INTERNAL_SECRET: 'a'.repeat(32),
+  },
+  clientEnv: {
+    NEXT_PUBLIC_APP_URL: 'http://localhost:3000',
+    NEXT_PUBLIC_APP_ENV: 'development',
+    NEXT_PUBLIC_SUPABASE_URL: 'http://localhost:54321',
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: 'anon',
+  },
+}));
+
+vi.mock('next/headers', () => ({
+  headers: async () => ({
+    get: (name: string) => {
+      if (name === 'x-forwarded-for') return '127.0.0.1';
+      if (name === 'user-agent') return 'vitest';
+      return null;
+    },
+  }),
+}));
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: async () => supa.client,
+  createAdminClient: async () => supa.client,
+}));
+
+vi.mock('@/lib/auth/require-user', () => ({
+  requireUserWithWorkspace: requireUserSpy,
+}));
+
+vi.mock('@/lib/security/audit-log', () => ({
+  AuditEvent: {
+    WORKSPACE_RESTE_A_VIVRE_UPDATED: 'workspace.reste_a_vivre_updated',
+  },
+  logAuditEvent: auditSpy,
+}));
+
+vi.mock('@/lib/security/rate-limit', () => ({
+  rateLimit: rateLimitSpy,
+}));
+
+vi.mock('@/lib/actions/revalidate', () => ({
+  revalidateDashboard: revalidateSpy,
+}));
+
+// Import AFTER mocks
+import { updateResteAVivreOverrideAction } from '../reste-a-vivre';
+
+const VALID_INPUT = {
+  monthYYYYMM: '2026-05',
+  montant: 450,
+};
+
+function resetAll() {
+  supa.reset();
+  requireUserSpy.mockClear();
+  requireUserSpy.mockImplementation(async () => ({
+    user: { id: 'user-1', email: 'u@a.test' } as unknown as Awaited<
+      ReturnType<typeof requireUserSpy>
+    >['user'],
+    workspaceId: 'ws-1',
+    role: 'owner' as const,
+  }));
+  auditSpy.mockClear();
+  rateLimitSpy.mockClear();
+  rateLimitSpy.mockImplementation(async () => ({ success: true, limit: 60, remaining: 59 }));
+  revalidateSpy.mockClear();
+}
+
+describe('updateResteAVivreOverrideAction — rate limit', () => {
+  beforeEach(resetAll);
+  afterEach(() => vi.clearAllMocks());
+
+  it('returns errors.session.rateLimited when rate-limit hit', async () => {
+    rateLimitSpy.mockImplementationOnce(async () => ({ success: false, limit: 60, remaining: 0 }));
+    const r = await updateResteAVivreOverrideAction(VALID_INPUT);
+    expect(r).toEqual({ ok: false, errorCode: 'errors.session.rateLimited' });
+    expect(auditSpy).not.toHaveBeenCalled();
+    expect(revalidateSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('updateResteAVivreOverrideAction — Zod validation', () => {
+  beforeEach(resetAll);
+  afterEach(() => vi.clearAllMocks());
+
+  it('rejects malformed monthYYYYMM (single-digit month)', async () => {
+    const r = await updateResteAVivreOverrideAction({ monthYYYYMM: '2026-5', montant: 450 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.errorCode).toBe('errors.validation.generic');
+      expect(r.fieldErrors?.monthYYYYMM).toBeDefined();
+    }
+    expect(auditSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects month 13', async () => {
+    const r = await updateResteAVivreOverrideAction({ monthYYYYMM: '2026-13', montant: 450 });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects negative montant', async () => {
+    const r = await updateResteAVivreOverrideAction({ monthYYYYMM: '2026-05', montant: -10 });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects montant above 100 000', async () => {
+    const r = await updateResteAVivreOverrideAction({ monthYYYYMM: '2026-05', montant: 100001 });
+    expect(r.ok).toBe(false);
+  });
+
+  it('accepts montant = 0 (zero-budget month is legitimate)', async () => {
+    supa.program({
+      table: 'workspace_settings',
+      op: 'select',
+      result: { data: { reste_a_vivre_overrides: {} }, error: null },
+    });
+    supa.program({
+      table: 'workspace_settings',
+      op: 'update',
+      result: { data: null, error: null },
+    });
+    const r = await updateResteAVivreOverrideAction({ monthYYYYMM: '2026-05', montant: 0 });
+    expect(r).toEqual({ ok: true });
+  });
+});
+
+describe('updateResteAVivreOverrideAction — happy path', () => {
+  beforeEach(resetAll);
+  afterEach(() => vi.clearAllMocks());
+
+  it('merges into existing overrides without clobbering other months', async () => {
+    supa.program({
+      table: 'workspace_settings',
+      op: 'select',
+      result: {
+        data: { reste_a_vivre_overrides: { '2026-04': 480, '2026-03': 520 } },
+        error: null,
+      },
+    });
+    supa.program({
+      table: 'workspace_settings',
+      op: 'update',
+      result: { data: null, error: null },
+    });
+
+    const r = await updateResteAVivreOverrideAction(VALID_INPUT);
+    expect(r).toEqual({ ok: true });
+    expect(supa.lastUpdatePayload()).toEqual({
+      reste_a_vivre_overrides: { '2026-04': 480, '2026-03': 520, '2026-05': 450 },
+    });
+  });
+
+  it('handles the first override (overrides starts as empty object)', async () => {
+    supa.program({
+      table: 'workspace_settings',
+      op: 'select',
+      result: { data: { reste_a_vivre_overrides: {} }, error: null },
+    });
+    supa.program({
+      table: 'workspace_settings',
+      op: 'update',
+      result: { data: null, error: null },
+    });
+
+    const r = await updateResteAVivreOverrideAction(VALID_INPUT);
+    expect(r).toEqual({ ok: true });
+    expect(supa.lastUpdatePayload()).toEqual({
+      reste_a_vivre_overrides: { '2026-05': 450 },
+    });
+  });
+
+  it('handles workspace_settings row missing (defensive)', async () => {
+    supa.program({
+      table: 'workspace_settings',
+      op: 'select',
+      result: { data: null, error: null },
+    });
+    supa.program({
+      table: 'workspace_settings',
+      op: 'update',
+      result: { data: null, error: null },
+    });
+
+    const r = await updateResteAVivreOverrideAction(VALID_INPUT);
+    expect(r).toEqual({ ok: true });
+    expect(supa.lastUpdatePayload()).toEqual({
+      reste_a_vivre_overrides: { '2026-05': 450 },
+    });
+  });
+
+  it('calls logAuditEvent with WORKSPACE_RESTE_A_VIVRE_UPDATED + period_yyyymm (NO amount)', async () => {
+    supa.program({
+      table: 'workspace_settings',
+      op: 'select',
+      result: { data: { reste_a_vivre_overrides: {} }, error: null },
+    });
+    supa.program({
+      table: 'workspace_settings',
+      op: 'update',
+      result: { data: null, error: null },
+    });
+
+    await updateResteAVivreOverrideAction(VALID_INPUT);
+    expect(auditSpy).toHaveBeenCalledTimes(1);
+    const call = (auditSpy.mock.calls as unknown as unknown[][])[0]!;
+    expect(call[0]).toBe('workspace.reste_a_vivre_updated');
+    expect(call[1]).toMatchObject({ userId: 'user-1', workspaceId: 'ws-1' });
+    expect(call[2]).toEqual({ period_yyyymm: '2026-05' });
+    // Defence-in-depth: the audit metadata must NEVER carry the amount —
+    // amounts are PII-adjacent in financial software.
+    expect(JSON.stringify(call[2])).not.toContain('450');
+    expect(JSON.stringify(call[2])).not.toContain('montant');
+  });
+
+  it('revalidates the dashboard on success', async () => {
+    supa.program({
+      table: 'workspace_settings',
+      op: 'select',
+      result: { data: { reste_a_vivre_overrides: {} }, error: null },
+    });
+    supa.program({
+      table: 'workspace_settings',
+      op: 'update',
+      result: { data: null, error: null },
+    });
+
+    await updateResteAVivreOverrideAction(VALID_INPUT);
+    expect(revalidateSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('updateResteAVivreOverrideAction — DB failures', () => {
+  beforeEach(resetAll);
+  afterEach(() => vi.clearAllMocks());
+
+  it('returns errors.settings.resteAVivreUpdateFailed on read error', async () => {
+    supa.program({
+      table: 'workspace_settings',
+      op: 'select',
+      result: { data: null, error: { code: 'PGRST500', message: 'boom' } },
+    });
+    const r = await updateResteAVivreOverrideAction(VALID_INPUT);
+    expect(r).toEqual({ ok: false, errorCode: 'errors.settings.resteAVivreUpdateFailed' });
+    expect(auditSpy).not.toHaveBeenCalled();
+    expect(revalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns errors.settings.resteAVivreUpdateFailed on write error', async () => {
+    supa.program({
+      table: 'workspace_settings',
+      op: 'select',
+      result: { data: { reste_a_vivre_overrides: {} }, error: null },
+    });
+    supa.program({
+      table: 'workspace_settings',
+      op: 'update',
+      result: { data: null, error: { code: 'PGRST500', message: 'boom' } },
+    });
+    const r = await updateResteAVivreOverrideAction(VALID_INPUT);
+    expect(r).toEqual({ ok: false, errorCode: 'errors.settings.resteAVivreUpdateFailed' });
+    expect(auditSpy).not.toHaveBeenCalled();
+    expect(revalidateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/actions/reste-a-vivre.ts
+++ b/src/lib/actions/reste-a-vivre.ts
@@ -1,0 +1,109 @@
+'use server';
+
+import { headers } from 'next/headers';
+
+import { createClient } from '@/lib/supabase/server';
+import { requireUserWithWorkspace } from '@/lib/auth/require-user';
+import { AuditEvent, logAuditEvent } from '@/lib/security/audit-log';
+import { rateLimit } from '@/lib/security/rate-limit';
+import { resteAVivreMonthOverrideSchema } from '@/lib/schemas/reste-a-vivre';
+import { revalidateDashboard } from '@/lib/actions/revalidate';
+import { log } from '@/lib/log';
+import type { ActionResult } from '@/lib/actions/types';
+
+async function contextFromHeaders(): Promise<{ ip: string | null; userAgent: string | null }> {
+  const h = await headers();
+  const forwarded = h.get('x-forwarded-for');
+  const ip = forwarded?.split(',')[0]?.trim() ?? h.get('x-real-ip') ?? null;
+  return { ip, userAgent: h.get('user-agent') };
+}
+
+/**
+ * "Ajuster ce mois" — PR-BETA-3 (THI-267) Capacité d'Épargne Réelle tryptique.
+ *
+ * Writes a per-month override into `workspace_settings.reste_a_vivre_overrides`,
+ * a JSONB column keyed by `YYYY-MM`. The dashboard lookup priority is:
+ *   `overrides[currentYYYYMM] ?? reste_a_vivre_default`.
+ *
+ * Security envelope (CLAUDE.md doctrine):
+ *   1. `requireUserWithWorkspace()` — Supabase session check + workspace
+ *       membership (RLS-friendly).
+ *   2. `rateLimit('mutation', user:${userId})` — Upstash sliding window.
+ *   3. Zod parse of the input before any DB I/O.
+ *   4. Read-modify-write merges into the existing JSONB so concurrent
+ *      overrides on different months never overwrite each other within a
+ *      single round-trip. RLS guarantees workspace isolation; the explicit
+ *      `eq('workspace_id', workspaceId)` is a defence-in-depth check.
+ *   5. `logAuditEvent(WORKSPACE_RESTE_A_VIVRE_UPDATED)` — no amount in
+ *      metadata (PII-adjacent in financial software), only the targeted
+ *      `period_yyyymm`.
+ *   6. `revalidateDashboard()` so the cockpit re-renders with the new
+ *      `resteAVivre` and the tryptique math updates on the next request.
+ */
+export async function updateResteAVivreOverrideAction(input: unknown): Promise<ActionResult> {
+  const { user, workspaceId } = await requireUserWithWorkspace();
+  const { ip, userAgent } = await contextFromHeaders();
+
+  const rl = await rateLimit('mutation', `user:${user.id}`);
+  if (!rl.success) return { ok: false, errorCode: 'errors.session.rateLimited' };
+
+  const parsed = resteAVivreMonthOverrideSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      errorCode: 'errors.validation.generic',
+      fieldErrors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+    };
+  }
+
+  const supabase = await createClient();
+  const { data: settings, error: readError } = await supabase
+    .from('workspace_settings')
+    .select('reste_a_vivre_overrides')
+    .eq('workspace_id', workspaceId)
+    .maybeSingle();
+
+  if (readError) {
+    log.error('Failed to read workspace_settings before reste-à-vivre override', {
+      workspace_id: workspaceId,
+      error_code: readError.code ?? 'unknown',
+    });
+    return { ok: false, errorCode: 'errors.settings.resteAVivreUpdateFailed' };
+  }
+
+  // Defensive cast — Supabase types may lag if `supabase:types` was not
+  // re-run after the PR-BETA-3 migration. The JSONB column is canonically
+  // `Record<string, number>` per the migration COMMENT.
+  const currentOverrides = (settings?.reste_a_vivre_overrides ?? {}) as Record<string, number>;
+  const nextOverrides: Record<string, number> = {
+    ...currentOverrides,
+    [parsed.data.monthYYYYMM]: parsed.data.montant,
+  };
+
+  const { error: writeError } = await supabase
+    .from('workspace_settings')
+    .update({ reste_a_vivre_overrides: nextOverrides })
+    .eq('workspace_id', workspaceId);
+
+  if (writeError) {
+    log.error('Failed to write workspace_settings reste-à-vivre override', {
+      workspace_id: workspaceId,
+      error_code: writeError.code ?? 'unknown',
+    });
+    return { ok: false, errorCode: 'errors.settings.resteAVivreUpdateFailed' };
+  }
+
+  await logAuditEvent(
+    AuditEvent.WORKSPACE_RESTE_A_VIVRE_UPDATED,
+    {
+      userId: user.id,
+      workspaceId,
+      ipAddress: ip,
+      userAgent,
+    },
+    { period_yyyymm: parsed.data.monthYYYYMM },
+  );
+
+  revalidateDashboard();
+  return { ok: true };
+}

--- a/src/lib/data/workspace-snapshot.ts
+++ b/src/lib/data/workspace-snapshot.ts
@@ -86,6 +86,14 @@ export type WorkspaceSnapshot = {
   vieCouranteMonthlyTransfer: number | null;
   savingsBalance: number;
   monthsTracked: number;
+  /**
+   * Monthly "vie courante" budget used by the Capacité d'Épargne Réelle
+   * tryptique (ADR-009 amendement 2026-05-09). Resolved per-request as
+   * `workspace_settings.reste_a_vivre_overrides[currentYYYYMM]`
+   * ?? `reste_a_vivre_default`. Always a non-negative finite number.
+   * Added PR-BETA-3 (THI-267).
+   */
+  resteAVivre: number;
   accounts: AccountSnapshot[];
   charges: Charge[];
   rawCharges: Array<{
@@ -164,7 +172,13 @@ export async function getWorkspaceSnapshot(): Promise<WorkspaceSnapshot> {
         .single(),
       supabase
         .from('workspace_settings')
-        .select('savings_balance, months_tracked')
+        .select(
+          // PR-BETA-3 (THI-267) added `reste_a_vivre_default` +
+          // `reste_a_vivre_overrides` for the Capacité tryptique. Read both
+          // here so the dashboard can resolve the current-month value in a
+          // single round-trip (no extra query in the page component).
+          'savings_balance, months_tracked, reste_a_vivre_default, reste_a_vivre_overrides',
+        )
         .eq('workspace_id', workspaceId)
         .maybeSingle(),
       supabase
@@ -272,6 +286,28 @@ export async function getWorkspaceSnapshot(): Promise<WorkspaceSnapshot> {
     paidAt: p.paid_at,
   }));
 
+  // PR-BETA-3 (THI-267) — resolve the current-month reste-à-vivre using
+  // overrides[YYYY-MM] ?? default. Supabase's generated types may still
+  // type the new JSONB column as `Json | null` until `supabase:types` is
+  // re-run post-migration, hence the defensive cast.
+  const currentYYYYMM = `${currentYear}-${String(currentMonth).padStart(2, '0')}`;
+  const settingsRow = settingsRes.data as {
+    savings_balance: number | null;
+    months_tracked: number | null;
+    reste_a_vivre_default: number | string | null;
+    reste_a_vivre_overrides: Record<string, number | string> | null;
+  } | null;
+  const resteAVivreDefault = Number(settingsRow?.reste_a_vivre_default ?? 500);
+  const overrideRaw = settingsRow?.reste_a_vivre_overrides?.[currentYYYYMM];
+  const resteAVivreOverride = overrideRaw === undefined ? undefined : Number(overrideRaw);
+  const resolvedResteAVivre =
+    resteAVivreOverride !== undefined && Number.isFinite(resteAVivreOverride)
+      ? resteAVivreOverride
+      : Number.isFinite(resteAVivreDefault)
+        ? resteAVivreDefault
+        : 500;
+  const resteAVivre = Math.max(0, resolvedResteAVivre);
+
   return {
     workspaceId,
     workspaceName: wsRes.data.name,
@@ -279,6 +315,7 @@ export async function getWorkspaceSnapshot(): Promise<WorkspaceSnapshot> {
     vieCouranteMonthlyTransfer: wsRes.data.vie_courante_monthly_transfer,
     savingsBalance: Number(settingsRes.data?.savings_balance ?? 0),
     monthsTracked: Math.max(1, settingsRes.data?.months_tracked ?? 1),
+    resteAVivre,
     accounts,
     charges,
     rawCharges,

--- a/src/lib/domain/cockpit/__tests__/capacite-epargne-reelle.test.ts
+++ b/src/lib/domain/cockpit/__tests__/capacite-epargne-reelle.test.ts
@@ -195,3 +195,79 @@ describe('capaciteEpargneReelle', () => {
     expect(out.isPositive).toBe(true);
   });
 });
+
+describe('capaciteEpargneReelle — PR-BETA-3 tryptique (ADR-009 amendement 2026-05-09)', () => {
+  it('exposes resteDisponible = revenus - effort, separate from capacite', () => {
+    const out = capaciteEpargneReelle({
+      revenus: new Decimal(2500),
+      charges: [charge({ amount: new Decimal(1838), frequency: 'monthly' })],
+      resteAVivre: new Decimal(500),
+    });
+    // resteDisponible should NOT include the reste-à-vivre subtraction.
+    expect(out.resteDisponible.toNumber()).toBe(662);
+    expect(out.resteAVivre.toNumber()).toBe(500);
+    expect(out.capacite.toNumber()).toBe(162);
+  });
+
+  it('reproduces the @thierry persona (662 / 500 / 162) — canonical fixture', () => {
+    // Cf. ADR-009 amendement lignes 252-256 + Athenaeum profil-financier.md.
+    // Effort = 1838 ≈ 1500 loyer + ~338 charges variées (lissées).
+    const out = capaciteEpargneReelle({
+      revenus: new Decimal(2500),
+      charges: [charge({ amount: new Decimal(1838), frequency: 'monthly' })],
+      resteAVivre: new Decimal(500),
+    });
+    expect(out.resteDisponible.toFixed(2)).toBe('662.00');
+    expect(out.resteAVivre.toFixed(2)).toBe('500.00');
+    expect(out.capacite.toFixed(2)).toBe('162.00');
+    expect(out.isPositive).toBe(true);
+  });
+
+  it('handles resteAVivre = 0 (capacite collapses to resteDisponible)', () => {
+    const out = capaciteEpargneReelle({
+      revenus: new Decimal(2000),
+      charges: [charge({ amount: new Decimal(800), frequency: 'monthly' })],
+      resteAVivre: new Decimal(0),
+    });
+    expect(out.resteDisponible.toNumber()).toBe(1200);
+    expect(out.capacite.toNumber()).toBe(1200);
+  });
+
+  it('returns negative capacite when resteAVivre exceeds resteDisponible', () => {
+    const out = capaciteEpargneReelle({
+      revenus: new Decimal(2000),
+      charges: [charge({ amount: new Decimal(1500), frequency: 'monthly' })],
+      resteAVivre: new Decimal(800),
+    });
+    expect(out.resteDisponible.toNumber()).toBe(500);
+    expect(out.capacite.toNumber()).toBe(-300);
+    expect(out.isPositive).toBe(false);
+  });
+
+  it('accepts the legacy plafondQuotidien input shape (back-compat)', () => {
+    // Existing call-sites (PR-D3 CapaciteEpargneCard) still pass
+    // `plafondQuotidien`. They must keep working until PR-BETA-3 lands.
+    const out = capaciteEpargneReelle({
+      revenus: new Decimal(2000),
+      charges: [charge({ amount: new Decimal(900), frequency: 'monthly' })],
+      plafondQuotidien: new Decimal(400),
+    });
+    expect(out.resteDisponible.toNumber()).toBe(1100);
+    expect(out.resteAVivre.toNumber()).toBe(400);
+    expect(out.capacite.toNumber()).toBe(700);
+  });
+
+  it('keeps decimal precision in resteDisponible across many annual provisions', () => {
+    // 53€/an × 12 = 53€ via lissage strict.
+    const charges = Array.from({ length: 12 }, () =>
+      charge({ amount: new Decimal(53), frequency: 'annual', paymentMonths: [4] }),
+    );
+    const out = capaciteEpargneReelle({
+      revenus: new Decimal(2000),
+      charges,
+      resteAVivre: new Decimal(0),
+    });
+    expect(out.resteDisponible.toFixed(6)).toBe('1947.000000');
+    expect(out.capacite.toFixed(6)).toBe('1947.000000');
+  });
+});

--- a/src/lib/domain/cockpit/capacite-epargne-reelle.ts
+++ b/src/lib/domain/cockpit/capacite-epargne-reelle.ts
@@ -6,37 +6,81 @@ import type { CockpitCharge } from './types';
 export type CapaciteEpargneReelleInput = Readonly<{
   revenus: Decimal;
   charges: readonly CockpitCharge[];
+  /**
+   * Monthly "vie courante" budget (groceries, leisure, plaisir, imprévus).
+   * ADR-009 amendement 2026-05-09 renamed this from `plafondQuotidien`
+   * — the formula is unchanged, the UX wording is the canonical one.
+   *
+   * The legacy `plafondQuotidien` alias is still accepted for one release
+   * cycle while the call-sites migrate (PR-BETA-3 → PR-BETA-4).
+   *
+   * @see CapaciteEpargneReelleInputLegacy
+   */
+  resteAVivre: Decimal;
+}>;
+
+/**
+ * @deprecated Use {@link CapaciteEpargneReelleInput} with `resteAVivre`.
+ * Kept for the duration of PR-BETA-3 → PR-BETA-4 to avoid a flag-day on
+ * existing call-sites. Will be removed before v1.0 publique.
+ */
+export type CapaciteEpargneReelleInputLegacy = Readonly<{
+  revenus: Decimal;
+  charges: readonly CockpitCharge[];
   plafondQuotidien: Decimal;
 }>;
 
 export type CapaciteEpargneReelleOutput = Readonly<{
   /** Σ charges mensuelles + provisions lissées (cf. ADR-009 + effort-financier-lisse). */
   effortFinancierLisse: Decimal;
-  /** revenus - effort - plafond. May be negative. */
+  /**
+   * Revenus − Effort_Financier_Lissé. Conceptually: what the user has left
+   * BEFORE allocating the "reste à vivre" budget. Stable mois-après-mois.
+   * Added PR-BETA-3 so the tryptique UI can expose the breakdown without
+   * recomputing the subtraction at the component layer.
+   */
+  resteDisponible: Decimal;
+  /** Passthrough of `input.resteAVivre`. Kept on the output for symmetry. */
+  resteAVivre: Decimal;
+  /** Reste_disponible − Reste_à_vivre. May be negative. */
   capacite: Decimal;
   /** Convenience flag for the UI. */
   isPositive: boolean;
 }>;
 
+function isLegacyInput(
+  input: CapaciteEpargneReelleInput | CapaciteEpargneReelleInputLegacy,
+): input is CapaciteEpargneReelleInputLegacy {
+  return 'plafondQuotidien' in input && !('resteAVivre' in input);
+}
+
 /**
- * Capacité d'Épargne Réelle (ADR-009) =
- *   Revenus - Effort_Financier_Lissé - Plafond_Quotidien
+ * Capacité d'Épargne Réelle (ADR-009 + amendement 2026-05-09) =
+ *   Revenus − Effort_Financier_Lissé − Reste_à_vivre
  *
  * The KPI hero of the cockpit. Designed to be stable mois-après-mois (the
  * lissage absorbs the volatility of periodic bills) and to be honest about
  * whether the user's lifestyle fits inside their income on a true annual
  * basis.
  *
- * No clamping: if revenus = 0 or plafond > revenus, this returns a negative
- * value and the UI layer is responsible for messaging the user.
+ * No clamping: if revenus = 0 or resteAVivre > revenus − effort, this
+ * returns a negative `capacite` and the UI layer is responsible for the
+ * messaging.
+ *
+ * Accepts both the canonical `resteAVivre` shape and the legacy
+ * `plafondQuotidien` shape during the PR-BETA-3 transition window.
  */
 export function capaciteEpargneReelle(
-  input: CapaciteEpargneReelleInput,
+  input: CapaciteEpargneReelleInput | CapaciteEpargneReelleInputLegacy,
 ): CapaciteEpargneReelleOutput {
+  const resteAVivre = isLegacyInput(input) ? input.plafondQuotidien : input.resteAVivre;
   const effort = effortFinancierLisse(input.charges);
-  const capacite = input.revenus.minus(effort).minus(input.plafondQuotidien);
+  const resteDisponible = input.revenus.minus(effort);
+  const capacite = resteDisponible.minus(resteAVivre);
   return {
     effortFinancierLisse: effort,
+    resteDisponible,
+    resteAVivre,
     capacite,
     isPositive: capacite.gte(0),
   };

--- a/src/lib/schemas/reste-a-vivre.ts
+++ b/src/lib/schemas/reste-a-vivre.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+/**
+ * Reste-à-vivre per-month override schema. The "Ajuster ce mois" drawer
+ * (PR-BETA-3, ADR-009 R-10) writes one entry into
+ * `workspace_settings.reste_a_vivre_overrides` keyed by `YYYY-MM`.
+ *
+ * Bounds rationale:
+ *  - 0 € minimum: a user may legitimately budget zero "vie courante" for a
+ *    month (e.g. while travelling and bills are pre-paid). Negative values
+ *    are nonsense and would break the tryptique math.
+ *  - 100 000 € maximum: defensive upper bound matching the DB CHECK
+ *    constraint (`workspace_settings_reste_a_vivre_default_range`). Above
+ *    this we assume an input typo and reject early.
+ *
+ * The regex enforces ISO-ish `YYYY-MM` with month in 01..12. We deliberately
+ * do NOT allow `YYYY-M` (single-digit month) to keep the JSONB key shape
+ * canonical.
+ */
+export const resteAVivreMonthOverrideSchema = z.object({
+  monthYYYYMM: z.string().regex(/^\d{4}-(?:0[1-9]|1[0-2])$/),
+  montant: z.number().finite().min(0).max(100000),
+});
+
+export type ResteAVivreMonthOverrideInput = z.infer<typeof resteAVivreMonthOverrideSchema>;

--- a/src/lib/security/audit-log.ts
+++ b/src/lib/security/audit-log.ts
@@ -23,6 +23,8 @@ export const AuditEvent = {
   WORKSPACE_CREATED: 'workspace.created',
   WORKSPACE_UPDATED: 'workspace.updated',
   WORKSPACE_DELETED: 'workspace.deleted',
+  // PR-BETA-3 (THI-267) — tryptique Capacité Épargne Réelle "Ajuster ce mois"
+  WORKSPACE_RESTE_A_VIVRE_UPDATED: 'workspace.reste_a_vivre_updated',
 
   // Financial data
   CHARGE_CREATED: 'charge.created',
@@ -88,6 +90,11 @@ const SAFE_METADATA_KEYS = new Set([
   // canonical `audit_log.user_id` column AND would survive deletion
   // pseudonymization (jsonb not cascaded by ON DELETE SET NULL).
   'path',
+  // PR-BETA-3 (THI-267) — "Ajuster ce mois" reste-à-vivre override.
+  // `period_yyyymm` = the calendar month targeted by the override
+  // (`YYYY-MM`). No amount stored — amounts are PII-adjacent in financial
+  // software (same rule as charge_payments which excludes `paid_amount`).
+  'period_yyyymm',
 ]);
 
 function sanitizeMetadata(metadata: Record<string, unknown> | undefined): Record<string, unknown> {

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -532,6 +532,11 @@ export type Database = {
         Row: {
           months_tracked: number | null;
           provision_target: number | null;
+          // PR-BETA-3 (THI-267) — columns added by migration 20260526000001.
+          // Patched here manually; `npm run supabase:types` will re-emit
+          // these on the next regeneration against the remote project.
+          reste_a_vivre_default: number;
+          reste_a_vivre_overrides: Json;
           savings_balance: number | null;
           updated_at: string;
           workspace_id: string;
@@ -539,6 +544,8 @@ export type Database = {
         Insert: {
           months_tracked?: number | null;
           provision_target?: number | null;
+          reste_a_vivre_default?: number;
+          reste_a_vivre_overrides?: Json;
           savings_balance?: number | null;
           updated_at?: string;
           workspace_id: string;
@@ -546,6 +553,8 @@ export type Database = {
         Update: {
           months_tracked?: number | null;
           provision_target?: number | null;
+          reste_a_vivre_default?: number;
+          reste_a_vivre_overrides?: Json;
           savings_balance?: number | null;
           updated_at?: string;
           workspace_id?: string;

--- a/supabase/migrations/20260526000001_pr_beta_3_reste_a_vivre.sql
+++ b/supabase/migrations/20260526000001_pr_beta_3_reste_a_vivre.sql
@@ -1,0 +1,41 @@
+-- =========================================================================
+-- PR-BETA-3 (THI-267) — Reste à vivre support for Capacité d'Épargne Réelle
+-- tryptique. ADR-009 amendement 2026-05-09.
+-- =========================================================================
+-- Adds two columns on `workspace_settings` so the dashboard tryptique can
+-- distinguish three concepts that PR-D3-bis collapsed into "Plafond
+-- Quotidien":
+--
+--   * Reste disponible  = Revenus − Effort_Financier_Lissé
+--   * Reste à vivre     = budget vie courante user-saisi (this migration)
+--   * Capacité épargne  = Reste disponible − Reste à vivre
+--
+-- `reste_a_vivre_default` is the steady-state monthly budget set at
+-- onboarding (PR-D5) or inferred from history. `reste_a_vivre_overrides`
+-- captures per-month adjustments via the "Ajuster ce mois" drawer
+-- (ADR-009 R-10 ajustement manuel). Lookup priority:
+-- `overrides[currentYYYYMM] ?? reste_a_vivre_default`.
+--
+-- The table already has RLS policies declared in 20260416000002_rls_policies
+-- — adding columns is automatically covered, no policy patch needed.
+-- =========================================================================
+
+alter table public.workspace_settings
+  add column if not exists reste_a_vivre_default numeric(12, 2) not null default 500.00,
+  add column if not exists reste_a_vivre_overrides jsonb not null default '{}'::jsonb;
+
+-- Defensive guard: `reste_a_vivre_default` must stay non-negative. A budget
+-- under zero is nonsensical and would break the tryptique math (capacite =
+-- reste_disponible - reste_a_vivre with a negative reste_a_vivre would add
+-- instead of subtract). The upper bound 100k matches the Server Action Zod
+-- schema (`z.number().min(0).max(100000)`) so DB constraint and app-level
+-- validation stay in sync.
+alter table public.workspace_settings
+  add constraint workspace_settings_reste_a_vivre_default_range
+  check (reste_a_vivre_default >= 0 and reste_a_vivre_default <= 100000);
+
+comment on column public.workspace_settings.reste_a_vivre_default is
+  'Default monthly reste-à-vivre (vie courante budget, en €). Saisi en onboarding ou ajustable user. ADR-009 amendement 2026-05-09.';
+
+comment on column public.workspace_settings.reste_a_vivre_overrides is
+  'Per-month overrides {"YYYY-MM": montant_numeric} for reste-à-vivre. Lookup priority: overrides[currentMonth] > reste_a_vivre_default. ADR-009 R-10.';


### PR DESCRIPTION
## Summary

- **ADR-009 amendement 2026-05-09** enfin implémenté : remplace le waterfall opaque par un **tryptique pédagogique** (Reste disponible / Reste à vivre / Capacité épargne) — différenciateur NORTH_STAR n°1 d'Ankora.
- **Drawer "Ajuster ce mois"** (R-10) : Server Action + Zod + rate-limit + audit log sans montant + helper text adaptatif (anti-culpabilisation R-06 préservée).
- **Migration SQL** `workspace_settings.reste_a_vivre_{default,overrides}` avec CHECK constraint et lookup `overrides[YYYY-MM] ?? default`.
- **5 locales parity** + 1281 Vitest tests passants + nouveau E2E `dashboard-capacite-tryptique.spec.ts`.

## Refs

- ADR-009 amendement canonique : `docs/adr/ADR-009-capacite-epargne-reelle.md` §"Amendement 2026-05-09"
- Rapport complet : `docs/prs/PR-BETA-3-capacite-tryptique-report.md` (motivation, scope, arbitrages, DoD, smoke iPhone)
- Persona @thierry : valeurs cibles **662 / 500 / 162** pour le smoke iPhone post-merge

## Décisions techniques

| Sujet | Décision |
|---|---|
| Waterfall PR-D3-bis | **Supprimé** (redondant avec sub-stats + EffortFinancierCard voisine) |
| Audit metadata | `period_yyyymm` uniquement — **aucun montant** (PII-adjacent) |
| Drawer | Composant dédié (helper adaptatif ratio resteAVivre/revenus) |
| Supabase types | Patch manuel — \`npm run supabase:types\` à relancer post-merge |
| Onboarding step 3 | Hors-scope (= PR-D5 séparée) |

## Test plan

- [x] Lint + lint:use-server + typecheck + test (1281 ✅) + build
- [x] Migration SQL idempotente (`if not exists` + CHECK nommé)
- [ ] CI verts sur la PR
- [ ] Sourcery silent
- [ ] Migration appliquée Supabase remote (\`supabase db push --linked\`)
- [ ] \`npm run supabase:types\` post-migration pour resync les types
- [ ] Smoke iPhone @thierry : sub-stats 662/500/162 → drawer → ajuster 500→450 → capacité passe à 212

🤖 Generated with [Claude Code](https://claude.com/claude-code)