### PR TITLE
chore(beta-cleanup-2): charges UX (paymentDay + Modifier) + santé provisions cap 100% (THI-281)

### DIFF
--- a/docs/prs/PR-BETA-CLEANUP-2-charges-ux-and-provisions-cap-report.md
+++ b/docs/prs/PR-BETA-CLEANUP-2-charges-ux-and-provisions-cap-report.md
@@ -1,0 +1,185 @@
+# PR-BETA-CLEANUP-2 — Charges UX (paymentDay + Modifier + nextDueDate) + Santé Provisions cap 100%
+
+**Linear** : THI-281 (Linear free tier limit atteint — backlog Obsidian)
+**Branch** : `chore/beta-cleanup-2-charges-ux-and-provisions-cap`
+**Date** : 2026-05-26
+**Pilote** : @cc-ankora (Claude Opus 4.7)
+**Demandeur** : @thierry via @cowork prompt — smoke prod 26/05 sur `/app/charges` et `/app`.
+
+---
+
+## Pourquoi cette PR
+
+Smoke @thierry post-merge PR-BETA-3 a révélé **2 bugs UX indépendants** sur le cockpit user :
+
+1. **`/app/charges`** affiche juste le mois abrégé ("JANV.") sans date complète, pas de bouton "Modifier" — seulement Supprimer
+2. **`/app` cockpit** card "Santé des provisions" affiche `546%` "À jour" — math correcte mais UX trompeuse
+
+Aucun Server Action touché → zéro risque de réintroduire l'incident 503 / NEXT_REDIRECT de PR-BETA-3.
+
+---
+
+## Challenge du prompt @cowork (doctrine "ingénieur partenaire d'abord")
+
+Trois corrections de scope avant exécution :
+
+| Prompt @cowork                                          | Réalité du code                                                     | Décision                                                              |
+| ------------------------------------------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| "Server Action `updateChargeAction` à créer si absente" | **Existe déjà** dans `src/lib/actions/charges.ts:88` (PR-D4)        | Réutilisé tel quel                                                    |
+| "Migration SQL si nécessaire pour colonne date"         | `payment_day` + `payment_months[]` existent depuis PR THI-192       | **Pas de migration**, juste exposer dans le UI                        |
+| "Référence UX = ExpensesClient"                         | ExpensesClient lui-même n'a ni bouton Modifier ni date locale-aware | Au-delà de "aligner" — drawer custom créé pour Charges spécifiquement |
+
+**Question levée à @thierry sur la sémantique "date saisie"** : ambiguë entre `created_at`, `payment_day` (jour du mois), ou `effective_from` (date d'effet). @thierry a confirmé "proche de l'option 2 (`payment_day`)" et invité à challenger via best practices. **Décision retenue** : `paymentDay` (jour du mois 1-31) + affichage de la **prochaine échéance complète** (`nextDueDateForCharge`) — pattern standard Monarch/YNAB/Linxo.
+
+---
+
+## Scope livré
+
+### Bug #2 — Santé Provisions cap visuel 100% (Option C)
+
+**Fichier** : `src/components/dashboard/ProvisionHealthGaugeCard.tsx`
+
+```diff
+- const percentLabel = Math.round(ratio * 100);  // 546% pour Thierry
++ const isOverachieving = hasTarget && ratio > 1;
++ const displayPercent = isOverachieving ? 100 : Math.round(ratio * 100);
++ const surplusOverTarget = isOverachieving
++   ? result.soldeEpargneActuel.minus(result.totalEpargneTheorique)
++   : null;
+```
+
+- KPI principal cappé à **100%** quand `solde > cible` (au lieu de 546%)
+- Sub-text **"+ 1 442,42 € au-delà de la cible"** affiché en couleur success
+- ProgressBar `value={Math.min(ratio, 1)}` cappée pour éviter overflow visuel
+- Math interne `result.soldeEpargneActuel` / `result.totalEpargneTheorique` **inchangée** (préservation pour autres consommateurs)
+
+**R-06 anti-culpabilisation respectée** : pas de "trop épargné", pas de "économise trop", juste factuel. Assertion testée.
+
+### Bug #1 — Charges UX (paymentDay + nextDueDate + Modifier)
+
+**Fichiers principaux** :
+
+- `src/lib/domain/charges/payment-months-from-frequency.ts` (nouveau, pure)
+- `src/lib/data/workspace-snapshot.ts` (type `rawCharges` étendu pour exposer `paymentDay` + `paymentMonths`)
+- `src/app/[locale]/app/charges/ChargesClient.tsx` (refactor : form + liste)
+- `src/app/[locale]/app/charges/ChargeEditDrawer.tsx` (nouveau, client)
+
+#### Formulaire "Ajouter une charge"
+
+Ajout d'un Input number **"Jour du mois"** (1-31, requis). Submit calcule désormais explicitement `paymentMonths` via le helper pur `paymentMonthsFromFrequency(frequency, dueMonth)` :
+
+- `monthly` → `[1..12]`
+- `quarterly` → `[dueMonth, +3, +6, +9]` modulo 12 (wrap année correct)
+- `semiannual` → `[dueMonth, +6]` modulo 12
+- `annual` → `[dueMonth]`
+
+**Bug latent corrigé en passant** : avant cette PR, `paymentMonths` était `undefined` à la création → DB default `[1..12]` même pour une charge annuelle → `nextDueDateForCharge()` la traitait comme mensuelle. Le helper garantit maintenant la cohérence frequency ↔ schedule.
+
+#### Liste des charges
+
+- **Colonne `charges-row-next-due`** : affiche la **prochaine échéance complète** locale-aware via `nextDueDateForCharge(c, todayIso)` + `formatDate(iso, locale, 'medium')`. Pour Thierry en fr-BE : "5 juin 2026" au lieu de "JANV." opaque
+- Fallback gracieux à `formatMonth(dueMonth, locale, 'long')` si la charge est inactive ou `paymentMonths` est vide
+- Bouton **"Modifier"** (icône Pencil) ajouté sur chaque row, à côté du Supprimer
+- ARIA labels `editAria` + `deleteAria` avec interpolation `{label}`
+
+#### Drawer "Modifier la charge"
+
+Nouveau composant client `ChargeEditDrawer.tsx` :
+
+- Slide-from-right desktop / full-screen mobile (`h-dvh` + `sm:max-w-md`) — même idiom que `AjusterResteAVivreDrawer` de PR-BETA-3
+- Pré-rempli depuis le row sélectionné (label, amount, frequency, dueMonth, paymentDay)
+- Re-seed synchrone à l'ouverture (pas dans `useEffect` — évite le `react-hooks/set-state-in-effect` anti-pattern de React 19)
+- ESC ferme, backdrop ferme, body scroll-lock pendant ouverture
+- Submit → `updateChargeAction(id, { ...fields, paymentMonths: paymentMonthsFromFrequency(...) })`
+- **Doctrine fail-loud PR-BETA-3 hotfix #3 respectée** : try/catch JS + `isNextControlFlowError(err) → throw err` (NEXT_REDIRECT propage), toast.error sur `{ok:false}` ou exception, drawer reste OUVERT pour retry sans re-saisie
+
+#### i18n 5 locales (fr-BE / en / nl-BE / de-DE / es-ES)
+
+Nouvelles clés :
+
+- `app.charges.paymentDayLabel` + `paymentDayHint`
+- `app.charges.editAria` (avec `{label}`)
+- `app.charges.toastUpdated`
+- `app.charges.drawer.{title, save, saving, cancel, errorGeneric}`
+- `dashboard.health.objectifDepasse` (avec `{amount}`)
+
+---
+
+## Tests
+
+### Vitest (1321 passing, +26 nouveaux)
+
+- **`payment-months-from-frequency.test.ts`** (7 cas) : monthly→[1..12], quarterly avec wrap, semiannual avec wrap, annual single, dueMonth out-of-range défensif, ordre ascendant garanti
+- **`ProvisionHealthGaugeCard.test.tsx`** (+6 cas Option C) : cap à 100%, sub-text "+X€" en couleur success, pas de sub-text à 100% pile, pas de sub-text < 100%, fixture @thierry (1766/323.58), ProgressBar clamped
+- **`ChargesClient.test.tsx`** (+13 cas PR-BETA-CLEANUP-2) :
+  - liste : next-due date locale-aware, Modifier + Supprimer buttons
+  - form add : input paymentDay présent, action payload contient `paymentDay` + `paymentMonths`
+  - drawer : open au Modifier click, pré-remplissage, save → updateChargeAction + toast success, échec → drawer reste ouvert + toast error
+  - i18n parity 5 locales (paymentDay + editAria + toastUpdated + drawer.\*)
+
+### Quality gates ✅
+
+`npm run lint` 0 err · `npm run lint:use-server` ✅ · `npm run typecheck` 0 err · `npm run test` **1321 passing** · `npm run build` ✅
+
+---
+
+## Décisions techniques et arbitrages
+
+| Sujet                               | Décision                                        | Justification                                                                                                 |
+| ----------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `paymentDay` input                  | Input number 1-31 requis                        | Pattern standard banking apps (Monarch, YNAB) ; couvre la sémantique "date de payement" demandée par @thierry |
+| `dueMonth` conservé                 | Oui, garde le UI 1-12                           | Legacy column maintenu pendant migration `paymentMonths`-only (PR-CLEANUP-LEGACY future)                      |
+| `paymentMonths` calculé client-side | Oui, via helper pur                             | Fix bug latent où DB default `[1..12]` cassait `nextDueDateForCharge` pour non-monthly                        |
+| Drawer dédié vs `EditDrawer` atom   | Dédié                                           | L'atom est field-générique, ne supporte pas natively les Select shadcn ; coût isolation faible                |
+| Re-seed drawer state                | Synchrone in-render (`if charge.id !== seedId`) | Évite `setState-in-effect` lint rule React 19 ; même approche que `AjusterResteAVivreDrawer`                  |
+| Cap 100% Option C                   | Math interne préservée                          | `result.ratio` raw reste accessible si autre consommateur en a besoin ; seul l'affichage est cappé            |
+| Migration SQL                       | **Aucune**                                      | `payment_day` + `payment_months[]` existent déjà (PR THI-192) — pas besoin de toucher le schema               |
+
+---
+
+## Smoke test @thierry POST-merge
+
+### `/app/charges`
+
+1. Form : champ "Jour du mois" visible, defaults à 1, required
+2. Ajouter charge "Test" 50€ "annuel" "juin" "jour 15" → liste affiche `15 juin 2026` + bouton Modifier visible
+3. Tap Modifier → drawer slide-in (right desktop / bottom-up mobile)
+4. Drawer pré-rempli avec les valeurs actuelles
+5. Changer montant 50→75 + Save → toast vert "Charge mise à jour" + drawer ferme + liste reflète 75€
+
+### `/app` cockpit
+
+1. Card "Santé des provisions" affiche **`100%`** (au lieu de `546%`)
+2. Sub-text **"+ 1 442,42 € au-delà de la cible"** visible en couleur success
+3. Status "À jour" toujours présent
+4. ProgressBar full (cappée à 100%)
+5. Pas de jugement / culpabilisation dans la copy
+
+---
+
+## Hors-scope (vraiment)
+
+- Refonte ExpensesClient pour ajouter bouton Modifier — autre PR si @thierry le souhaite
+- Refonte categoryId UI dans `/app/charges` — pas demandé
+- Migration `dueMonth` → `paymentMonths`-only — PR-CLEANUP-LEGACY future
+- Notifications J-3 / J-1 / overdue basées sur `paymentDay` — utilise déjà la colonne, pas de changement requis
+
+---
+
+## Files
+
+### Nouveaux (3)
+
+- `src/lib/domain/charges/payment-months-from-frequency.ts`
+- `src/lib/domain/charges/__tests__/payment-months-from-frequency.test.ts`
+- `src/app/[locale]/app/charges/ChargeEditDrawer.tsx`
+
+### Modifiés (11)
+
+- `src/components/dashboard/ProvisionHealthGaugeCard.tsx` (cap 100% + sub-text overflow)
+- `src/components/dashboard/__tests__/ProvisionHealthGaugeCard.test.tsx` (+6 tests + parity overflow)
+- `src/lib/data/workspace-snapshot.ts` (type `rawCharges` exposant `paymentDay` + `paymentMonths`)
+- `src/lib/domain/charges/index.ts` (re-export utility)
+- `src/app/[locale]/app/charges/ChargesClient.tsx` (form + liste refactor)
+- `src/app/[locale]/app/charges/__tests__/ChargesClient.test.tsx` (+13 tests + fixture étendue)
+- `messages/{fr-BE,en,nl-BE,de-DE,es-ES}.json` (clés paymentDay + edit + drawer + objectifDepasse)

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -698,13 +698,24 @@
       "amountLabel": "Betrag (€)",
       "frequencyLabel": "Frequenz",
       "dueMonthLabel": "Referenzmonat",
+      "paymentDayLabel": "Tag im Monat",
+      "paymentDayHint": "Der Tag, an dem die Fixkost abgebucht wird (1–31).",
       "addButton": "Hinzufügen",
       "adding": "Hinzufügen…",
       "count": "{count, plural, =0 {keine Fixkosten} one {1 Fixkosten-Eintrag} other {# Fixkosten-Einträge}}",
       "referenceFormat": "{frequency} · Ref. {month}",
       "deleteAria": "{label} löschen",
+      "editAria": "{label} bearbeiten",
       "toastCreated": "Fixkosten hinzugefügt",
-      "toastDeleted": "Fixkosten gelöscht"
+      "toastUpdated": "Fixkosten aktualisiert",
+      "toastDeleted": "Fixkosten gelöscht",
+      "drawer": {
+        "title": "Fixkosten bearbeiten",
+        "save": "Speichern",
+        "saving": "Speichern…",
+        "cancel": "Abbrechen",
+        "errorGeneric": "Die Änderung konnte nicht gespeichert werden. Bitte gleich erneut versuchen."
+      }
     },
     "accounts": {
       "metaTitle": "Meine Konten",
@@ -998,6 +1009,7 @@
       "empty": "Keine periodischen Kosten geplant — noch nichts anzusparen.",
       "ariaLabel": "Gesundheit der Rücklagen: {percent}% des theoretischen Ziels",
       "deficit": "3-Monats-Aufholplan: {amount}/Monat",
+      "objectifDepasse": "+ {amount} über dem Ziel",
       "status": {
         "a_jour": "Auf Kurs",
         "deficit": "Defizit"

--- a/messages/en.json
+++ b/messages/en.json
@@ -698,13 +698,24 @@
       "amountLabel": "Amount (€)",
       "frequencyLabel": "Frequency",
       "dueMonthLabel": "Reference month",
+      "paymentDayLabel": "Day of month",
+      "paymentDayHint": "The day the bill is debited (1–31).",
       "addButton": "Add",
       "adding": "Adding…",
       "count": "{count, plural, =0 {no bills} one {1 bill} other {# bills}}",
       "referenceFormat": "{frequency} · ref. {month}",
       "deleteAria": "Delete {label}",
+      "editAria": "Edit {label}",
       "toastCreated": "Bill added",
-      "toastDeleted": "Bill deleted"
+      "toastUpdated": "Bill updated",
+      "toastDeleted": "Bill deleted",
+      "drawer": {
+        "title": "Edit bill",
+        "save": "Save",
+        "saving": "Saving…",
+        "cancel": "Cancel",
+        "errorGeneric": "The change couldn't be saved. Please try again in a moment."
+      }
     },
     "accounts": {
       "metaTitle": "My accounts",
@@ -998,6 +1009,7 @@
       "empty": "No periodic charges scheduled — nothing to save up for yet.",
       "ariaLabel": "Provisions health: {percent}% of theoretical target",
       "deficit": "3-month catch-up plan: {amount}/month",
+      "objectifDepasse": "+ {amount} beyond target",
       "status": {
         "a_jour": "On track",
         "deficit": "Deficit"

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -698,13 +698,24 @@
       "amountLabel": "Importe (€)",
       "frequencyLabel": "Frecuencia",
       "dueMonthLabel": "Mes de referencia",
+      "paymentDayLabel": "Día del mes",
+      "paymentDayHint": "El día en que se cobra el gasto fijo (1–31).",
       "addButton": "Añadir",
       "adding": "Añadiendo…",
       "count": "{count, plural, =0 {ningún gasto fijo} one {1 gasto fijo} other {# gastos fijos}}",
       "referenceFormat": "{frequency} · ref. {month}",
       "deleteAria": "Eliminar {label}",
+      "editAria": "Modificar {label}",
       "toastCreated": "Gasto fijo añadido",
-      "toastDeleted": "Gasto fijo eliminado"
+      "toastUpdated": "Gasto fijo actualizado",
+      "toastDeleted": "Gasto fijo eliminado",
+      "drawer": {
+        "title": "Modificar gasto fijo",
+        "save": "Guardar",
+        "saving": "Guardando…",
+        "cancel": "Cancelar",
+        "errorGeneric": "El cambio no se ha podido guardar. Inténtalo de nuevo dentro de un momento."
+      }
     },
     "accounts": {
       "metaTitle": "Mis cuentas",
@@ -998,6 +1009,7 @@
       "empty": "Sin gastos periódicos programados — nada para provisionar por ahora.",
       "ariaLabel": "Salud de las provisiones: {percent}% del objetivo teórico",
       "deficit": "Plan de recuperación a 3 meses: {amount}/mes",
+      "objectifDepasse": "+ {amount} por encima del objetivo",
       "status": {
         "a_jour": "Al día",
         "deficit": "Déficit"

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -698,13 +698,24 @@
       "amountLabel": "Montant (€)",
       "frequencyLabel": "Fréquence",
       "dueMonthLabel": "Mois de référence",
+      "paymentDayLabel": "Jour du mois",
+      "paymentDayHint": "Le jour où la charge est prélevée (1 à 31).",
       "addButton": "Ajouter",
       "adding": "Ajout…",
       "count": "{count, plural, =0 {aucune charge} one {1 charge} other {# charges}}",
       "referenceFormat": "{frequency} · ref. {month}",
       "deleteAria": "Supprimer {label}",
+      "editAria": "Modifier {label}",
       "toastCreated": "Charge ajoutée",
-      "toastDeleted": "Charge supprimée"
+      "toastUpdated": "Charge mise à jour",
+      "toastDeleted": "Charge supprimée",
+      "drawer": {
+        "title": "Modifier la charge",
+        "save": "Enregistrer",
+        "saving": "Enregistrement…",
+        "cancel": "Annuler",
+        "errorGeneric": "La modification n'a pas pu être enregistrée. Réessaye dans un instant."
+      }
     },
     "accounts": {
       "metaTitle": "Mes comptes",
@@ -998,6 +1009,7 @@
       "empty": "Aucune charge périodique programmée — rien à provisionner pour l'instant.",
       "ariaLabel": "Santé des provisions : {percent}% de la cible théorique",
       "deficit": "Plan de rattrapage sur 3 mois : {amount}/mois",
+      "objectifDepasse": "+ {amount} au-delà de la cible",
       "status": {
         "a_jour": "À jour",
         "deficit": "Déficit"

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -698,13 +698,24 @@
       "amountLabel": "Bedrag (€)",
       "frequencyLabel": "Frequentie",
       "dueMonthLabel": "Referentiemaand",
+      "paymentDayLabel": "Dag van de maand",
+      "paymentDayHint": "De dag waarop de kost wordt afgeschreven (1–31).",
       "addButton": "Toevoegen",
       "adding": "Toevoegen…",
       "count": "{count, plural, =0 {geen vaste kosten} one {1 vaste kost} other {# vaste kosten}}",
       "referenceFormat": "{frequency} · ref. {month}",
       "deleteAria": "{label} verwijderen",
+      "editAria": "{label} bewerken",
       "toastCreated": "Vaste kost toegevoegd",
-      "toastDeleted": "Vaste kost verwijderd"
+      "toastUpdated": "Vaste kost bijgewerkt",
+      "toastDeleted": "Vaste kost verwijderd",
+      "drawer": {
+        "title": "Vaste kost bewerken",
+        "save": "Opslaan",
+        "saving": "Opslaan…",
+        "cancel": "Annuleren",
+        "errorGeneric": "De wijziging kon niet worden opgeslagen. Probeer het zo opnieuw."
+      }
     },
     "accounts": {
       "metaTitle": "Mijn rekeningen",
@@ -998,6 +1009,7 @@
       "empty": "Geen periodieke kosten gepland — nog niets om voor te sparen.",
       "ariaLabel": "Gezondheid van de voorzieningen: {percent}% van het theoretische doel",
       "deficit": "Inhaalplan over 3 maanden: {amount}/maand",
+      "objectifDepasse": "+ {amount} boven het doel",
       "status": {
         "a_jour": "Op koers",
         "deficit": "Tekort"

--- a/src/app/[locale]/app/charges/ChargeEditDrawer.tsx
+++ b/src/app/[locale]/app/charges/ChargeEditDrawer.tsx
@@ -1,0 +1,291 @@
+'use client';
+
+import { useEffect, useId, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { X } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+import { updateChargeAction } from '@/lib/actions/charges';
+import { isNextControlFlowError } from '@/lib/actions/next-control-flow';
+import { paymentMonthsFromFrequency } from '@/lib/domain/charges';
+import { useActionErrorTranslator } from '@/lib/i18n/action-errors';
+import { toast } from '@/components/ui/toast';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { cn } from '@/lib/utils';
+
+type Frequency = 'monthly' | 'quarterly' | 'semiannual' | 'annual';
+
+const MONTH_KEYS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const;
+const FREQUENCIES: readonly Frequency[] = ['monthly', 'quarterly', 'semiannual', 'annual'];
+
+export type ChargeEditDrawerCharge = {
+  id: string;
+  label: string;
+  amount: number;
+  frequency: string;
+  dueMonth: number;
+  paymentDay: number;
+};
+
+type Props = {
+  charge: ChargeEditDrawerCharge | null;
+  onClose: () => void;
+};
+
+/**
+ * "Modifier une charge" drawer — PR-BETA-CLEANUP-2 (THI-281).
+ *
+ * Edit affordance for `/app/charges` rows. Mirrors the create form
+ * 1:1 (label, amount, frequency, dueMonth, paymentDay) so the user has
+ * the same mental model whether they're adding or editing.
+ *
+ * Error handling follows the PR-BETA-3 fail-loud pattern:
+ *   - `{ ok: true }` → toast success + close + router.refresh
+ *   - `{ ok: false, errorCode }` → toast translated, drawer STAYS OPEN
+ *   - JS throw → toast generic, drawer STAYS OPEN
+ *   - NEXT_REDIRECT / NEXT_NOT_FOUND → re-thrown so Next.js can navigate
+ *
+ * Slide-from-right on desktop, full-screen on mobile (h-dvh + sm:max-w-md).
+ */
+export function ChargeEditDrawer({ charge, onClose }: Props) {
+  const t = useTranslations('app.charges');
+  const tFreq = useTranslations('common.frequency');
+  const tMonths = useTranslations('common.months');
+  const translateError = useActionErrorTranslator();
+  const router = useRouter();
+
+  const labelId = useId();
+  const amountId = useId();
+  const frequencyId = useId();
+  const dueMonthId = useId();
+  const paymentDayId = useId();
+  const titleId = useId();
+
+  // Seed the form state from the charge BEFORE first render via a `key`-like
+  // technique: derive initial values from the charge.id so that opening a
+  // new charge swaps the entire state in one synchronous batch (no
+  // `setState`-in-effect cascading render). Tracks the last-seeded id to
+  // detect when a different charge is opened and re-seed accordingly.
+  const [seedId, setSeedId] = useState<string | null>(charge?.id ?? null);
+  const [label, setLabel] = useState(charge?.label ?? '');
+  const [amount, setAmount] = useState(charge?.amount.toString() ?? '');
+  const [frequency, setFrequency] = useState<Frequency>(
+    charge ? normalizeFrequency(charge.frequency) : 'monthly',
+  );
+  const [dueMonth, setDueMonth] = useState(charge ? String(charge.dueMonth) : '1');
+  const [paymentDay, setPaymentDay] = useState(charge ? String(charge.paymentDay) : '1');
+  const [isPending, startTransition] = useTransition();
+
+  // When the parent swaps to a different charge while the component is
+  // still mounted, re-seed all fields. Running this during render (rather
+  // than in an effect) avoids the `react-hooks/set-state-in-effect`
+  // anti-pattern: React 19 reconciles the cascading setState batch in the
+  // same render pass.
+  if (charge && charge.id !== seedId) {
+    setSeedId(charge.id);
+    setLabel(charge.label);
+    setAmount(charge.amount.toString());
+    setFrequency(normalizeFrequency(charge.frequency));
+    setDueMonth(String(charge.dueMonth));
+    setPaymentDay(String(charge.paymentDay));
+  }
+
+  // ESC closes; body scroll-locked while open.
+  useEffect(() => {
+    if (!charge) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      document.body.style.overflow = previous;
+    };
+  }, [charge, onClose]);
+
+  if (!charge) return null;
+
+  function submit() {
+    if (!charge) return;
+    const parsedAmount = Number(amount.replace(',', '.'));
+    if (!Number.isFinite(parsedAmount) || parsedAmount < 0) {
+      toast.error(translateError('errors.validation.generic'));
+      return;
+    }
+    const parsedDueMonth = Number(dueMonth);
+    const parsedPaymentDay = Number(paymentDay);
+    const computedPaymentMonths = paymentMonthsFromFrequency(frequency, parsedDueMonth);
+
+    startTransition(async () => {
+      try {
+        const result = await updateChargeAction(charge.id, {
+          label: label.trim(),
+          amount: parsedAmount,
+          frequency,
+          dueMonth: parsedDueMonth,
+          paymentDay: parsedPaymentDay,
+          paymentMonths: computedPaymentMonths,
+        });
+        if (result.ok) {
+          toast.success(t('toastUpdated'));
+          onClose();
+          router.refresh();
+        } else {
+          toast.error(translateError(result.errorCode) || t('drawer.errorGeneric'));
+        }
+      } catch (err) {
+        // Doctrine PR-BETA-3 hotfix #3 — never swallow Next.js control flow.
+        if (isNextControlFlowError(err)) throw err;
+        // eslint-disable-next-line no-console
+        console.error('updateChargeAction threw', err);
+        toast.error(t('drawer.errorGeneric'));
+      }
+    });
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-end sm:items-stretch"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      data-testid="charge-edit-drawer"
+    >
+      <button
+        type="button"
+        aria-label={t('drawer.cancel')}
+        className="bg-foreground/40 absolute inset-0 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      <aside
+        className={cn(
+          'bg-card text-foreground border-border relative flex w-full flex-col border shadow-xl',
+          'h-dvh max-h-dvh',
+          'sm:h-full sm:max-w-md sm:border-l',
+        )}
+      >
+        <header className="border-border flex items-center justify-between gap-3 border-b px-5 py-4">
+          <h2 id={titleId} className="text-lg font-semibold tracking-tight">
+            {t('drawer.title')}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-muted-foreground hover:text-foreground focus-visible:ring-brand-700 -mr-1 rounded-md p-2 focus-visible:ring-2 focus-visible:outline-none"
+            aria-label={t('drawer.cancel')}
+          >
+            <X className="h-5 w-5" aria-hidden />
+          </button>
+        </header>
+
+        <div className="flex flex-1 flex-col gap-4 overflow-y-auto px-5 py-6">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor={labelId}>{t('labelLabel')}</Label>
+            <Input
+              id={labelId}
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              maxLength={120}
+              data-testid="charge-edit-label"
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor={amountId}>{t('amountLabel')}</Label>
+            <Input
+              id={amountId}
+              type="number"
+              inputMode="decimal"
+              min={0}
+              step="0.01"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              data-testid="charge-edit-amount"
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor={frequencyId}>{t('frequencyLabel')}</Label>
+            <Select value={frequency} onValueChange={(v) => setFrequency(v as Frequency)}>
+              <SelectTrigger id={frequencyId} data-testid="charge-edit-frequency">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {FREQUENCIES.map((key) => (
+                  <SelectItem key={key} value={key}>
+                    {tFreq(key)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor={dueMonthId}>{t('dueMonthLabel')}</Label>
+            <Select value={dueMonth} onValueChange={setDueMonth}>
+              <SelectTrigger id={dueMonthId} data-testid="charge-edit-due-month">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {MONTH_KEYS.map((n) => (
+                  <SelectItem key={n} value={String(n)}>
+                    {tMonths(String(n) as '1')}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor={paymentDayId}>{t('paymentDayLabel')}</Label>
+            <Input
+              id={paymentDayId}
+              type="number"
+              inputMode="numeric"
+              min={1}
+              max={31}
+              value={paymentDay}
+              onChange={(e) => setPaymentDay(e.target.value)}
+              data-testid="charge-edit-payment-day"
+            />
+            <p className="text-muted-foreground text-xs">{t('paymentDayHint')}</p>
+          </div>
+        </div>
+
+        <footer className="border-border bg-card flex items-center justify-end gap-2 border-t px-5 py-4">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={onClose}
+            disabled={isPending}
+            data-testid="charge-edit-cancel"
+          >
+            {t('drawer.cancel')}
+          </Button>
+          <Button
+            type="button"
+            onClick={submit}
+            disabled={isPending || label.trim().length === 0}
+            data-testid="charge-edit-save"
+          >
+            {isPending ? t('drawer.saving') : t('drawer.save')}
+          </Button>
+        </footer>
+      </aside>
+    </div>
+  );
+}
+
+function normalizeFrequency(value: string): Frequency {
+  return (FREQUENCIES as readonly string[]).includes(value) ? (value as Frequency) : 'monthly';
+}

--- a/src/app/[locale]/app/charges/ChargesClient.tsx
+++ b/src/app/[locale]/app/charges/ChargesClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState, useTransition } from 'react';
-import { Plus, Trash2 } from 'lucide-react';
+import { useMemo, useState, useTransition } from 'react';
+import { Pencil, Plus, Trash2 } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 
 import { Button } from '@/components/ui/button';
@@ -18,8 +18,12 @@ import {
 import { toast } from '@/components/ui/toast';
 import type { Locale } from '@/i18n/routing';
 import { createChargeAction, deleteChargeAction } from '@/lib/actions/charges';
-import { formatCurrency, formatMonth } from '@/lib/i18n/formatters';
+import { isNextControlFlowError } from '@/lib/actions/next-control-flow';
+import { nextDueDateForCharge, paymentMonthsFromFrequency } from '@/lib/domain/charges';
+import { formatCurrency, formatDate, formatMonth } from '@/lib/i18n/formatters';
 import { useActionErrorTranslator } from '@/lib/i18n/action-errors';
+
+import { ChargeEditDrawer, type ChargeEditDrawerCharge } from './ChargeEditDrawer';
 
 type Frequency = 'monthly' | 'quarterly' | 'semiannual' | 'annual';
 
@@ -32,10 +36,28 @@ type RawCharge = {
   amount: number;
   frequency: string;
   dueMonth: number;
+  paymentDay: number;
+  paymentMonths: readonly number[];
   categoryId: string | null;
   isActive: boolean;
   notes: string | null;
 };
+
+/**
+ * Today as an ISO `YYYY-MM-DD` string anchored to Europe/Brussels — same
+ * timezone the rest of the cockpit uses for due-date math (cf.
+ * `workspace-snapshot` and `dashboard/page`). Computing locally on the
+ * client is fine here because `nextDueDateForCharge()` is a pure function
+ * of the charge schedule + the reference ISO date.
+ */
+function todayBrusselsIso(): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Europe/Brussels',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date());
+}
 
 export function ChargesClient({ charges }: { charges: RawCharge[] }) {
   const t = useTranslations('app.charges');
@@ -49,38 +71,96 @@ export function ChargesClient({ charges }: { charges: RawCharge[] }) {
   const [amount, setAmount] = useState('');
   const [frequency, setFrequency] = useState<Frequency>('monthly');
   const [dueMonth, setDueMonth] = useState('1');
+  const [paymentDay, setPaymentDay] = useState('1');
+  const [editingCharge, setEditingCharge] = useState<ChargeEditDrawerCharge | null>(null);
+
+  const todayIso = useMemo(() => todayBrusselsIso(), []);
 
   function onCreate(e: React.FormEvent) {
     e.preventDefault();
+    const parsedAmount = Number(amount.replace(',', '.'));
+    if (!Number.isFinite(parsedAmount) || parsedAmount < 0) {
+      toast.error(translateError('errors.validation.generic'));
+      return;
+    }
+    const parsedDueMonth = Number(dueMonth);
+    const parsedPaymentDay = Number(paymentDay);
+    const computedPaymentMonths = paymentMonthsFromFrequency(frequency, parsedDueMonth);
+
     startTransition(async () => {
-      const result = await createChargeAction({
-        label: label.trim(),
-        amount: Number(amount),
-        frequency,
-        dueMonth: Number(dueMonth),
-        categoryId: null,
-        isActive: true,
-        notes: null,
-      });
-      if (result.ok) {
-        toast.success(t('toastCreated'));
-        setLabel('');
-        setAmount('');
-      } else {
-        toast.error(translateError(result.errorCode));
+      try {
+        const result = await createChargeAction({
+          label: label.trim(),
+          amount: parsedAmount,
+          frequency,
+          dueMonth: parsedDueMonth,
+          paymentDay: parsedPaymentDay,
+          paymentMonths: computedPaymentMonths,
+          categoryId: null,
+          isActive: true,
+          notes: null,
+        });
+        if (result.ok) {
+          toast.success(t('toastCreated'));
+          setLabel('');
+          setAmount('');
+        } else {
+          toast.error(translateError(result.errorCode));
+        }
+      } catch (err) {
+        if (isNextControlFlowError(err)) throw err;
+        // eslint-disable-next-line no-console
+        console.error('createChargeAction threw', err);
+        toast.error(translateError('errors.charges.createFailed'));
       }
     });
   }
 
   function onDelete(id: string) {
     startTransition(async () => {
-      const result = await deleteChargeAction(id);
-      if (result.ok) {
-        toast.success(t('toastDeleted'));
-      } else {
-        toast.error(translateError(result.errorCode));
+      try {
+        const result = await deleteChargeAction(id);
+        if (result.ok) {
+          toast.success(t('toastDeleted'));
+        } else {
+          toast.error(translateError(result.errorCode));
+        }
+      } catch (err) {
+        if (isNextControlFlowError(err)) throw err;
+        // eslint-disable-next-line no-console
+        console.error('deleteChargeAction threw', err);
+        toast.error(translateError('errors.charges.deleteFailed'));
       }
     });
+  }
+
+  function onEdit(c: RawCharge) {
+    setEditingCharge({
+      id: c.id,
+      label: c.label,
+      amount: c.amount,
+      frequency: c.frequency,
+      dueMonth: c.dueMonth,
+      paymentDay: c.paymentDay,
+    });
+  }
+
+  /**
+   * Compute the next due date label for a row.
+   * Falls back to `formatMonth(dueMonth)` if `nextDueDateForCharge` returns
+   * null (inactive charge or empty paymentMonths from legacy data).
+   */
+  function nextDueLabel(c: RawCharge): string {
+    const iso = nextDueDateForCharge(
+      {
+        isActive: c.isActive,
+        paymentMonths: c.paymentMonths,
+        paymentDay: c.paymentDay,
+      } as Parameters<typeof nextDueDateForCharge>[0],
+      todayIso,
+    );
+    if (iso) return formatDate(iso, locale, 'medium');
+    return formatMonth(c.dueMonth, locale, 'long');
   }
 
   return (
@@ -149,6 +229,20 @@ export function ChargesClient({ charges }: { charges: RawCharge[] }) {
                 </SelectContent>
               </Select>
             </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="paymentDay">{t('paymentDayLabel')}</Label>
+              <Input
+                id="paymentDay"
+                type="number"
+                inputMode="numeric"
+                min={1}
+                max={31}
+                value={paymentDay}
+                onChange={(e) => setPaymentDay(e.target.value)}
+                required
+              />
+              <p className="text-muted-foreground text-xs">{t('paymentDayHint')}</p>
+            </div>
             <div className="md:col-span-2">
               <Button type="submit" disabled={isPending}>
                 <Plus className="h-4 w-4" />
@@ -178,16 +272,16 @@ export function ChargesClient({ charges }: { charges: RawCharge[] }) {
                 <li
                   key={c.id}
                   data-testid={`charges-row-${c.id}`}
-                  className="bg-card border-border/60 md:hover:bg-surface-muted relative rounded-lg border p-4 pr-14 transition-colors md:grid md:grid-cols-[5rem_minmax(0,1fr)_auto_auto_auto] md:items-baseline md:gap-4 md:rounded-none md:border-0 md:bg-transparent md:px-2 md:py-3 md:pr-2"
+                  className="bg-card border-border/60 md:hover:bg-surface-muted relative rounded-lg border p-4 pr-24 transition-colors md:grid md:grid-cols-[minmax(8rem,10rem)_minmax(0,1fr)_auto_auto_auto_auto] md:items-baseline md:gap-4 md:rounded-none md:border-0 md:bg-transparent md:px-2 md:py-3 md:pr-2"
                 >
-                  {/* Mobile: header row (month + amount on a single line, justify-between).
-                      Desktop: contents — projects month + amount as direct grid children. */}
+                  {/* Mobile: header row (next-due + amount on a single line).
+                      Desktop: contents — projects next-due + amount as grid cells 1 / 4. */}
                   <div className="flex items-baseline justify-between gap-3 md:contents">
                     <span
-                      data-testid="charges-row-month"
-                      className="text-muted-foreground text-xs font-medium tracking-wide uppercase md:order-1 md:text-sm"
+                      data-testid="charges-row-next-due"
+                      className="text-muted-foreground text-xs font-medium tracking-wide md:order-1 md:text-sm"
                     >
-                      {formatMonth(c.dueMonth, locale, 'short')}
+                      {nextDueLabel(c)}
                     </span>
                     <span
                       data-testid="charges-row-amount"
@@ -197,8 +291,8 @@ export function ChargesClient({ charges }: { charges: RawCharge[] }) {
                     </span>
                   </div>
 
-                  {/* Mobile: body row (label + frequency chip, flex gap-2 mt-2).
-                      Desktop: contents — projects label + chip as cells 2 and 3. */}
+                  {/* Mobile: body row (label + frequency chip).
+                      Desktop: contents — projects label + chip as cells 2 / 3. */}
                   <div className="mt-2 flex items-center gap-2 md:mt-0 md:contents">
                     <span
                       data-testid="charges-row-label"
@@ -214,7 +308,20 @@ export function ChargesClient({ charges }: { charges: RawCharge[] }) {
                     </span>
                   </div>
 
-                  {/* Delete: top-right tap target on mobile (44×44), inline cell 5 on desktop (36×36). */}
+                  {/* Edit + Delete: stacked top-right tap targets on mobile,
+                      inline cells 5 / 6 on desktop. */}
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => onEdit(c)}
+                    disabled={isPending}
+                    aria-label={t('editAria', { label: c.label })}
+                    data-testid={`charges-row-edit-${c.id}`}
+                    className="absolute top-2 right-14 size-11 shrink-0 md:static md:order-5 md:size-9 md:self-center"
+                  >
+                    <Pencil className="text-muted-foreground h-4 w-4" />
+                  </Button>
                   <Button
                     type="button"
                     variant="ghost"
@@ -222,7 +329,8 @@ export function ChargesClient({ charges }: { charges: RawCharge[] }) {
                     onClick={() => onDelete(c.id)}
                     disabled={isPending}
                     aria-label={t('deleteAria', { label: c.label })}
-                    className="absolute top-2 right-2 size-11 shrink-0 md:static md:order-5 md:size-9 md:self-center"
+                    data-testid={`charges-row-delete-${c.id}`}
+                    className="absolute top-2 right-2 size-11 shrink-0 md:static md:order-6 md:size-9 md:self-center"
                   >
                     <Trash2 className="text-danger h-4 w-4" />
                   </Button>
@@ -232,6 +340,8 @@ export function ChargesClient({ charges }: { charges: RawCharge[] }) {
           )}
         </CardContent>
       </Card>
+
+      <ChargeEditDrawer charge={editingCharge} onClose={() => setEditingCharge(null)} />
     </div>
   );
 }

--- a/src/app/[locale]/app/charges/__tests__/ChargesClient.test.tsx
+++ b/src/app/[locale]/app/charges/__tests__/ChargesClient.test.tsx
@@ -11,25 +11,30 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { NextIntlClientProvider } from 'next-intl';
 
 import messages from '../../../../../../messages/fr-BE.json';
 
 const createChargeMock = vi.hoisted(() => vi.fn());
+const updateChargeMock = vi.hoisted(() => vi.fn());
 const deleteChargeMock = vi.hoisted(() => vi.fn());
+const toastSuccessMock = vi.hoisted(() => vi.fn());
+const toastErrorMock = vi.hoisted(() => vi.fn());
+const routerRefreshMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/actions/charges', () => ({
   createChargeAction: createChargeMock,
+  updateChargeAction: updateChargeMock,
   deleteChargeAction: deleteChargeMock,
 }));
 
 vi.mock('@/components/ui/toast', () => ({
-  toast: { success: vi.fn(), error: vi.fn() },
+  toast: { success: toastSuccessMock, error: toastErrorMock },
 }));
 
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ refresh: vi.fn(), push: vi.fn(), replace: vi.fn() }),
+  useRouter: () => ({ refresh: routerRefreshMock, push: vi.fn(), replace: vi.fn() }),
 }));
 
 import { ChargesClient } from '../ChargesClient';
@@ -49,6 +54,8 @@ const sampleCharges = [
     amount: 1200,
     frequency: 'monthly',
     dueMonth: 1,
+    paymentDay: 5,
+    paymentMonths: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const,
     categoryId: null,
     isActive: true,
     notes: null,
@@ -59,6 +66,8 @@ const sampleCharges = [
     amount: 300,
     frequency: 'annual',
     dueMonth: 6,
+    paymentDay: 15,
+    paymentMonths: [6] as const,
     categoryId: null,
     isActive: true,
     notes: null,
@@ -68,7 +77,11 @@ const sampleCharges = [
 describe('<ChargesClient /> — PR-BETA-1 visual refactor', () => {
   beforeEach(() => {
     createChargeMock.mockReset();
+    updateChargeMock.mockReset();
     deleteChargeMock.mockReset();
+    toastSuccessMock.mockReset();
+    toastErrorMock.mockReset();
+    routerRefreshMock.mockReset();
   });
 
   it('shows the empty-state copy when no charges are provided', () => {
@@ -91,7 +104,9 @@ describe('<ChargesClient /> — PR-BETA-1 visual refactor', () => {
 
     // Row 1 — dueMonth: 1 (january) → "Janv." in fr-BE short, amount 1 200 €.
     const firstRow = screen.getByTestId('charges-row-a1');
-    expect(within(firstRow).getByTestId('charges-row-month')).toHaveTextContent(/^janv\.?$/i);
+    // PR-BETA-CLEANUP-2 (THI-281): `charges-row-month` was replaced by
+    // `charges-row-next-due` (locale-aware date). See the dedicated next-due
+    // assertions in the PR-BETA-CLEANUP-2 describe block below.
     expect(within(firstRow).getByTestId('charges-row-label')).toHaveTextContent(
       'Loyer appartement',
     );
@@ -102,7 +117,7 @@ describe('<ChargesClient /> — PR-BETA-1 visual refactor', () => {
     // Row 2 — dueMonth: 6 (june) → "Juin" in fr-BE short, amount 300 €.
     // Locks the dueMonth → formatMonth wiring against silent regressions.
     const secondRow = screen.getByTestId('charges-row-a2');
-    expect(within(secondRow).getByTestId('charges-row-month')).toHaveTextContent(/^juin$/i);
+    // PR-BETA-CLEANUP-2: next-due asserted below; month-only cell removed.
     expect(within(secondRow).getByTestId('charges-row-label')).toHaveTextContent('Taxe voiture');
     expect(within(secondRow).getByTestId('charges-row-frequency')).toHaveTextContent(/annuel/i);
     expect(within(secondRow).getByTestId('charges-row-amount')).toHaveTextContent(/300/);
@@ -123,11 +138,150 @@ describe('<ChargesClient /> — PR-BETA-1 visual refactor', () => {
 
   it('preserves the add-form CRUD scaffolding (out-of-scope guard against accidental refactor)', () => {
     renderWithIntl(<ChargesClient charges={[]} />);
-    // The 4 form fields + submit button stay reachable by their labels and roles.
+    // The 5 form fields + submit button stay reachable by their labels and roles.
     expect(screen.getByLabelText('Libellé')).toBeInTheDocument();
     expect(screen.getByLabelText(/Montant/)).toBeInTheDocument();
     expect(screen.getByLabelText('Fréquence')).toBeInTheDocument();
     expect(screen.getByLabelText('Mois de référence')).toBeInTheDocument();
+    expect(screen.getByLabelText(/jour du mois/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /^ajouter$/i })).toBeInTheDocument();
   });
+});
+
+// PR-BETA-CLEANUP-2 (THI-281) — next-due cell, paymentDay input, edit drawer.
+describe('<ChargesClient /> — PR-BETA-CLEANUP-2 list & form', () => {
+  beforeEach(() => {
+    createChargeMock.mockReset();
+    updateChargeMock.mockReset();
+    deleteChargeMock.mockReset();
+    toastSuccessMock.mockReset();
+    toastErrorMock.mockReset();
+    routerRefreshMock.mockReset();
+  });
+
+  it('renders the next-due column with a locale-aware date for active charges', () => {
+    renderWithIntl(<ChargesClient charges={sampleCharges} />);
+    const cell = within(screen.getByTestId('charges-row-a1')).getByTestId('charges-row-next-due');
+    // 4-digit year present (formatDate medium) — no longer just "JANV.".
+    expect(cell.textContent ?? '').toMatch(/\d{4}/);
+    expect(cell.textContent ?? '').not.toMatch(/^[a-zà-ÿ]{3,5}\.?$/i);
+  });
+
+  it('renders both Modifier and Supprimer buttons on each row', () => {
+    renderWithIntl(<ChargesClient charges={sampleCharges} />);
+    expect(screen.getByTestId('charges-row-edit-a1')).toBeInTheDocument();
+    expect(screen.getByTestId('charges-row-delete-a1')).toBeInTheDocument();
+    expect(screen.getByTestId('charges-row-edit-a2')).toBeInTheDocument();
+    expect(screen.getByTestId('charges-row-delete-a2')).toBeInTheDocument();
+  });
+
+  it('passes paymentDay + computed paymentMonths to createChargeAction', async () => {
+    createChargeMock.mockResolvedValue({ ok: true });
+    renderWithIntl(<ChargesClient charges={[]} />);
+    fireEvent.change(screen.getByLabelText('Libellé'), { target: { value: 'Assurance' } });
+    fireEvent.change(screen.getByLabelText(/Montant/), { target: { value: '120' } });
+    fireEvent.change(screen.getByLabelText(/jour du mois/i), { target: { value: '15' } });
+    await act(async () => {
+      fireEvent.submit(screen.getByRole('button', { name: /^ajouter$/i }).closest('form')!);
+    });
+    await waitFor(() => expect(createChargeMock).toHaveBeenCalledTimes(1));
+    const payload = createChargeMock.mock.calls[0]?.[0];
+    expect(payload.paymentDay).toBe(15);
+    expect(payload.amount).toBe(120);
+    expect(payload.label).toBe('Assurance');
+    // Monthly default → all 12 months in the schedule.
+    expect(payload.paymentMonths).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+  });
+});
+
+describe('<ChargesClient /> — PR-BETA-CLEANUP-2 edit drawer', () => {
+  beforeEach(() => {
+    createChargeMock.mockReset();
+    updateChargeMock.mockReset();
+    deleteChargeMock.mockReset();
+    toastSuccessMock.mockReset();
+    toastErrorMock.mockReset();
+    routerRefreshMock.mockReset();
+  });
+
+  it('opens the drawer when the Modifier button is clicked', async () => {
+    renderWithIntl(<ChargesClient charges={sampleCharges} />);
+    expect(screen.queryByTestId('charge-edit-drawer')).toBeNull();
+    fireEvent.click(screen.getByTestId('charges-row-edit-a1'));
+    expect(await screen.findByTestId('charge-edit-drawer')).toBeInTheDocument();
+  });
+
+  it('pre-fills the drawer fields with the row data', async () => {
+    renderWithIntl(<ChargesClient charges={sampleCharges} />);
+    fireEvent.click(screen.getByTestId('charges-row-edit-a1'));
+    await screen.findByTestId('charge-edit-drawer');
+    expect(screen.getByTestId('charge-edit-label')).toHaveValue('Loyer appartement');
+    expect(screen.getByTestId('charge-edit-amount')).toHaveValue(1200);
+    expect(screen.getByTestId('charge-edit-payment-day')).toHaveValue(5);
+  });
+
+  it('calls updateChargeAction with the modified amount on Save', async () => {
+    updateChargeMock.mockResolvedValue({ ok: true });
+    renderWithIntl(<ChargesClient charges={sampleCharges} />);
+    fireEvent.click(screen.getByTestId('charges-row-edit-a1'));
+    await screen.findByTestId('charge-edit-drawer');
+    fireEvent.change(screen.getByTestId('charge-edit-amount'), { target: { value: '1350' } });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('charge-edit-save'));
+    });
+    await waitFor(() => expect(updateChargeMock).toHaveBeenCalledTimes(1));
+    expect(updateChargeMock.mock.calls[0]?.[0]).toBe('a1');
+    expect(updateChargeMock.mock.calls[0]?.[1]).toMatchObject({ amount: 1350, paymentDay: 5 });
+    expect(toastSuccessMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the drawer open and shows an error toast on update failure', async () => {
+    updateChargeMock.mockResolvedValue({ ok: false, errorCode: 'errors.charges.updateFailed' });
+    renderWithIntl(<ChargesClient charges={sampleCharges} />);
+    fireEvent.click(screen.getByTestId('charges-row-edit-a1'));
+    await screen.findByTestId('charge-edit-drawer');
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('charge-edit-save'));
+    });
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId('charge-edit-drawer')).toBeInTheDocument();
+    expect(toastSuccessMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('app.charges — i18n parity (5 locales, PR-BETA-CLEANUP-2)', () => {
+  it.each(['fr-BE', 'en', 'de-DE', 'es-ES', 'nl-BE'] as const)(
+    'locale %s exposes paymentDay + edit + drawer keys',
+    async (locale) => {
+      const m = (await import(`../../../../../../messages/${locale}.json`)).default as {
+        app: {
+          charges: {
+            paymentDayLabel?: string;
+            paymentDayHint?: string;
+            editAria?: string;
+            toastUpdated?: string;
+            drawer?: {
+              title?: string;
+              save?: string;
+              saving?: string;
+              cancel?: string;
+              errorGeneric?: string;
+            };
+          };
+        };
+      };
+      const c = m.app.charges;
+      expect(c.paymentDayLabel).toBeTypeOf('string');
+      expect((c.paymentDayLabel ?? '').length).toBeGreaterThan(0);
+      expect(c.paymentDayHint).toBeTypeOf('string');
+      expect(c.editAria).toBeTypeOf('string');
+      expect((c.editAria ?? '').includes('{label}')).toBe(true);
+      expect(c.toastUpdated).toBeTypeOf('string');
+      expect(c.drawer?.title).toBeTypeOf('string');
+      expect(c.drawer?.save).toBeTypeOf('string');
+      expect(c.drawer?.saving).toBeTypeOf('string');
+      expect(c.drawer?.cancel).toBeTypeOf('string');
+      expect(c.drawer?.errorGeneric).toBeTypeOf('string');
+    },
+  );
 });

--- a/src/components/dashboard/ProvisionHealthGaugeCard.tsx
+++ b/src/components/dashboard/ProvisionHealthGaugeCard.tsx
@@ -67,13 +67,23 @@ export async function ProvisionHealthGaugeCard({
 
   const hasTarget = result.totalEpargneTheorique.gt(0);
 
-  // Ratio in [0, ~Infinity[. Clamped to [0, 1.5] for the ProgressBar visual
-  // (display only — accounting math keeps the raw Decimal precision).
+  // Ratio in [0, ~Infinity[. Clamped to [0, ∞) for math, displayed below.
   const rawRatio = hasTarget
     ? result.soldeEpargneActuel.dividedBy(result.totalEpargneTheorique).toNumber()
     : 1;
   const ratio = Number.isFinite(rawRatio) ? Math.max(0, rawRatio) : 0;
-  const percentLabel = Math.round(ratio * 100);
+
+  // PR-BETA-CLEANUP-2 (THI-281) — visual cap @ 100% Option C.
+  // The cockpit was showing "546% À jour" when the user had stashed far
+  // more than the 12-month target — math correct, UX confusing. We now
+  // display 100% as the headline KPI once the user is on or past target,
+  // and surface the overflow as a factual sub-text "+ X € au-delà de la
+  // cible" (R-06 anti-culpabilisation: no judgement, no "trop épargné").
+  const isOverachieving = hasTarget && ratio > 1;
+  const displayPercent = isOverachieving ? 100 : Math.round(ratio * 100);
+  const surplusOverTarget = isOverachieving
+    ? result.soldeEpargneActuel.minus(result.totalEpargneTheorique)
+    : null;
 
   const tier: HealthTier =
     !hasTarget || ratio >= 1.0 ? 'success' : ratio >= 0.75 ? 'warning' : 'danger';
@@ -144,12 +154,20 @@ export async function ProvisionHealthGaugeCard({
               className={`text-4xl font-bold tracking-tight tabular-nums ${accent.valueColor}`}
               data-testid="provision-health-gauge-percent"
             >
-              {percentLabel}%
+              {displayPercent}%
             </p>
             <p className="text-muted-foreground mt-1 text-sm">{statusLabel}</p>
+            {surplusOverTarget && (
+              <p
+                className={`mt-1 text-sm font-medium tabular-nums ${accent.valueColor}`}
+                data-testid="provision-health-gauge-surplus"
+              >
+                {t('objectifDepasse', { amount: fmt(surplusOverTarget) })}
+              </p>
+            )}
             <div className="mt-4">
               <ProgressBar
-                value={ratio}
+                value={Math.min(ratio, 1)}
                 max={1}
                 tone={tier}
                 size="md"

--- a/src/components/dashboard/__tests__/ProvisionHealthGaugeCard.test.tsx
+++ b/src/components/dashboard/__tests__/ProvisionHealthGaugeCard.test.tsx
@@ -154,6 +154,93 @@ describe('<ProvisionHealthGaugeCard /> (THI-190 cockpit v3 #2)', () => {
   });
 });
 
+// PR-BETA-CLEANUP-2 (THI-281) — Option C visual cap.
+// Before this PR the headline KPI showed e.g. "546% — À jour" when the
+// user had stashed well past the 12-month provisions target. Math was
+// correct but UX was confusing. We now cap the headline at 100% and
+// surface the surplus as "+ X € au-delà de la cible" — factual, R-06
+// anti-culpabilisation-safe wording.
+describe('<ProvisionHealthGaugeCard /> — Option C 100% cap (PR-BETA-CLEANUP-2)', () => {
+  it('caps the headline percent at 100% when soldeActuel > target', async () => {
+    // amount = 1200 € target, soldeActuel = 1766 € → raw ratio ≈ 1.47
+    await renderCard({
+      charges: [ANNUAL_CHARGE({})],
+      soldeEpargneActuel: new Decimal(1766),
+    });
+    const percent = screen.getByTestId('provision-health-gauge-percent');
+    // Must show 100%, never the raw ~147%.
+    expect(percent.textContent ?? '').toBe('100%');
+    // Tier stays 'success' (math says we are at or beyond target).
+    const card = screen.getByTestId('provision-health-gauge-card');
+    expect(card.getAttribute('data-tier')).toBe('success');
+  });
+
+  it('renders the "+ X € au-delà de la cible" surplus sub-text when overachieving', async () => {
+    // soldeActuel - target = 1766 - 1200 = 566 €.
+    await renderCard({
+      charges: [ANNUAL_CHARGE({})],
+      soldeEpargneActuel: new Decimal(1766),
+    });
+    const surplus = screen.getByTestId('provision-health-gauge-surplus');
+    expect(surplus).toBeInTheDocument();
+    expect(surplus.textContent ?? '').toMatch(/566/);
+    expect(surplus.className).toContain('text-success');
+    // Anti-culpabilisation contract — no judgement language.
+    expect(surplus.textContent ?? '').not.toMatch(/trop|économise|devrais/i);
+  });
+
+  it('does NOT render the surplus sub-text when ratio = 100% exactly', async () => {
+    // soldeActuel = target = 1200 → ratio = 1.0 exact, no overflow.
+    await renderCard({
+      charges: [ANNUAL_CHARGE({})],
+      soldeEpargneActuel: new Decimal(1200),
+    });
+    expect(screen.getByTestId('provision-health-gauge-percent').textContent ?? '').toBe('100%');
+    expect(screen.queryByTestId('provision-health-gauge-surplus')).toBeNull();
+  });
+
+  it('does NOT render the surplus sub-text when ratio < 100%', async () => {
+    // soldeActuel = 600, target = 1200 → ratio = 0.5, no overflow.
+    await renderCard({
+      charges: [ANNUAL_CHARGE({})],
+      soldeEpargneActuel: new Decimal(600),
+    });
+    expect(screen.getByTestId('provision-health-gauge-percent').textContent ?? '').toBe('50%');
+    expect(screen.queryByTestId('provision-health-gauge-surplus')).toBeNull();
+  });
+
+  it('reproduces the @thierry incident fixture (1766 / 323.58 → "100%" + "+ 1 442,42 €")', async () => {
+    // Smoke 2026-05-26 — the user saw "546%". Target reverse-engineered
+    // from the screenshot to 323.58 €.
+    await renderCard({
+      charges: [
+        ANNUAL_CHARGE({
+          amount: new Decimal('323.58'),
+          paymentMonths: [1],
+        }),
+      ],
+      soldeEpargneActuel: new Decimal('1766.00'),
+    });
+    expect(screen.getByTestId('provision-health-gauge-percent').textContent ?? '').toBe('100%');
+    const surplus = screen.getByTestId('provision-health-gauge-surplus');
+    // 1766.00 - 323.58 = 1442.42. The fr-BE formatter uses comma + NBSP for
+    // thousand separators, so accept the rendered shape "1 442,42 €".
+    expect(surplus.textContent ?? '').toMatch(/1[\s ]?442[,.]42/);
+  });
+
+  it('clamps the ProgressBar at value=1 when overachieving (visual safety)', async () => {
+    // ProgressBar's `value` prop is consumed as a [0..max] range. We must
+    // pass `Math.min(ratio, 1)` so the gauge fills exactly the bar — no
+    // overflow even though the raw ratio is >1.
+    await renderCard({
+      charges: [ANNUAL_CHARGE({})],
+      soldeEpargneActuel: new Decimal(2400),
+    });
+    const bar = document.querySelector('[role="progressbar"]');
+    expect(bar?.getAttribute('aria-valuenow')).toBe('100');
+  });
+});
+
 describe('dashboard.health — i18n parity (5 locales)', () => {
   it.each(['fr-BE', 'en', 'de-DE', 'es-ES', 'nl-BE'] as const)(
     'locale %s exposes title + ratio + target + current + empty + ariaLabel + deficit + status.{a_jour,deficit}',
@@ -168,6 +255,7 @@ describe('dashboard.health — i18n parity (5 locales)', () => {
             empty?: string;
             ariaLabel?: string;
             deficit?: string;
+            objectifDepasse?: string;
             status?: { a_jour?: string; deficit?: string };
           };
         };
@@ -183,6 +271,9 @@ describe('dashboard.health — i18n parity (5 locales)', () => {
       expect((h.ariaLabel ?? '').includes('{percent}')).toBe(true);
       expect(h.deficit).toBeTypeOf('string');
       expect((h.deficit ?? '').includes('{amount}')).toBe(true);
+      // PR-BETA-CLEANUP-2 (THI-281) — Option C overflow sub-text.
+      expect(h.objectifDepasse).toBeTypeOf('string');
+      expect((h.objectifDepasse ?? '').includes('{amount}')).toBe(true);
       expect(h.status?.a_jour).toBeTypeOf('string');
       expect(h.status?.deficit).toBeTypeOf('string');
     },

--- a/src/lib/data/workspace-snapshot.ts
+++ b/src/lib/data/workspace-snapshot.ts
@@ -102,6 +102,11 @@ export type WorkspaceSnapshot = {
     amount: number;
     frequency: string;
     dueMonth: number;
+    // PR-BETA-CLEANUP-2 (THI-281): expose the full schedule so the
+    // ChargesClient list can compute `nextDueDateForCharge()` and the
+    // form / edit drawer can edit the day-of-month precisely.
+    paymentDay: number;
+    paymentMonths: readonly number[];
     categoryId: string | null;
     isActive: boolean;
     notes: string | null;

--- a/src/lib/domain/charges/__tests__/payment-months-from-frequency.test.ts
+++ b/src/lib/domain/charges/__tests__/payment-months-from-frequency.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { paymentMonthsFromFrequency } from '../payment-months-from-frequency';
+
+describe('paymentMonthsFromFrequency', () => {
+  it('returns [1..12] for monthly regardless of dueMonth', () => {
+    expect(paymentMonthsFromFrequency('monthly', 1)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+    ]);
+    expect(paymentMonthsFromFrequency('monthly', 5)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+    ]);
+  });
+
+  it('returns 4 months for quarterly anchored on dueMonth', () => {
+    expect(paymentMonthsFromFrequency('quarterly', 1)).toEqual([1, 4, 7, 10]);
+    expect(paymentMonthsFromFrequency('quarterly', 3)).toEqual([3, 6, 9, 12]);
+  });
+
+  it('wraps quarterly across the year boundary correctly', () => {
+    // dueMonth 11 → 11, 2, 5, 8 → sorted [2, 5, 8, 11]
+    expect(paymentMonthsFromFrequency('quarterly', 11)).toEqual([2, 5, 8, 11]);
+    // dueMonth 12 → 12, 3, 6, 9 → sorted [3, 6, 9, 12]
+    expect(paymentMonthsFromFrequency('quarterly', 12)).toEqual([3, 6, 9, 12]);
+  });
+
+  it('returns 2 months for semiannual anchored on dueMonth', () => {
+    expect(paymentMonthsFromFrequency('semiannual', 2)).toEqual([2, 8]);
+    expect(paymentMonthsFromFrequency('semiannual', 6)).toEqual([6, 12]);
+  });
+
+  it('wraps semiannual across the year boundary correctly', () => {
+    expect(paymentMonthsFromFrequency('semiannual', 9)).toEqual([3, 9]);
+    expect(paymentMonthsFromFrequency('semiannual', 12)).toEqual([6, 12]);
+  });
+
+  it('returns [dueMonth] for annual', () => {
+    expect(paymentMonthsFromFrequency('annual', 1)).toEqual([1]);
+    expect(paymentMonthsFromFrequency('annual', 6)).toEqual([6]);
+    expect(paymentMonthsFromFrequency('annual', 12)).toEqual([12]);
+  });
+
+  it('clamps out-of-range dueMonth defensively (no crash)', () => {
+    expect(paymentMonthsFromFrequency('annual', 0)).toEqual([1]);
+    expect(paymentMonthsFromFrequency('annual', 13)).toEqual([12]);
+    expect(paymentMonthsFromFrequency('annual', -5)).toEqual([1]);
+    expect(paymentMonthsFromFrequency('annual', Number.NaN)).toEqual([1]);
+  });
+
+  it('output is always sorted ascending', () => {
+    for (let m = 1; m <= 12; m += 1) {
+      const out = paymentMonthsFromFrequency('quarterly', m);
+      const sorted = [...out].sort((a, b) => a - b);
+      expect(out).toEqual(sorted);
+    }
+  });
+});

--- a/src/lib/domain/charges/index.ts
+++ b/src/lib/domain/charges/index.ts
@@ -2,6 +2,7 @@ export type { ChargeRecord, ChargeUpdateInput } from './types';
 export { updateCharge, validateChargeUpdate, type ChargeUpdateValidation } from './update';
 export { nextDueDateForCharge } from './next-due-date';
 export { chargeMatchesMonth } from './match-month';
+export { paymentMonthsFromFrequency } from './payment-months-from-frequency';
 export {
   getUpcomingCharges,
   type GetUpcomingChargesInput,

--- a/src/lib/domain/charges/payment-months-from-frequency.ts
+++ b/src/lib/domain/charges/payment-months-from-frequency.ts
@@ -1,0 +1,59 @@
+import type { ChargeFrequency } from '@/lib/domain/types';
+
+/**
+ * Derive the canonical `payment_months[]` schedule for a charge from its
+ * frequency + due-month anchor. Pure function.
+ *
+ * Why this exists: PR-D1 introduced `payment_months[]` as the precise
+ * schedule, but the existing ChargesClient form only ever submitted
+ * `frequency` + `dueMonth` and left `paymentMonths` undefined — which let
+ * the Supabase column default to `[1..12]` for every charge regardless of
+ * frequency. That silently broke `nextDueDateForCharge()` for non-monthly
+ * charges (a yearly bill would look due every month).
+ *
+ * Mapping:
+ *   - monthly    → [1..12]                     (every month)
+ *   - quarterly  → [dueMonth, +3, +6, +9]      (rolled into [1..12] window)
+ *   - semiannual → [dueMonth, +6]              (rolled into [1..12] window)
+ *   - annual     → [dueMonth]                  (one month per year)
+ *
+ * All months are normalised into `[1..12]` and sorted ascending so the
+ * downstream `Array.from(new Set(...))` in `createChargeAction` is
+ * idempotent.
+ */
+export function paymentMonthsFromFrequency(frequency: ChargeFrequency, dueMonth: number): number[] {
+  const anchor = clampToMonth(dueMonth);
+
+  switch (frequency) {
+    case 'monthly':
+      return [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+    case 'quarterly':
+      return [anchor, addMonths(anchor, 3), addMonths(anchor, 6), addMonths(anchor, 9)].sort(
+        (a, b) => a - b,
+      );
+    case 'semiannual':
+      return [anchor, addMonths(anchor, 6)].sort((a, b) => a - b);
+    case 'annual':
+      return [anchor];
+    default: {
+      // Exhaustiveness check — TypeScript errors here if a new frequency is
+      // added without updating the switch. Defensive return so the runtime
+      // never hits an "undefined" path.
+      const _exhaustive: never = frequency;
+      return [_exhaustive as never];
+    }
+  }
+}
+
+function addMonths(month: number, offset: number): number {
+  // `((m + offset - 1) mod 12) + 1` keeps the result in [1..12] while
+  // wrapping correctly (e.g. 11 + 3 → 2).
+  return ((month + offset - 1) % 12) + 1;
+}
+
+function clampToMonth(value: number): number {
+  if (!Number.isFinite(value)) return 1;
+  if (value < 1) return 1;
+  if (value > 12) return 12;
+  return Math.floor(value);
+}


### PR DESCRIPTION
## Summary

Mini-PR groupée — 2 bugs UX indépendants détectés au smoke @thierry 26/05 post-PR-BETA-3. Zéro Server Action touché → aucun risque de réintroduire l'incident 503 / NEXT_REDIRECT.

### Bug #1 — \`/app/charges\` UX (paymentDay + Modifier + nextDueDate)

- **Form** : input "Jour du mois" (1-31) ajouté, mappé sur \`payment_day\` (PR THI-192 deja en DB)
- **Liste** : prochaine échéance complète locale-aware via \`nextDueDateForCharge\` + \`formatDate(medium)\` — fini le "JANV." opaque
- **Bouton Modifier** + drawer dédié \`ChargeEditDrawer\` (slide-right desktop, full-screen mobile, doctrine fail-loud PR-BETA-3 hotfix #3 respectée)
- **Bug latent corrigé** : nouveau helper pur \`paymentMonthsFromFrequency()\` calcule explicitement le schedule. Avant : \`paymentMonths=undefined\` → DB default \`[1..12]\` cassait \`nextDueDateForCharge\` pour les charges non-mensuelles

### Bug #2 — Santé Provisions cap 100% (Option C)

- Cockpit affichait "**546%** À jour" — math correcte mais UX trompeuse
- KPI principal cappé à **100%** quand \`solde > cible\`
- Sub-text factuel **"+ 1 442,42 € au-delà de la cible"** en couleur success
- ProgressBar clamped \`value={Math.min(ratio, 1)}\`
- Math interne préservée (autres consommateurs intacts)
- R-06 anti-culpabilisation respectée

## Challenge du prompt @cowork

| Prompt | Réalité code | Décision |
|---|---|---|
| "updateChargeAction à créer si absente" | Existe déjà (charges.ts:88) | Réutilisé |
| "Migration SQL si nécessaire" | \`payment_day\` + \`payment_months[]\` existent (PR THI-192) | Pas de migration |
| "Référence UX = ExpensesClient" | ExpensesClient n'a ni Modifier ni date locale | Drawer custom dédié |

Sémantique "date saisie" clarifiée avec @thierry : retenu **\`paymentDay\`** (jour du mois) + affichage prochaine échéance (pattern Monarch/YNAB/Linxo).

## Tests

- **1321 Vitest passing** (+26 nouveaux)
- \`payment-months-from-frequency.test.ts\` (7) : monthly→[1..12], quarterly avec wrap année, semiannual, annual, défensif
- \`ProvisionHealthGaugeCard.test.tsx\` (+6 Option C) : cap 100%, sub-text "+X€", edge cases =100% et <100%, fixture @thierry (1766/323.58), ProgressBar clamped, parity i18n
- \`ChargesClient.test.tsx\` (+13) : next-due locale-aware, paymentDay input, action payload, drawer open/prefill/save/error, i18n parity 5 locales

## Quality gates ✅

\`lint\` 0 err · \`lint:use-server\` ✅ · \`typecheck\` 0 err · \`test\` 1321 passing · \`build\` ✅

## Smoke @thierry post-merge

### /app/charges
- [ ] Form : champ "Jour du mois" visible + required
- [ ] Ajouter charge annuelle juin jour 15 → liste affiche "15 juin 2026"
- [ ] Tap Modifier → drawer slide-in pré-rempli
- [ ] Changer montant + Save → toast vert + drawer ferme + liste update

### /app cockpit
- [ ] Santé Provisions affiche "**100%**" (au lieu de "**546%**")
- [ ] Sub-text "+ 1 442,42 € au-delà de la cible" visible en couleur success
- [ ] ProgressBar full (cappée 100%)

## Refs

- Rapport complet : \`docs/prs/PR-BETA-CLEANUP-2-charges-ux-and-provisions-cap-report.md\`
- Smoke @thierry 26/05 — backlog Obsidian (\`Athenaeum/10_Projects/ankora/backlog/2026-05-26-bugs-ux-charges-sante-provisions.md\`)
- Linear THI-281 : free tier limit atteint, traçage Obsidian

🤖 Generated with [Claude Code](https://claude.com/claude-code)