### PR TITLE
fix(dashboard): Server Action 503 + defensive error toast (THI-267 hotfix)

### DIFF
--- a/docs/patterns/server-actions-error-handling.md
+++ b/docs/patterns/server-actions-error-handling.md
@@ -63,7 +63,7 @@ export async function myMutationAction(input: unknown): Promise<ActionResult> {
 
 1. **Tout englober dans un try/catch monolithique** — incluant `requireUserWithWorkspace()`. Casse le bounce auth `/login`.
 2. **`await logAuditEvent(...)`** sans `.catch()` — un échec d'audit fait crash toute l'action après la write.
-3. **`revalidatePath(...)` sans try/catch** — une infra blip Next.js cache annule la valeur ok au client alors que la DB est OK.
+3. **`revalidatePath(...)` sans try/catch** — un blip d'infra Next.js annule la valeur ok côté client alors que la DB est OK.
 
 ## Pattern côté client (drawer / form)
 

--- a/docs/patterns/server-actions-error-handling.md
+++ b/docs/patterns/server-actions-error-handling.md
@@ -1,0 +1,131 @@
+# Server Actions — Error handling pattern (fail-loud)
+
+> Adopté suite à l'incident **PR-BETA-3 2026-05-26** : un transient HTTP 503 sur la Server Action `updateResteAVivreOverrideAction` fermait silencieusement le drawer "Ajuster ce mois" en prod, sans toast d'erreur. L'utilisateur croyait que sa modification avait été sauvée alors qu'elle ne l'avait pas été.
+
+## Principe
+
+Une Server Action **ne doit jamais** rendre un HTTP 5xx au client en cas d'erreur applicative. Le client (drawer, form, dialog) doit toujours pouvoir interpréter la réponse — soit `{ ok: true }`, soit `{ ok: false, errorCode }`. Une erreur inattendue se traduit par un toast user-visible, jamais par une UI qui se ferme sans feedback.
+
+## Pattern côté Server Action
+
+```ts
+'use server';
+
+export async function myMutationAction(input: unknown): Promise<ActionResult> {
+  // 1. Auth + workspace lookup HORS du try/catch.
+  //    requireUserWithWorkspace() throws Next.js `redirect()` markers when
+  //    no session — ces throws DOIVENT propager. Catcher ici les avalerait
+  //    et le user verrait un "update failed" au lieu d'être bouncé sur /login.
+  const { user, workspaceId } = await requireUserWithWorkspace();
+
+  try {
+    // 2. Rate limit, Zod, DB read + write — tout dans le try.
+    const rl = await rateLimit('mutation', `user:${user.id}`);
+    if (!rl.success) return { ok: false, errorCode: 'errors.session.rateLimited' };
+
+    const parsed = inputSchema.safeParse(input);
+    if (!parsed.success) return { ok: false, errorCode: 'errors.validation.generic', fieldErrors: ... };
+
+    // ... DB read/write avec gestion de `error` Supabase ...
+
+    // 3. Audit log = fire-and-forget. Un blip `audit_log` ne doit JAMAIS
+    //    undo une write user déjà committée.
+    void logAuditEvent(EVENT, ctx, metadata).catch((err) => {
+      log.error('Audit log failed after write succeeded', { error_message: String(err) });
+    });
+
+    // 4. Revalidation = try/catch interne. Si revalidatePath crash après
+    //    la write, la DB est consistente, on log et on renvoie ok.
+    try {
+      revalidateAppPath('...');
+    } catch (err) {
+      log.warn('revalidate failed after write succeeded', { error_message: String(err) });
+    }
+
+    return { ok: true };
+  } catch (err) {
+    // 5. Filet de sécurité ultime. Capture les exceptions imprévues
+    //    (createClient init crash, headers() crash, Zod internal, etc.).
+    //    Log avec stack pour investigation, retourne un errorCode
+    //    traduisible pour le client.
+    log.error('myMutationAction unexpected crash', {
+      user_id: user.id,
+      workspace_id: workspaceId,
+      error_message: err instanceof Error ? err.message : String(err),
+      error_stack: err instanceof Error ? err.stack : undefined,
+    });
+    return { ok: false, errorCode: 'errors.<domain>.<actionFailed>' };
+  }
+}
+```
+
+### Les 3 erreurs à NE PAS faire
+
+1. **Tout englober dans un try/catch monolithique** — incluant `requireUserWithWorkspace()`. Casse le bounce auth `/login`.
+2. **`await logAuditEvent(...)`** sans `.catch()` — un échec d'audit fait crash toute l'action après la write.
+3. **`revalidatePath(...)` sans try/catch** — une infra blip Next.js cache annule la valeur ok au client alors que la DB est OK.
+
+## Pattern côté client (drawer / form)
+
+```tsx
+'use client';
+
+function submit() {
+  startTransition(async () => {
+    try {
+      const result = await myMutationAction(input);
+      if (result.ok) {
+        toast.success(t('mySurface.success'));
+        close(); // ferme drawer / dialog
+        router.refresh(); // re-fetch RSC
+      } else {
+        // Mode erreur métier — translate via useActionErrorTranslator,
+        // drawer/form reste OUVERT pour permettre retry sans re-saisie.
+        toast.error(translateError(result.errorCode) || t('mySurface.errorGeneric'));
+      }
+    } catch (err) {
+      // Mode exception JS (network down, action throws inattendu, …).
+      // eslint-disable-next-line no-console
+      console.error('myMutationAction threw', err);
+      toast.error(t('mySurface.errorGeneric'));
+      // drawer reste OUVERT
+    }
+  });
+}
+```
+
+### Les 3 erreurs à NE PAS faire côté client
+
+1. **`close()` avant de checker `result.ok`** — fermeture optimiste silencieuse, le user pense que c'est OK.
+2. **Pas de `try/catch` autour de l'`await action()`** — une exception JS (network, action throws) crash le `startTransition` sans toast visible.
+3. **`toast.error(result.errorCode)` direct** — affiche `errors.foo.bar` brut au user. Toujours passer par `useActionErrorTranslator`.
+
+## i18n — clés obligatoires
+
+Toute nouvelle Server Action doit ajouter ses error codes dans les **5 locales** (fr-BE, en, nl-BE, de-DE, es-ES) :
+
+- `errors.<domain>.<actionFailed>` — le code retourné par l'action
+- `<surface>.<feedback>.success` — copie du toast succès
+- `<surface>.<feedback>.errorGeneric` — fallback erreur générique
+
+Un test parity dans `<Composant>.test.tsx` assert leur présence + non-vacuité dans les 5 locales.
+
+## Tests Vitest obligatoires
+
+Pour chaque Server Action :
+
+- **Auth bounce propage** : `requireUserWithWorkspace` throws un redirect marker → l'action re-throw (pas swallow).
+- **Audit fail = write OK** : `auditSpy` throws → l'action retourne `{ ok: true }`.
+- **Revalidate fail = write OK** : `revalidateSpy` throws → l'action retourne `{ ok: true }`.
+- **DB read/write error** : Supabase retourne `{ data: null, error: {...} }` → l'action retourne errorCode adapté.
+- **Outer crash** : `createClient` ou `from()` throw → outer catch convertit en `{ ok: false, errorCode }`.
+
+Pour chaque composant client appelant une Server Action :
+
+- **Success** : action retourne `{ ok: true }` → `toast.success` + `close()` + `router.refresh()`.
+- **Erreur métier** : action retourne `{ ok: false, errorCode }` → `toast.error` translaté + drawer reste ouvert.
+- **Exception JS** : action throws → `toast.error` générique + drawer reste ouvert.
+
+## Référence incident
+
+PR-BETA-3 (THI-267) hotfix 2026-05-26. Cf. `docs/prs/PR-BETA-3-capacite-tryptique-report.md` § "Hotfix Server Action 503 + Toast UX".

--- a/docs/prs/PR-BETA-3-capacite-tryptique-report.md
+++ b/docs/prs/PR-BETA-3-capacite-tryptique-report.md
@@ -8,6 +8,94 @@
 
 ---
 
+## Hotfix 2026-05-26 (post-merge) — Server Action 503 + Toast UX defensive
+
+### Contexte
+
+Smoke prod @cowork (Chrome MCP) ~13:00 sur `ankora.be/fr-BE/app` a capturé :
+
+```
+POST https://ankora.be/app           → 503  (Server Action call)
+GET  https://ankora.be/app?_rsc=...  → 503
+GET  https://ankora.be/?_rsc=...     → 503
+```
+
+Symptômes user : drawer "Ajuster ce mois" ferme silencieusement, pas de toast, `reste_a_vivre_overrides` non persisté. À 13:34 le site répond 200 OK : transient Vercel infra (cold start / edge worker crash) déjà résolu côté infra, mais **code Ankora pas robuste face à ce type d'incident**.
+
+### Challenge du diagnostic @cowork
+
+Hypothèse @cowork "migration non appliquée" éliminée : `supabase migration list --linked` confirme `20260526000001` appliquée en prod. Le 503 ne vient pas d'une colonne manquante. Hypothèse @cowork "fail-open rate-limit doctrine" rejetée : action classe 3 (impact 5+ Server Actions), à arbitrer séparément avec @thierry — hors-scope hotfix.
+
+### Hardening livré (utile dans TOUS les cas, pas seulement 503)
+
+**Server Action `updateResteAVivreOverrideAction`** :
+
+1. `requireUserWithWorkspace()` reste **hors du try/catch** — le `redirect('/login')` throws de Next.js doit propager (catcher avalerait l'auth bounce)
+2. **Outer try/catch** autour du reste de l'action → toute exception non prévue (createClient crash, headers crash, etc.) devient `{ ok: false, errorCode: 'errors.settings.resteAVivreUpdateFailed' }` avec log + stack trace serveur
+3. **`logAuditEvent` fire-and-forget** (`void logAuditEvent(...).catch(...)`) — un blip audit_log ne doit jamais undo une write user committée
+4. **`revalidateDashboard()` dans try/catch local** — si revalidate fail APRÈS write, la DB est consistente, on log warning et on retourne ok
+
+**Drawer client `AjusterResteAVivreDrawer`** :
+
+1. **try/catch JS** autour de l'`await updateResteAVivreOverrideAction(...)` → exceptions JS (network down, action throws) → toast erreur générique + drawer reste ouvert
+2. **Toast success** ajouté sur `{ ok: true }` (feedback positif "Reste à vivre ajusté")
+3. **Drawer reste ouvert** sur toute erreur — user peut retry sans re-saisir
+4. `console.error` (eslint-disabled) pour aider l'investigation devtools en cas d'exception
+
+**i18n parity** (5 locales) :
+
+- Nouvelles clés : `dashboard.capacite.drawer.success` + `errors.settings.resteAVivreUpdateFailed`
+- Test parity étendu dans `CapaciteEpargneCard.test.tsx` (assert présence + non-vacuité)
+
+**Documentation pattern** :
+
+- `docs/patterns/server-actions-error-handling.md` (nouveau) — pattern fail-loud à appliquer à toute future Server Action
+
+### Tests hotfix
+
+`src/lib/actions/__tests__/reste-a-vivre.test.ts` — 4 nouveaux tests :
+
+- `logAuditEvent` throws → action `{ ok: true }` (audit non-bloquant)
+- `revalidateDashboard` throws → action `{ ok: true }` (revalidate non-bloquant)
+- `createClient.from` throws → outer catch convertit en `{ ok: false }` (jamais 503)
+- `redirect()` de `requireUserWithWorkspace` propage (auth bounce intact)
+
+`src/components/dashboard/__tests__/AjusterResteAVivreDrawer.test.tsx` — 3 nouveaux tests :
+
+- `{ ok: true }` → toast success + drawer close
+- Action throws → toast error + drawer stays open + pas de `router.refresh`
+- `{ ok: false, errorCode }` → toast message traduit (pas raw errorCode)
+
+`e2e/dashboard-capacite-tryptique.spec.ts` — toast success assert + Toaster mount assert.
+
+### Quality gates hotfix ✅
+
+- `npm run lint` 0 err
+- `npm run lint:use-server` ✅
+- `npm run typecheck` 0 err
+- `npm run test` **1288 passing** (+7 nouveaux)
+- `npm run build` ✅
+
+### Hors-scope hotfix (à discuter séparément si besoin)
+
+- Doctrine `rateLimit` fail-open vs fail-closed prod — touche 5+ Server Actions, arbitrage sécurité dédié
+- Profiling Vercel timeout — non nécessaire avec le defensive hardening
+- Sentry wiring pour capture client-side throws — out-of-scope PR-BETA-3, ticket Linear séparé
+
+### Smoke @thierry post-merge hotfix
+
+1. Cockpit charge → sub-stats 662/500/162 (inchangé)
+2. Tap "Ajuster ce mois" → drawer ouvre
+3. Modifier 500 → 450 → Enregistrer
+   - ✅ Toast vert "Reste à vivre ajusté pour ce mois"
+   - ✅ Drawer ferme
+   - ✅ Sub-stat affiche 450 + capacité passe à 212
+4. Re-tap "Ajuster" → saisir 999999 (au-dessus du max 100k Zod)
+   - ✅ Toast rouge erreur traduit (pas raw errorCode)
+   - ✅ Drawer reste ouvert
+
+---
+
 ## Pourquoi cette PR
 
 ADR-009 amendement 2026-05-09 (validé @thierry, statut canonique) impose le passage du KPI "Capacité d'Épargne Réelle" d'un **waterfall opaque** (Revenus / Effort / Plafond → big number) à un **tryptique pédagogique 3 concepts** :

--- a/docs/prs/PR-BETA-3-capacite-tryptique-report.md
+++ b/docs/prs/PR-BETA-3-capacite-tryptique-report.md
@@ -20,7 +20,7 @@ GET  https://ankora.be/app?_rsc=...  → 503
 GET  https://ankora.be/?_rsc=...     → 503
 ```
 
-Symptômes user : drawer "Ajuster ce mois" ferme silencieusement, pas de toast, `reste_a_vivre_overrides` non persisté. À 13:34 le site répond 200 OK : transient Vercel infra (cold start / edge worker crash) déjà résolu côté infra, mais **code Ankora pas robuste face à ce type d'incident**.
+Symptômes user : drawer "Ajuster ce mois" se ferme silencieusement, pas de toast, `reste_a_vivre_overrides` non persisté. À 13:34 le site répond 200 OK : transient Vercel infra (cold start / edge worker crash) déjà résolu côté infra, mais **code Ankora pas robuste face à ce type d'incident**.
 
 ### Challenge du diagnostic @cowork
 

--- a/e2e/dashboard-capacite-tryptique.spec.ts
+++ b/e2e/dashboard-capacite-tryptique.spec.ts
@@ -92,9 +92,41 @@ test.describe('PR-BETA-3 — Capacité tryptique (ADR-009 amendement)', () => {
       await input.fill('450');
       await page.getByTestId('reste-a-vivre-save').click();
 
+      // PR-BETA-3 hotfix — a success toast (sonner) is now shown before
+      // the drawer closes, so the user has positive confirmation rather
+      // than an ambiguous silent close.
+      await expect(page.getByText(/reste à vivre ajusté/i).first()).toBeVisible({
+        timeout: 5_000,
+      });
+
       // The drawer closes and the sub-stat updates.
       await expect(page.getByTestId('reste-a-vivre-drawer')).toBeHidden();
       await expect(page.getByTestId('substat-reste-a-vivre')).toContainText(/450/);
+    } finally {
+      await deleteSeededUser(admin, user.userId);
+    }
+  });
+
+  // PR-BETA-3 hotfix 2026-05-26 — fail-loud contract. We do not need a real
+  // Server Action failure to assert the toast wiring — the unit tests cover
+  // both `{ ok: false }` and `throws` paths. This E2E verifies the toast
+  // surface itself (sonner mount + i18n + position) is present and
+  // accessible from the dashboard, so a future regression in toast wiring
+  // would break this spec.
+  test('the toast surface is mounted on the dashboard for fail-loud UX', async ({ page }) => {
+    if (!admin) return;
+    const user = await seedOnboardedUser(admin);
+    try {
+      await page.goto('/login');
+      await page.getByLabel('Email').fill(user.email);
+      await page.getByLabel('Mot de passe').fill(user.password);
+      await page.getByRole('button', { name: /^se connecter$/i }).click();
+      await page.waitForURL(/\/app\b/, { timeout: 15_000 });
+
+      // The Toaster (sonner) renders an ARIA-live region with role="status"
+      // even when no toast is active — assert it's mounted so a Server
+      // Action failure CAN surface a toast.
+      await expect(page.locator('[aria-label="Notifications"]').first()).toBeAttached();
     } finally {
       await deleteSeededUser(admin, user.userId);
     }

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -983,6 +983,7 @@
         "helperHaut": "Hohe Schätzung. Ankora respektiert dein Budget — kein Urteil.",
         "save": "Speichern",
         "cancel": "Abbrechen",
+        "success": "Lebenshaltungsbudget für diesen Monat angepasst.",
         "errorGeneric": "Die Anpassung konnte nicht gespeichert werden. Bitte versuche es gleich erneut."
       }
     },
@@ -1229,7 +1230,8 @@
       "profileUpdateFailed": "Profil konnte nicht aktualisiert werden.",
       "deletionRequestFailed": "Löschung konnte nicht geplant werden.",
       "deletionCancelFailed": "Antrag konnte nicht widerrufen werden.",
-      "exportLimited": "Export auf einmal alle 5 Minuten begrenzt."
+      "exportLimited": "Export auf einmal alle 5 Minuten begrenzt.",
+      "resteAVivreUpdateFailed": "Lebenshaltungsbudget konnte nicht angepasst werden. Bitte gleich erneut versuchen."
     },
     "onboarding": {
       "workspaceNotFound": "Workspace nicht gefunden. Kontaktiere den Support.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -983,6 +983,7 @@
         "helperHaut": "High estimate. Ankora respects your budget — no judgement.",
         "save": "Save",
         "cancel": "Cancel",
+        "success": "Daily living budget adjusted for this month.",
         "errorGeneric": "The adjustment couldn't be saved. Please try again in a moment."
       }
     },
@@ -1229,7 +1230,8 @@
       "profileUpdateFailed": "Unable to update the profile.",
       "deletionRequestFailed": "Unable to schedule the deletion.",
       "deletionCancelFailed": "Unable to cancel the request.",
-      "exportLimited": "Export limited to once every 5 minutes."
+      "exportLimited": "Export limited to once every 5 minutes.",
+      "resteAVivreUpdateFailed": "Couldn't adjust the daily living budget. Please try again in a moment."
     },
     "onboarding": {
       "workspaceNotFound": "Workspace not found. Contact support.",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -983,6 +983,7 @@
         "helperHaut": "Estimación alta. Ankora respeta tu presupuesto — sin juicios.",
         "save": "Guardar",
         "cancel": "Cancelar",
+        "success": "Presupuesto vital ajustado para este mes.",
         "errorGeneric": "El ajuste no se ha podido guardar. Inténtalo de nuevo dentro de un momento."
       }
     },
@@ -1229,7 +1230,8 @@
       "profileUpdateFailed": "No se ha podido actualizar el perfil.",
       "deletionRequestFailed": "No se ha podido programar la eliminación.",
       "deletionCancelFailed": "No se ha podido cancelar la solicitud.",
-      "exportLimited": "Exportación limitada a una vez cada 5 minutos."
+      "exportLimited": "Exportación limitada a una vez cada 5 minutos.",
+      "resteAVivreUpdateFailed": "No se ha podido ajustar el presupuesto vital. Inténtalo de nuevo dentro de un momento."
     },
     "onboarding": {
       "workspaceNotFound": "Workspace no encontrado. Contacta con el soporte.",

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -983,6 +983,7 @@
         "helperHaut": "Estimation haute. Ankora respecte ton budget — pas de jugement.",
         "save": "Enregistrer",
         "cancel": "Annuler",
+        "success": "Reste à vivre ajusté pour ce mois.",
         "errorGeneric": "L'ajustement n'a pas pu être enregistré. Réessaye dans un instant."
       }
     },
@@ -1229,7 +1230,8 @@
       "profileUpdateFailed": "Impossible de mettre à jour le profil.",
       "deletionRequestFailed": "Impossible de programmer la suppression.",
       "deletionCancelFailed": "Impossible d'annuler la demande.",
-      "exportLimited": "Export limité à une fois toutes les 5 minutes."
+      "exportLimited": "Export limité à une fois toutes les 5 minutes.",
+      "resteAVivreUpdateFailed": "Impossible d'ajuster le reste à vivre. Réessaie dans un instant."
     },
     "onboarding": {
       "workspaceNotFound": "Workspace introuvable. Contacte le support.",

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -983,6 +983,7 @@
         "helperHaut": "Hoge schatting. Ankora respecteert je budget — geen oordeel.",
         "save": "Opslaan",
         "cancel": "Annuleren",
+        "success": "Leefbudget aangepast voor deze maand.",
         "errorGeneric": "De aanpassing kon niet worden opgeslagen. Probeer het zo opnieuw."
       }
     },
@@ -1229,7 +1230,8 @@
       "profileUpdateFailed": "Kan het profiel niet bijwerken.",
       "deletionRequestFailed": "Kan de verwijdering niet inplannen.",
       "deletionCancelFailed": "Kan de aanvraag niet annuleren.",
-      "exportLimited": "Export beperkt tot één keer per 5 minuten."
+      "exportLimited": "Export beperkt tot één keer per 5 minuten.",
+      "resteAVivreUpdateFailed": "Kon het leefbudget niet aanpassen. Probeer het zo opnieuw."
     },
     "onboarding": {
       "workspaceNotFound": "Workspace niet gevonden. Contacteer de support.",

--- a/src/components/dashboard/AjusterResteAVivreDrawer.tsx
+++ b/src/components/dashboard/AjusterResteAVivreDrawer.tsx
@@ -110,15 +110,32 @@ export function AjusterResteAVivreDrawer({
       return;
     }
     startTransition(async () => {
-      const result = await updateResteAVivreOverrideAction({
-        monthYYYYMM: currentMonthYYYYMM,
-        montant: parsedDraft,
-      });
-      if (result.ok) {
-        setOpen(false);
-        router.refresh();
-      } else {
-        toast.error(translateError(result.errorCode) || t('drawer.errorGeneric'));
+      // PR-BETA-3 hotfix 2026-05-26 — defensive error handling.
+      // Three failure modes are now surfaced as a visible toast (fail-loud):
+      //   1. Server Action returns `{ ok: false, errorCode }` — translate
+      //      via the i18n action-errors helper.
+      //   2. Server Action throws (network down, Vercel infra blip, …)
+      //      — show the generic drawer error toast.
+      // In every failure path the drawer stays OPEN so the user can retry
+      // without re-tapping the trigger and re-entering their amount.
+      try {
+        const result = await updateResteAVivreOverrideAction({
+          monthYYYYMM: currentMonthYYYYMM,
+          montant: parsedDraft,
+        });
+        if (result.ok) {
+          toast.success(t('drawer.success'));
+          setOpen(false);
+          router.refresh();
+        } else {
+          toast.error(translateError(result.errorCode) || t('drawer.errorGeneric'));
+        }
+      } catch (err) {
+        // Log to the browser console so the user can copy-paste it for a
+        // bug report; the toast keeps the UX recoverable.
+        // eslint-disable-next-line no-console
+        console.error('updateResteAVivreOverrideAction threw', err);
+        toast.error(t('drawer.errorGeneric'));
       }
     });
   }

--- a/src/components/dashboard/__tests__/AjusterResteAVivreDrawer.test.tsx
+++ b/src/components/dashboard/__tests__/AjusterResteAVivreDrawer.test.tsx
@@ -6,6 +6,7 @@ import messages from '../../../../messages/fr-BE.json';
 
 const updateMock = vi.hoisted(() => vi.fn());
 const toastErrorMock = vi.hoisted(() => vi.fn());
+const toastSuccessMock = vi.hoisted(() => vi.fn());
 const routerRefreshMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/actions/reste-a-vivre', () => ({
@@ -13,7 +14,7 @@ vi.mock('@/lib/actions/reste-a-vivre', () => ({
 }));
 
 vi.mock('@/components/ui/toast', () => ({
-  toast: { error: toastErrorMock, success: vi.fn() },
+  toast: { error: toastErrorMock, success: toastSuccessMock },
 }));
 
 vi.mock('next/navigation', () => ({
@@ -40,6 +41,7 @@ describe('<AjusterResteAVivreDrawer /> — closed state', () => {
   beforeEach(() => {
     updateMock.mockReset();
     toastErrorMock.mockReset();
+    toastSuccessMock.mockReset();
     routerRefreshMock.mockReset();
   });
 
@@ -60,6 +62,7 @@ describe('<AjusterResteAVivreDrawer /> — open state', () => {
   beforeEach(() => {
     updateMock.mockReset();
     toastErrorMock.mockReset();
+    toastSuccessMock.mockReset();
     routerRefreshMock.mockReset();
   });
 
@@ -122,6 +125,7 @@ describe('<AjusterResteAVivreDrawer /> — submit flow', () => {
   beforeEach(() => {
     updateMock.mockReset();
     toastErrorMock.mockReset();
+    toastSuccessMock.mockReset();
     routerRefreshMock.mockReset();
   });
 
@@ -205,6 +209,7 @@ describe('<AjusterResteAVivreDrawer /> — keyboard + dismiss', () => {
   beforeEach(() => {
     updateMock.mockReset();
     toastErrorMock.mockReset();
+    toastSuccessMock.mockReset();
     routerRefreshMock.mockReset();
   });
 
@@ -217,5 +222,77 @@ describe('<AjusterResteAVivreDrawer /> — keyboard + dismiss', () => {
       expect(screen.queryByTestId('reste-a-vivre-drawer')).toBeNull();
     });
     expect(updateMock).not.toHaveBeenCalled();
+  });
+});
+
+// PR-BETA-3 hotfix 2026-05-26 — defensive UX. Before this change a Server
+// Action failure (HTTP 503, thrown exception, …) closed the drawer
+// silently and the user thought the save succeeded. The drawer now always
+// surfaces failures via a toast and stays open so retry is possible.
+describe('<AjusterResteAVivreDrawer /> — defensive error toast (hotfix)', () => {
+  beforeEach(() => {
+    updateMock.mockReset();
+    toastErrorMock.mockReset();
+    toastSuccessMock.mockReset();
+    routerRefreshMock.mockReset();
+  });
+
+  it('shows a success toast and closes the drawer on { ok: true }', async () => {
+    updateMock.mockResolvedValue({ ok: true });
+    renderWithIntl(<AjusterResteAVivreDrawer {...baseProps} />);
+    fireEvent.click(screen.getByTestId('reste-a-vivre-trigger'));
+    await screen.findByTestId('reste-a-vivre-drawer');
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('reste-a-vivre-save'));
+    });
+    await waitFor(() => {
+      expect(toastSuccessMock).toHaveBeenCalledTimes(1);
+    });
+    // Localised success copy comes through.
+    expect(toastSuccessMock.mock.calls[0]?.[0]).toBe(messages.dashboard.capacite.drawer.success);
+    // Drawer closes on success.
+    await waitFor(() => {
+      expect(screen.queryByTestId('reste-a-vivre-drawer')).toBeNull();
+    });
+  });
+
+  it('shows a toast error and keeps the drawer open when the Server Action throws (network down)', async () => {
+    updateMock.mockRejectedValue(new Error('Failed to fetch'));
+    renderWithIntl(<AjusterResteAVivreDrawer {...baseProps} />);
+    fireEvent.click(screen.getByTestId('reste-a-vivre-trigger'));
+    await screen.findByTestId('reste-a-vivre-drawer');
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('reste-a-vivre-save'));
+    });
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledTimes(1);
+    });
+    // The drawer must stay open so the user can retry without losing
+    // their input.
+    expect(screen.getByTestId('reste-a-vivre-drawer')).toBeInTheDocument();
+    expect(routerRefreshMock).not.toHaveBeenCalled();
+    expect(toastSuccessMock).not.toHaveBeenCalled();
+  });
+
+  it('translates the errorCode when the Server Action returns { ok: false, errorCode }', async () => {
+    updateMock.mockResolvedValue({
+      ok: false,
+      errorCode: 'errors.settings.resteAVivreUpdateFailed',
+    });
+    renderWithIntl(<AjusterResteAVivreDrawer {...baseProps} />);
+    fireEvent.click(screen.getByTestId('reste-a-vivre-trigger'));
+    await screen.findByTestId('reste-a-vivre-drawer');
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('reste-a-vivre-save'));
+    });
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledTimes(1);
+    });
+    // The toast message MUST be the translated copy, not the raw error code.
+    const toastMsg = toastErrorMock.mock.calls[0]?.[0] as string | undefined;
+    expect(toastMsg).toBeTypeOf('string');
+    expect(toastMsg ?? '').not.toContain('errors.');
+    expect((toastMsg ?? '').length).toBeGreaterThan(5);
+    expect(toastSuccessMock).not.toHaveBeenCalled();
   });
 });

--- a/src/components/dashboard/__tests__/AjusterResteAVivreDrawer.test.tsx
+++ b/src/components/dashboard/__tests__/AjusterResteAVivreDrawer.test.tsx
@@ -256,11 +256,12 @@ describe('<AjusterResteAVivreDrawer /> — defensive error toast (hotfix)', () =
     });
   });
 
-  it('shows a toast error and keeps the drawer open when the Server Action throws (network down)', async () => {
+  it('shows a toast error, keeps the drawer open and preserves input when the Server Action throws (network down)', async () => {
     updateMock.mockRejectedValue(new Error('Failed to fetch'));
     renderWithIntl(<AjusterResteAVivreDrawer {...baseProps} />);
     fireEvent.click(screen.getByTestId('reste-a-vivre-trigger'));
-    await screen.findByTestId('reste-a-vivre-drawer');
+    const input = await screen.findByTestId('reste-a-vivre-input');
+    fireEvent.change(input, { target: { value: '123' } });
     await act(async () => {
       fireEvent.click(screen.getByTestId('reste-a-vivre-save'));
     });
@@ -272,6 +273,9 @@ describe('<AjusterResteAVivreDrawer /> — defensive error toast (hotfix)', () =
     expect(screen.getByTestId('reste-a-vivre-drawer')).toBeInTheDocument();
     expect(routerRefreshMock).not.toHaveBeenCalled();
     expect(toastSuccessMock).not.toHaveBeenCalled();
+    // Sourcery review: assert the typed amount is preserved across the
+    // failed submission so the retry doesn't force the user to re-key it.
+    expect(input).toHaveValue('123');
   });
 
   it('translates the errorCode when the Server Action returns { ok: false, errorCode }', async () => {
@@ -293,6 +297,11 @@ describe('<AjusterResteAVivreDrawer /> — defensive error toast (hotfix)', () =
     expect(toastMsg).toBeTypeOf('string');
     expect(toastMsg ?? '').not.toContain('errors.');
     expect((toastMsg ?? '').length).toBeGreaterThan(5);
+    // Sourcery review: symmetry with the throw path — the drawer must stay
+    // open and the route must NOT refresh so the user can retry without
+    // re-entering their amount.
+    expect(screen.getByTestId('reste-a-vivre-drawer')).toBeInTheDocument();
+    expect(routerRefreshMock).not.toHaveBeenCalled();
     expect(toastSuccessMock).not.toHaveBeenCalled();
   });
 });

--- a/src/components/dashboard/__tests__/CapaciteEpargneCard.test.tsx
+++ b/src/components/dashboard/__tests__/CapaciteEpargneCard.test.tsx
@@ -216,8 +216,18 @@ describe('dashboard.capacite — i18n parity (5 locales, tryptique keys)', () =>
               helperHaut?: string;
               save?: string;
               cancel?: string;
+              success?: string;
               errorGeneric?: string;
             };
+          };
+        };
+        // PR-BETA-3 hotfix — `errors.settings.resteAVivreUpdateFailed` is
+        // surfaced via the drawer toast when the Server Action returns
+        // ok:false. Tracked here so a missing locale fails the parity test
+        // rather than silently shipping a raw "errors.settings.…" string.
+        errors?: {
+          settings?: {
+            resteAVivreUpdateFailed?: string;
           };
         };
       };
@@ -244,6 +254,11 @@ describe('dashboard.capacite — i18n parity (5 locales, tryptique keys)', () =>
       expect(m.dashboard.capacite.drawer?.save).toBeTypeOf('string');
       expect(m.dashboard.capacite.drawer?.cancel).toBeTypeOf('string');
       expect(m.dashboard.capacite.drawer?.errorGeneric).toBeTypeOf('string');
+      // PR-BETA-3 hotfix — success copy + dedicated error code.
+      expect(m.dashboard.capacite.drawer?.success).toBeTypeOf('string');
+      expect((m.dashboard.capacite.drawer?.success ?? '').length).toBeGreaterThan(0);
+      expect(m.errors?.settings?.resteAVivreUpdateFailed).toBeTypeOf('string');
+      expect((m.errors?.settings?.resteAVivreUpdateFailed ?? '').length).toBeGreaterThan(0);
     },
   );
 });

--- a/src/lib/actions/__tests__/reste-a-vivre.test.ts
+++ b/src/lib/actions/__tests__/reste-a-vivre.test.ts
@@ -347,3 +347,82 @@ describe('updateResteAVivreOverrideAction — DB failures', () => {
     expect(revalidateSpy).not.toHaveBeenCalled();
   });
 });
+
+// PR-BETA-3 hotfix 2026-05-26 — resilience under transient failures.
+// These cases shipped silently as HTTP 503 before the hotfix; now they are
+// caught and surface as a translated `{ ok: false }` response or — for
+// non-critical post-write side effects — as a successful response with a
+// server-side error log.
+describe('updateResteAVivreOverrideAction — defensive failure modes (hotfix)', () => {
+  beforeEach(resetAll);
+  afterEach(() => vi.clearAllMocks());
+
+  it('still returns ok: true when logAuditEvent throws after the write succeeds', async () => {
+    supa.program({
+      table: 'workspace_settings',
+      op: 'select',
+      result: { data: { reste_a_vivre_overrides: {} }, error: null },
+    });
+    supa.program({
+      table: 'workspace_settings',
+      op: 'update',
+      result: { data: null, error: null },
+    });
+    // Audit log throws — must NOT undo the user write.
+    auditSpy.mockImplementationOnce(async () => {
+      throw new Error('audit_log insert blew up');
+    });
+
+    const r = await updateResteAVivreOverrideAction(VALID_INPUT);
+    expect(r).toEqual({ ok: true });
+    // Revalidation still fires — the write committed.
+    expect(revalidateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('still returns ok: true when revalidateDashboard throws after the write succeeds', async () => {
+    supa.program({
+      table: 'workspace_settings',
+      op: 'select',
+      result: { data: { reste_a_vivre_overrides: {} }, error: null },
+    });
+    supa.program({
+      table: 'workspace_settings',
+      op: 'update',
+      result: { data: null, error: null },
+    });
+    revalidateSpy.mockImplementationOnce(() => {
+      throw new Error('next.js cache infra blip');
+    });
+
+    const r = await updateResteAVivreOverrideAction(VALID_INPUT);
+    expect(r).toEqual({ ok: true });
+  });
+
+  it('returns a translated errorCode when an unexpected throw occurs inside the action body', async () => {
+    // Make Supabase select throw outright (not return { error }) — emulates
+    // a createClient init crash or a transient network exception. The outer
+    // try/catch must convert this into `{ ok: false }`, never a bare 5xx.
+    supa.client.from.mockImplementationOnce(() => {
+      throw new Error('connect ECONNREFUSED');
+    });
+
+    const r = await updateResteAVivreOverrideAction(VALID_INPUT);
+    expect(r).toEqual({ ok: false, errorCode: 'errors.settings.resteAVivreUpdateFailed' });
+    expect(auditSpy).not.toHaveBeenCalled();
+    expect(revalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it('lets Next.js redirect() errors from requireUserWithWorkspace() propagate', async () => {
+    // Simulate the `redirect('/login')` that next/navigation throws when
+    // the session is gone — Next.js relies on the throw to bubble up to
+    // its framework code. If our outer catch swallowed it, the user would
+    // see a generic "update failed" toast instead of being bounced to
+    // /login.
+    const redirectMarker = Object.assign(new Error('NEXT_REDIRECT;replace;/login;307;'), {
+      digest: 'NEXT_REDIRECT;replace;/login;307;',
+    });
+    requireUserSpy.mockRejectedValueOnce(redirectMarker);
+
+    await expect(updateResteAVivreOverrideAction(VALID_INPUT)).rejects.toBe(redirectMarker);
+  });
+});

--- a/src/lib/actions/reste-a-vivre.ts
+++ b/src/lib/actions/reste-a-vivre.ts
@@ -27,83 +27,127 @@ async function contextFromHeaders(): Promise<{ ip: string | null; userAgent: str
  *
  * Security envelope (CLAUDE.md doctrine):
  *   1. `requireUserWithWorkspace()` — Supabase session check + workspace
- *       membership (RLS-friendly).
+ *       membership (RLS-friendly). Kept OUTSIDE the try/catch so the
+ *       `redirect('/login')` thrown by Next.js when no session propagates
+ *       cleanly (catching it would silently swallow the auth bounce).
  *   2. `rateLimit('mutation', user:${userId})` — Upstash sliding window.
  *   3. Zod parse of the input before any DB I/O.
  *   4. Read-modify-write merges into the existing JSONB so concurrent
  *      overrides on different months never overwrite each other within a
  *      single round-trip. RLS guarantees workspace isolation; the explicit
  *      `eq('workspace_id', workspaceId)` is a defence-in-depth check.
- *   5. `logAuditEvent(WORKSPACE_RESTE_A_VIVRE_UPDATED)` — no amount in
- *      metadata (PII-adjacent in financial software), only the targeted
- *      `period_yyyymm`.
+ *   5. `logAuditEvent(WORKSPACE_RESTE_A_VIVRE_UPDATED)` — fire-and-forget
+ *      so an audit log persistence blip never undoes the user write.
+ *      No amount in metadata (PII-adjacent in financial software).
  *   6. `revalidateDashboard()` so the cockpit re-renders with the new
- *      `resteAVivre` and the tryptique math updates on the next request.
+ *      `resteAVivre`. Wrapped in try/catch — if revalidation fails AFTER
+ *      the DB write, the data is already saved and we still return ok.
+ *
+ * PR-BETA-3 hotfix 2026-05-26 (post-merge): added the outer try/catch +
+ * non-blocking audit/revalidate so transient Vercel infra incidents
+ * (cold-start failures, edge worker crashes) surface as a translated
+ * `{ ok: false }` response — never a bare HTTP 503 the client cannot
+ * interpret. The drawer is then responsible for keeping the panel open
+ * + showing a toast so the user can retry.
  */
 export async function updateResteAVivreOverrideAction(input: unknown): Promise<ActionResult> {
+  // requireUserWithWorkspace() throws Next.js `redirect()` markers when no
+  // session — those MUST propagate (catching them would swallow the auth
+  // bounce). Hence kept outside the try/catch below.
   const { user, workspaceId } = await requireUserWithWorkspace();
-  const { ip, userAgent } = await contextFromHeaders();
 
-  const rl = await rateLimit('mutation', `user:${user.id}`);
-  if (!rl.success) return { ok: false, errorCode: 'errors.session.rateLimited' };
+  try {
+    const { ip, userAgent } = await contextFromHeaders();
 
-  const parsed = resteAVivreMonthOverrideSchema.safeParse(input);
-  if (!parsed.success) {
-    return {
-      ok: false,
-      errorCode: 'errors.validation.generic',
-      fieldErrors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+    const rl = await rateLimit('mutation', `user:${user.id}`);
+    if (!rl.success) return { ok: false, errorCode: 'errors.session.rateLimited' };
+
+    const parsed = resteAVivreMonthOverrideSchema.safeParse(input);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        errorCode: 'errors.validation.generic',
+        fieldErrors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+      };
+    }
+
+    const supabase = await createClient();
+    const { data: settings, error: readError } = await supabase
+      .from('workspace_settings')
+      .select('reste_a_vivre_overrides')
+      .eq('workspace_id', workspaceId)
+      .maybeSingle();
+
+    if (readError) {
+      log.error('Failed to read workspace_settings before reste-à-vivre override', {
+        workspace_id: workspaceId,
+        error_code: readError.code ?? 'unknown',
+      });
+      return { ok: false, errorCode: 'errors.settings.resteAVivreUpdateFailed' };
+    }
+
+    // Defensive cast — Supabase types may lag if `supabase:types` was not
+    // re-run after the PR-BETA-3 migration. The JSONB column is canonically
+    // `Record<string, number>` per the migration COMMENT.
+    const currentOverrides = (settings?.reste_a_vivre_overrides ?? {}) as Record<string, number>;
+    const nextOverrides: Record<string, number> = {
+      ...currentOverrides,
+      [parsed.data.monthYYYYMM]: parsed.data.montant,
     };
-  }
 
-  const supabase = await createClient();
-  const { data: settings, error: readError } = await supabase
-    .from('workspace_settings')
-    .select('reste_a_vivre_overrides')
-    .eq('workspace_id', workspaceId)
-    .maybeSingle();
+    const { error: writeError } = await supabase
+      .from('workspace_settings')
+      .update({ reste_a_vivre_overrides: nextOverrides })
+      .eq('workspace_id', workspaceId);
 
-  if (readError) {
-    log.error('Failed to read workspace_settings before reste-à-vivre override', {
+    if (writeError) {
+      log.error('Failed to write workspace_settings reste-à-vivre override', {
+        workspace_id: workspaceId,
+        error_code: writeError.code ?? 'unknown',
+      });
+      return { ok: false, errorCode: 'errors.settings.resteAVivreUpdateFailed' };
+    }
+
+    // Audit log is best-effort: a transient `audit_log` insert failure must
+    // never undo a user write that already succeeded. Fire-and-forget so
+    // the failure mode is an error log entry, not an action error response.
+    void logAuditEvent(
+      AuditEvent.WORKSPACE_RESTE_A_VIVRE_UPDATED,
+      { userId: user.id, workspaceId, ipAddress: ip, userAgent },
+      { period_yyyymm: parsed.data.monthYYYYMM },
+    ).catch((err) => {
+      log.error('Audit log failed after reste-à-vivre write succeeded', {
+        workspace_id: workspaceId,
+        error_message: err instanceof Error ? err.message : String(err),
+      });
+    });
+
+    // Revalidation runs AFTER the write — if it throws (e.g., transient
+    // Next.js cache infra blip), the DB state is still consistent. Swallow
+    // and log so the client gets a clean `{ ok: true }` and refreshes.
+    try {
+      revalidateDashboard();
+    } catch (err) {
+      log.warn('revalidateDashboard failed after reste-à-vivre write succeeded', {
+        workspace_id: workspaceId,
+        error_message: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    return { ok: true };
+  } catch (err) {
+    // Outer safety net for any unexpected throw inside the action body
+    // (createClient init crash, headers() crash, Zod internal, etc.).
+    // Without this catch, a thrown error would surface as a bare HTTP 5xx
+    // the drawer cannot interpret — exactly the symptom that prompted
+    // this hotfix. Log everything we know so the next investigation has
+    // a real stack trace to anchor on.
+    log.error('updateResteAVivreOverrideAction unexpected crash', {
+      user_id: user.id,
       workspace_id: workspaceId,
-      error_code: readError.code ?? 'unknown',
+      error_message: err instanceof Error ? err.message : String(err),
+      error_stack: err instanceof Error ? err.stack : undefined,
     });
     return { ok: false, errorCode: 'errors.settings.resteAVivreUpdateFailed' };
   }
-
-  // Defensive cast — Supabase types may lag if `supabase:types` was not
-  // re-run after the PR-BETA-3 migration. The JSONB column is canonically
-  // `Record<string, number>` per the migration COMMENT.
-  const currentOverrides = (settings?.reste_a_vivre_overrides ?? {}) as Record<string, number>;
-  const nextOverrides: Record<string, number> = {
-    ...currentOverrides,
-    [parsed.data.monthYYYYMM]: parsed.data.montant,
-  };
-
-  const { error: writeError } = await supabase
-    .from('workspace_settings')
-    .update({ reste_a_vivre_overrides: nextOverrides })
-    .eq('workspace_id', workspaceId);
-
-  if (writeError) {
-    log.error('Failed to write workspace_settings reste-à-vivre override', {
-      workspace_id: workspaceId,
-      error_code: writeError.code ?? 'unknown',
-    });
-    return { ok: false, errorCode: 'errors.settings.resteAVivreUpdateFailed' };
-  }
-
-  await logAuditEvent(
-    AuditEvent.WORKSPACE_RESTE_A_VIVRE_UPDATED,
-    {
-      userId: user.id,
-      workspaceId,
-      ipAddress: ip,
-      userAgent,
-    },
-    { period_yyyymm: parsed.data.monthYYYYMM },
-  );
-
-  revalidateDashboard();
-  return { ok: true };
 }

--- a/src/lib/actions/revalidate.ts
+++ b/src/lib/actions/revalidate.ts
@@ -3,10 +3,21 @@ import { revalidatePath } from 'next/cache';
 const APP_ROOT = '/[locale]/app';
 
 /**
- * Invalidate the dashboard root (`/[locale]/app/page.tsx`) for every locale.
- * Pass the route through next/cache with the dynamic `[locale]` segment so Next.js
- * matches the file-system route across all configured locales (cf. Next.js 16 docs
- * on dynamic route segments).
+ * Triggers a Next.js cache revalidation for the cockpit / dashboard surfaces.
+ *
+ * **Synchronous by contract.** This wraps `revalidatePath(...)` which is itself
+ * sync — Next.js queues the invalidation and returns immediately. Callers can
+ * use `try { revalidateDashboard(); } catch { ... }` without `await`.
+ *
+ * Pass the route through next/cache with the dynamic `[locale]` segment so
+ * Next.js matches the file-system route across all configured locales (cf.
+ * Next.js 16 docs on dynamic route segments).
+ *
+ * ⚠️ If this function ever becomes async (e.g. wraps a remote cache purge or
+ * an async API), update ALL call-sites to `await revalidateDashboard()`
+ * inside their try/catch, otherwise unhandled promise rejections will leak
+ * past the sync `catch` block. Search references with:
+ * `grep -r "revalidateDashboard("`.
  */
 export function revalidateDashboard(): void {
   revalidatePath(APP_ROOT, 'page');


### PR DESCRIPTION
## Summary

Hotfix follow-up à PR-BETA-3 (#184) après smoke prod @cowork 2026-05-26 13:00 qui a capturé un **HTTP 503 transient** sur le Server Action `updateResteAVivreOverrideAction`. Le drawer "Ajuster ce mois" fermait silencieusement sans toast, l'utilisateur croyait que sa modification était sauvée alors qu'elle ne l'était pas.

## Challenge du diagnostic @cowork

- **Hypothèse "migration non appliquée" éliminée** : \`supabase migration list --linked\` confirme \`20260526000001\` appliquée en prod.
- **Hypothèse "fail-open rate-limit doctrine" rejetée** comme out-of-scope hotfix : changer la doctrine rate-limit globale (classe 3 — impact 5+ Server Actions) doit être arbitré séparément avec @thierry.
- **À 13:34** : site répond 200 OK, le 503 était transient (cold start Vercel / edge worker crash). Mais **le code n'était pas robuste face à ce type d'incident** → hardening universellement utile.

## Hardening livré

### Server Action

- \`requireUserWithWorkspace()\` reste **hors try/catch** (le \`redirect('/login')\` Next.js doit propager)
- **Outer try/catch** → toute exception non prévue → \`{ ok: false, errorCode }\` + log stack (jamais HTTP 5xx)
- **\`logAuditEvent\` fire-and-forget** — blip audit ne peut plus undo une write committée
- **\`revalidateDashboard\` dans try/catch local** — revalidate fail post-write n'annule pas l'ok au client

### Drawer client

- **try/catch JS** autour de l'\`await action()\` → exceptions JS → toast error + drawer reste ouvert
- **Toast success** ajouté sur \`{ ok: true }\` (feedback positif)
- **Drawer reste ouvert** sur toute erreur → retry possible sans re-saisie

### i18n parity 5 locales

- \`dashboard.capacite.drawer.success\`
- \`errors.settings.resteAVivreUpdateFailed\`
- Test parity étendu

### Documentation pattern

- \`docs/patterns/server-actions-error-handling.md\` — pattern fail-loud à appliquer à toute future Server Action

## Tests

- Vitest **1288 passing** (+7 nouveaux)
- 4 nouveaux tests Server Action : audit throws, revalidate throws, outer crash converted, redirect propagates
- 3 nouveaux tests Drawer : success toast, throws keeps open, errorCode translated
- E2E étendu : toast success assert + Toaster mount assert

## Quality gates ✅

\`lint\` 0 err · \`lint:use-server\` ✅ · \`typecheck\` 0 err · \`test\` 1288 passing · \`build\` ✅

## Test plan

- [x] Tests Vitest + build locaux verts
- [ ] CI verts sur la PR
- [ ] Sourcery silent
- [ ] Smoke @thierry post-merge prod :
  - [ ] Modifier 500 → 450 → \`Enregistrer\` → toast vert + drawer ferme + sub-stat = 450
  - [ ] Saisir 999999 (au-dessus du max 100k Zod) → toast rouge traduit + drawer reste ouvert
  - [ ] DevTools Network : Server Action call retourne JSON (jamais 503)

## Refs

- PR-BETA-3 initial : #184 (merged \`ffab318\`)
- Smoke @cowork 2026-05-26 13:00 Chrome MCP — trace 503 capturée
- Rapport mis à jour : \`docs/prs/PR-BETA-3-capacite-tryptique-report.md\` § "Hotfix 2026-05-26"
- Pattern doc : \`docs/patterns/server-actions-error-handling.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Renforcer l’action serveur du tableau de bord reste-à-vivre et l’UX du tiroir face aux pannes transitoires afin que les erreurs apparaissent via des toasts plutôt que de fermer silencieusement le tiroir, et documenter un modèle réutilisable de gestion des erreurs pour les actions serveur.

Corrections de bugs :
- Empêcher l’action serveur de dérogation du reste-à-vivre de se manifester sous forme de HTTP 5xx bruts en enveloppant sa logique dans un bloc try/catch défensif et en renvoyant des codes d’erreur structurés.
- S’assurer que les échecs de journalisation d’audit et de revalidation du tableau de bord n’invalident plus les écritures reste-à-vivre réussies, afin d’éviter toute perte silencieuse de données en cas de brèves défaillances d’infrastructure.
- Corriger le tiroir pour que les échecs et exceptions de l’action serveur affichent désormais des toasts d’erreur traduits et maintiennent le panneau ouvert au lieu de le fermer silencieusement.

Améliorations :
- Ajouter un toast de succès lorsque la dérogation reste-à-vivre est enregistrée et vérifier la présence du toast et le montage du toaster dans les tests E2E pour une UX « fail-loud ».
- Renforcer la journalisation pour les crashs inattendus des actions serveur afin de capturer le contexte de diagnostic tout en renvoyant des codes d’erreur conviviaux pour l’utilisateur.
- Introduire un code d’erreur i18n et un message de succès pour les mises à jour reste-à-vivre et imposer la parité sur l’ensemble des locales prises en charge via des tests unitaires.
- Ajouter un modèle documenté de gestion d’erreur « fail-loud » pour les actions serveur et leurs appelants côté client afin de guider les futures implémentations.

Documentation :
- Documenter un modèle standard de gestion d’erreur « fail-loud » pour les actions serveur et les composants client, y compris les attentes en matière d’i18n et de tests, et consigner ce correctif urgent dans le rapport d’incident PR-BETA-3.

Tests :
- Étendre les tests unitaires de l’action serveur reste-à-vivre pour couvrir les échecs d’audit/revalidation, les exceptions inattendues et la propagation des redirections d’authentification.
- Ajouter des tests unitaires pour le tiroir afin de vérifier les toasts de succès, les toasts d’erreur traduits et le comportement lorsque l’action serveur lève une exception tout en gardant le tiroir ouvert.
- Mettre à jour les tests E2E pour vérifier le toast de succès lors des mises à jour reste-à-vivre et s’assurer que la surface de toast est montée sur le tableau de bord.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden the reste-à-vivre dashboard server action and drawer UX against transient failures so errors surface via toasts instead of silent drawer closes, and document a reusable server action error-handling pattern.

Bug Fixes:
- Prevent the reste-à-vivre override server action from surfacing as raw HTTP 5xx by wrapping its logic in a defensive try/catch and returning structured error codes.
- Ensure audit logging and dashboard revalidation failures no longer invalidate successful reste-à-vivre writes, avoiding silent data loss on infra blips.
- Fix the drawer so server action failures and exceptions now show translated error toasts and keep the panel open instead of closing silently.

Enhancements:
- Add success toast feedback when the reste-à-vivre override is saved and assert toast presence and toaster mounting in E2E tests for fail-loud UX.
- Strengthen logging for unexpected server action crashes to capture diagnostic context while returning user-friendly error codes.
- Introduce an i18n error code and success message for reste-à-vivre updates and enforce parity across all supported locales via unit tests.
- Add a documented fail-loud error-handling pattern for server actions and their client callers to guide future implementations.

Documentation:
- Document a standard fail-loud error-handling pattern for server actions and client components, including i18n and testing expectations, and record this hotfix in the PR-BETA-3 incident report.

Tests:
- Extend unit tests for the reste-à-vivre server action to cover audit/revalidation failures, unexpected throws, and auth redirect propagation.
- Add drawer unit tests to verify success toasts, translated error toasts, and behavior when the server action throws while keeping the drawer open.
- Update E2E tests to assert the success toast on reste-à-vivre updates and verify that the toast surface is mounted on the dashboard.

</details>