### PR TITLE
feat(simulator): reframe what-if impact on réserve libre (THI-195)

### DIFF
--- a/docs/prs/PR-THI-195-report.md
+++ b/docs/prs/PR-THI-195-report.md
@@ -1,0 +1,110 @@
+# PR-THI-195 — Simulateur what-if en drawer depuis le dashboard
+
+**Branch** : `feat/thi-195-simulator-drawer`
+**Date** : 2026-05-29
+**Pilote** : @cc-ankora (Claude Opus 4.8)
+**Demandeur** : @thierry via @cowork prompt 29/05
+**Linear** : THI-195 — 3e des 3 sections cockpit « essentielles Beta » (après Health gauge THI-190 ✅ + Bills J-7/14/30 THI-192 ✅).
+
+---
+
+## Pourquoi cette PR
+
+Le simulateur what-if existait uniquement en route dédiée `/app/simulator` → sous-utilisé car invisible depuis le cockpit. THI-195 le rend accessible **en drawer in-page** depuis le dashboard, sans navigation, tout en **conservant la route** comme fallback (SEO + lien direct).
+
+---
+
+## Phase 0 — contre-analyse (correction du prompt d'origine)
+
+Le prompt @cowork prescrivait `vaul` (« déjà présent, aucune dépendance neuve ») et l'atome `Drawer.tsx` (`EditDrawer`). Le code-verify a invalidé ces deux hypothèses :
+
+| Hypothèse prompt             | Réalité repo (vérifiée)                                                                            |
+| ---------------------------- | -------------------------------------------------------------------------------------------------- |
+| `vaul` déjà présent          | ❌ **Absent** de `package.json`, 0 import dans `src/`                                              |
+| Atome `Drawer.tsx` à wrapper | ⚠️ `EditDrawer` = drawer **de formulaire** (champs discriminés), inadapté pour un calculateur live |
+| « drawer vaul = quirks iOS » | Les 3 drawers existants sont **hand-rolled, sans vaul**                                            |
+
+**Décision @thierry (AskUserQuestion)** : pattern drawer **maison, zéro dépendance** → budget 0 € respecté + cohérence avec les 3 drawers sibling (`AjusterResteAVivreDrawer`, `ChargeEditDrawer`, `ExpenseEditDrawer`).
+
+**Gouvernance** : spec-translator (spec Phase 0 + Scope + DoD) → plan-reviewer (🟡 APPROVED WITH CHANGES → 3 conditions de re-vérif satisfaites avec preuve filesystem : branche créée, serializabilité `rawCharges` confirmée, absence de `RawCharge` canonique → Option A validée).
+
+---
+
+## Scope livré
+
+### Fichiers
+
+| Fichier                                                       | Nature      | Détail                                                                                                                                      |
+| ------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/components/dashboard/SimulatorDrawer.tsx`                | **NOUVEAU** | Drawer maison wrappant `<SimulatorClient hideHeader>`. Trigger `<Button variant="outline" size="lg">`.                                      |
+| `src/app/[locale]/app/simulator/SimulatorClient.tsx`          | modifié     | `export type RawCharge` + prop `hideHeader?: boolean` (masque le `<header>` h1+subtitle dans le drawer ; défaut `false` → route inchangée). |
+| `src/app/[locale]/app/page.tsx`                               | modifié     | Le 3e CTA grid « Simuler » (ex `<Link href="/app/simulator">`) → `<SimulatorDrawer charges={snapshot.rawCharges} />`.                       |
+| `src/components/dashboard/__tests__/SimulatorDrawer.test.tsx` | **NOUVEAU** | 12 cas Vitest.                                                                                                                              |
+| `e2e/dashboard-simulator-drawer.spec.ts`                      | **NOUVEAU** | 4 parcours × 3 projets (12 tests).                                                                                                          |
+
+### Comportement
+
+- **bottom mobile / right desktop** : `fixed inset-0 z-50 flex items-end justify-end sm:items-stretch` + panel `h-dvh max-h-dvh sm:h-full sm:max-w-md sm:border-l` (idiome identique aux siblings).
+- **ESC + backdrop + X** ferment.
+- **return-focus** : à la fermeture, `requestAnimationFrame(() => triggerRef.current?.focus())` → le focus revient sur le CTA d'origine (WCAG 2.4.3).
+- **Tab focus-trap** : cycle Tab / Shift+Tab confiné au panel (WCAG 4.1.2). _Amélioration vs les 3 siblings qui ne l'ont pas — local au composant, pas de hook partagé (éviterait le scope creep ; extraction `useDrawerA11y` notée en backlog)._
+- **Pas de re-fetch à l'ouverture** : `charges` passées en prop depuis le server component (`snapshot.rawCharges`, déjà en mémoire).
+- **Zéro nouvelle clé i18n** : réutilise `app.dashboard.ctaSimulator`, `app.simulator.title`, `ui.action.close` (parité 5 locales confirmée).
+
+### Hors scope (respecté)
+
+Route `/app/simulator` intacte · `getWorkspaceSnapshot` / `src/lib/domain` / migrations non touchés · aucune dépendance npm · pas de pré-remplissage contextuel enveloppe (backlog) · `.husky`/GHA/`settings.local.json` non touchés.
+
+---
+
+## Agents QA
+
+| Agent                    | Verdict         | Suite                                                                                                                                                                                                          |
+| ------------------------ | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ui-auditor**           | PASS_WITH_NOTES | F2/F3 corrigés : `role="dialog"` + `aria-modal` + `aria-labelledby` déplacés sur le panel (au lieu de l'overlay), `<aside>` → `<div>` (landmark propre).                                                       |
+| **dashboard-ux-auditor** | PASSED          | Cohérence pixel-parfaite avec le sibling ; focus-trap + return-focus salués comme améliorations.                                                                                                               |
+| **mobile-ios-auditor**   | PASS_WITH_NOTES | F1 corrigé : `pb-[max(1.5rem,env(safe-area-inset-bottom))]` sur le scroll container. F5 corrigé : scroll-lock `position:fixed` (pattern `MoreSheet`, rubber-band iOS proof) au lieu de `overflow:hidden` seul. |
+| **i18n-auditor**         | PASS            | Parité 3 clés OK sur 5 locales, aucun hardcode FR.                                                                                                                                                             |
+| **test-runner**          | couvert         | Suite Vitest complète exécutée manuellement (108 fichiers / 1349 tests verts).                                                                                                                                 |
+
+### Findings non retenus (justifiés)
+
+- **X button 36×36px** (ui F1/mobile F2) : conforme WCAG AA 2.5.8 (min 24px ; 2.5.5 « 44px » est AAA). Identique aux 3 siblings → cohérence préservée. Dette partagée backlog.
+- **`autocomplete` absent sur inputs montant** (mobile F3) : code **pré-existant** dans `SimulatorClient`, hors scope THI-195.
+- **Radix Select portal × focus-trap** (mobile F4) : edge case à valider au smoke iPhone réel (le filtre `offsetParent` exclut déjà les items portalisés). → checklist smoke ci-dessous.
+- **Animation slide / scroll affordance** (ux OBS-2 / mobile F6) : backlog UI, cohérent avec les siblings (aucune animation).
+
+---
+
+## Quality gates (local)
+
+| Gate                             | Résultat                                                    |
+| -------------------------------- | ----------------------------------------------------------- |
+| `npm run typecheck`              | ✅ 0 erreur                                                 |
+| `npm run lint`                   | ✅ 0 erreur (6 warnings pré-existants hors diff)            |
+| `npm run lint:use-server`        | ✅ clean                                                    |
+| `npm run test`                   | ✅ **108 fichiers / 1349 tests**                            |
+| `npx playwright test ... --list` | ✅ 12 tests collectés (e2e tourne en CI avec Supabase réel) |
+
+> E2E skip en local (`test.skip(!admin)` — pas de `SUPABASE_SERVICE_ROLE_KEY`), exécuté en CI.
+
+---
+
+## Smoke test @thierry (post-preview / post-merge)
+
+Sur la preview Vercel `/app` :
+
+1. Cliquer « Simuler » → le drawer s'ouvre **par-dessus** le dashboard, sans changement d'URL. Mobile (iPhone) = slide du bas ; desktop = slide de la droite.
+2. Mode « Annuler une charge » → sélectionner une charge → vérifier l'impact dans le drawer. ESC → le drawer se ferme, le focus revient sur « Simuler ».
+3. **iPhone** : scroller jusqu'au bas des résultats → le dernier chiffre n'est pas masqué par le home indicator (F1). Tenter de scroller la page sous le drawer par rebond → elle ne bouge pas (F5). En mode « Annuler », ouvrir le Select charge, sélectionner un item → le focus ne saute pas (F4).
+4. Naviguer manuellement vers `/app/simulator` → la page dédiée affiche toujours son `<h1>` complet.
+
+---
+
+## DoD (anti « push done = task done »)
+
+1. ⏳ CI verte — à confirmer après push.
+2. ⏳ Sourcery silencieux sur le dernier commit — à vérifier après push (`gh api repos/thierryvm/ankora/pulls/<N>/comments`).
+3. ⏳ Review @thierry approuvée + merge.
+4. ⏳ Pas de conflit avec `main`.
+5. ✅ Rapport livré (ce fichier).

--- a/docs/prs/PR-THI-195-v2-report.md
+++ b/docs/prs/PR-THI-195-v2-report.md
@@ -1,0 +1,63 @@
+# PR-THI-195-v2 — Simulateur what-if recâblé sur la réserve libre
+
+> **Branche** : `feat/thi-195-simulator-drawer` (amende PR #199, gelée) · **Date** : 2026-05-30 · **Auteur** : @cc-ankora (Opus 4.8)
+> **Spec d'entrée** : [`docs/design/audit-simulateur-nav-2026-05-30.md`](../design/audit-simulateur-nav-2026-05-30.md) (@cowork)
+
+## Contexte
+
+PR #199 livrait un drawer what-if techniquement correct (a11y/focus-trap/scroll-lock smoke-testés) mais qui **ne tenait pas la promesse de la landing** : défaut absurde « Annuler le Loyer », impact cadré sur l'« effort financier » au lieu de la **réserve libre** (métrique signature), et un « +37,26 %/mois » faux-ami. Cette PR amende #199 pour le scope **P0** de l'audit.
+
+## Décisions verrouillées (D1–D5, @cowork)
+
+| #   | Décision                                                                                           | Implémentation                                                                                                                                                                               |
+| --- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | Recâbler le `SimulatorClient` **partagé** une fois (drawer + route `/app/simulator`)               | Un seul composant modifié, les 2 surfaces héritent                                                                                                                                           |
+| D2  | Réserve libre = **`resteDisponible`** = Revenus − Effort lissé (PAS `capacite`)                    | `resteDisponibleView(revenus, result)` ; libellé « Reste disponible » aligné sur le hero `CapaciteEpargneCard`                                                                               |
+| D3  | Unifier le lissage ; « Actuel » simulateur == « Effort lissé » dashboard                           | Code-verify : `budget.monthlyProvisionTotal` ≡ `effortFinancierLisse` **numériquement** → recâblage = framing, pas de réécriture math. **Test garde-fou d'équivalence** ajouté (anti-drift). |
+| D4  | Scénarios **Option D** : pas de chips catégorie (Télécom/Énergie inexistantes, pas de slug stable) | Défaut = placeholder guidé « Choisis une charge à simuler » (zéro auto-sélection loyer) + dropdown sur charges réelles + copy d'exemple                                                      |
+| D5  | FSMA : aucun montant suggéré                                                                       | « Annuler » = montant plein ; « Renégocier » = montant saisi par l'user                                                                                                                      |
+
+## Scope P0 livré
+
+- **S1** — Défaut « Annuler le Loyer » supprimé → placeholder guidé (Q3, validé plan-reviewer).
+- **S2** — Impact recâblé sur la **réserve libre** : ligne héros « Reste disponible : {actuel} → {projeté} » + économie annuelle + ancre sous-texte « Effort lissé ». Suppression du `%/mois` faux-ami.
+- **§2 audit** — Ancrage des chiffres ; libellé « Reste disponible » identique au hero (parité 5 locales).
+- Edge **revenus non configuré** (route autonome sans garde `missingSetup`) : hint + CTA `/app/accounts` au lieu d'une réserve négative trompeuse.
+
+**Hors scope P0 (= P1, non faits)** : projection 6 mois, curseur, contexte marché, chips Option B/C, redesign drawer, liquid glass, DateField, IA nav.
+
+## Changements (fichiers)
+
+- `src/lib/domain/simulation.ts` — retrait `changePercent` (type + calcul) ; ajout helper pur `resteDisponibleView`.
+- `src/lib/domain/__tests__/simulation.test.ts` — retrait assertion `changePercent` ; +6 tests (resteDisponibleView cancel/negotiate/add/revenus=0/invariance + **équivalence `monthlyProvisionTotal ≈ effortFinancierLisse`** sur fixture mixte + toutes fréquences + inactive).
+- `src/app/[locale]/app/simulator/SimulatorClient.tsx` — prop `revenus` ; carte Impact recâblée ; défaut placeholder ; edge `revenus ≤ 0` ; pont `sr-only` « de X à Y » ; CTA `min-h-11`.
+- `src/app/[locale]/app/simulator/page.tsx` + `src/app/[locale]/app/page.tsx` — call-sites passent `revenus`.
+- `src/components/dashboard/SimulatorDrawer.tsx` — prop `revenus`.
+- `src/components/dashboard/__tests__/SimulatorDrawer.test.tsx` — mock `@/i18n/navigation`, prop `revenus`, test Q3 (placeholder guidé).
+- `e2e/dashboard-simulator-drawer.spec.ts` — +2 tests (framing « Reste disponible » avec revenus seedés ; income-hint sans revenus).
+- `messages/{fr-BE,en,nl-BE,de-DE,es-ES}.json` — clés `app.simulator.impact` recâblées (parité 5/5, `monthlyChange` retiré).
+
+## Agents QA
+
+| Agent                                | Verdict                       | Notes                                                                                                                                   |
+| ------------------------------------ | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `financial-formula-validator` (opus) | **PASS**                      | Math correcte, Decimal partout, équivalence D3 en place et non négociable, 0 % faux-ami.                                                |
+| `dashboard-ux-auditor`               | **GO**                        | 7/7 checks simulateur v2 ; parité libellé hero confirmée 5 locales.                                                                     |
+| `ui-auditor`                         | **PASS_WITH_NOTES** → corrigé | F1 sr-only « de X à Y » **corrigé** ; F3 cible tactile CTA `min-h-11` **corrigé** ; F2 (contraste dark) → **différé** (cf. ci-dessous). |
+| `feature-dev:code-reviewer`          | 2 findings → traités          | [1] test branche revenus=0 **ajouté** (e2e) ; [2] garde `!reserveView` = narrowing TS, **commenté** (le retirer casse le typecheck).    |
+
+### Finding différé (hors scope, à tracker)
+
+**F2 — `text-success` / `text-danger` borderline/échec en dark mode** (`globals.css`, `#059669`/`#dc2626` sur `#111a2e`). **Systémique au design-system** : ces tokens sémantiques sont utilisés dans toute l'app (CapaciteEpargneCard, cards plan, etc.), **pas introduit par cette PR**. Corriger les overrides dark dans `globals.css` impacte des dizaines de composants → PR a11y dédiée (famille THI-202). Documenté ici + handoff.
+
+## Évidence DoD
+
+| #   | Critère                                                 | État                                                                                               |
+| --- | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| 1   | CI verte (Lint, Typecheck, Tests, E2E, Security, Build) | ⏳ après push — local : `typecheck` ✅, `eslint` ✅, `lint:use-server` ✅, **`test` 1356/1356 ✅** |
+| 2   | Sourcery silencieux sur le dernier commit               | ⏳ après push                                                                                      |
+| 3   | Reviews humaines résolues (@thierry)                    | ⏳                                                                                                 |
+| 4   | Pas de conflit avec main                                | ✅ (branche rebasée sur `7e0fedc`)                                                                 |
+| 5   | Rapport livré                                           | ✅ (ce fichier)                                                                                    |
+
+**Local evidence** : `npm run typecheck` → 0 erreur · `npm run test` → 1356 passed · parité i18n 5/5 (`monthlyChange` orphelin = 0).

--- a/e2e/dashboard-simulator-drawer.spec.ts
+++ b/e2e/dashboard-simulator-drawer.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from './helpers/test';
+import { adminClientOrNull, deleteSeededUser, seedOnboardedUser } from './helpers/seed';
+
+const admin = adminClientOrNull();
+
+/**
+ * THI-195 — What-if simulator drawer.
+ *
+ * The simulator is now reachable in-page from the dashboard "Simuler" CTA
+ * (drawer), while the standalone /app/simulator route is preserved.
+ *
+ * Verifies end-to-end:
+ *   - the CTA opens the drawer (no navigation), with the calculator mounted
+ *   - ESC / backdrop / X all close it
+ *   - focus returns to the trigger after closing (WCAG 2.4.3)
+ *   - /app/simulator still renders its full header (hideHeader default = false)
+ */
+test.describe('THI-195 — simulator drawer', () => {
+  test.skip(!admin, 'Needs real Supabase (NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY).');
+
+  async function login(page: import('@playwright/test').Page, email: string, password: string) {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(email);
+    await page.getByLabel('Mot de passe').fill(password);
+    await page.getByRole('button', { name: /^se connecter$/i }).click();
+    await page.waitForURL(/\/app\b/, { timeout: 15_000 });
+  }
+
+  test('the "Simuler" CTA opens the drawer in-page with the calculator mounted', async ({
+    page,
+  }) => {
+    if (!admin) return;
+    const user = await seedOnboardedUser(admin, [
+      {
+        label: 'Assurance auto',
+        amount: 120,
+        frequency: 'monthly',
+        dueMonth: 1,
+        paidFrom: 'principal',
+      },
+    ]);
+    try {
+      await login(page, user.email, user.password);
+
+      const trigger = page.getByTestId('simulator-drawer-trigger');
+      await expect(trigger).toBeVisible();
+      await trigger.click();
+
+      const drawer = page.getByTestId('simulator-drawer');
+      await expect(drawer).toBeVisible();
+      // URL must NOT have navigated — the drawer is in-page.
+      await expect(page).toHaveURL(/\/app\b(?!\/simulator)/);
+      // The calculator mounted: the three mode pills come from SimulatorClient.
+      await expect(page.getByRole('button', { name: 'Annuler une charge' })).toBeVisible();
+    } finally {
+      await deleteSeededUser(admin, user.userId);
+    }
+  });
+
+  test('ESC, backdrop and X each close the drawer', async ({ page }) => {
+    if (!admin) return;
+    const user = await seedOnboardedUser(admin, [
+      { label: 'Loyer', amount: 1000, frequency: 'monthly', dueMonth: 1, paidFrom: 'principal' },
+    ]);
+    try {
+      await login(page, user.email, user.password);
+      const trigger = page.getByTestId('simulator-drawer-trigger');
+      const drawer = page.getByTestId('simulator-drawer');
+
+      // ESC
+      await trigger.click();
+      await expect(drawer).toBeVisible();
+      await page.keyboard.press('Escape');
+      await expect(drawer).toBeHidden();
+
+      // Backdrop
+      await trigger.click();
+      await expect(drawer).toBeVisible();
+      await page.getByTestId('simulator-drawer-backdrop').click({ position: { x: 5, y: 5 } });
+      await expect(drawer).toBeHidden();
+
+      // X button
+      await trigger.click();
+      await expect(drawer).toBeVisible();
+      await page.getByTestId('simulator-drawer-close').click();
+      await expect(drawer).toBeHidden();
+    } finally {
+      await deleteSeededUser(admin, user.userId);
+    }
+  });
+
+  test('focus returns to the trigger after closing with ESC', async ({ page }) => {
+    if (!admin) return;
+    const user = await seedOnboardedUser(admin);
+    try {
+      await login(page, user.email, user.password);
+      const trigger = page.getByTestId('simulator-drawer-trigger');
+      await trigger.click();
+      await expect(page.getByTestId('simulator-drawer')).toBeVisible();
+      await page.keyboard.press('Escape');
+      await expect(page.getByTestId('simulator-drawer')).toBeHidden();
+      await expect(trigger).toBeFocused();
+    } finally {
+      await deleteSeededUser(admin, user.userId);
+    }
+  });
+
+  test('the /app/simulator route fallback still renders its full header', async ({ page }) => {
+    if (!admin) return;
+    const user = await seedOnboardedUser(admin);
+    try {
+      await login(page, user.email, user.password);
+      await page.goto('/app/simulator');
+      // hideHeader defaults to false on the standalone route → the page <h1>
+      // is present (the drawer suppresses it; the route must not regress).
+      await expect(page.getByRole('heading', { level: 1, name: 'Simulateur' })).toBeVisible();
+    } finally {
+      await deleteSeededUser(admin, user.userId);
+    }
+  });
+});

--- a/e2e/dashboard-simulator-drawer.spec.ts
+++ b/e2e/dashboard-simulator-drawer.spec.ts
@@ -105,6 +105,76 @@ test.describe('THI-195 — simulator drawer', () => {
     }
   });
 
+  test('selecting a charge reframes the impact on "Reste disponible" (no faux-ami %)', async ({
+    page,
+  }) => {
+    if (!admin) return;
+    const user = await seedOnboardedUser(admin, [
+      {
+        label: 'Abonnement mobile',
+        amount: 40,
+        frequency: 'monthly',
+        dueMonth: 1,
+        paidFrom: 'principal',
+      },
+    ]);
+    try {
+      // THI-195: réserve libre = revenus − effort lissé. Seed income so the
+      // "Reste disponible" framing is shown (not the income-setup hint).
+      await admin.from('workspaces').update({ monthly_income: 2466 }).eq('id', user.workspaceId);
+
+      await login(page, user.email, user.password);
+      await page.getByTestId('simulator-drawer-trigger').click();
+      const drawer = page.getByTestId('simulator-drawer');
+      await expect(drawer).toBeVisible();
+
+      // Q3 guided default: no charge pre-selected → empty impact, no rent default.
+      await expect(drawer.getByText("Choisis une charge pour voir l'impact.")).toBeVisible();
+
+      // Select the seeded charge (Radix option renders in a portal).
+      await drawer.locator('#chargeId').click();
+      await page.getByRole('option', { name: /Abonnement mobile/ }).click();
+
+      // Impact is reframed on "Reste disponible" (the cockpit hero metric).
+      await expect(page.getByTestId('simulator-reserve')).toBeVisible();
+      await expect(drawer.getByText('Reste disponible')).toBeVisible();
+      // The "+37,26 % / mois" faux-ami is gone for good.
+      await expect(drawer.getByText(/%\s*\/\s*mois/)).toHaveCount(0);
+    } finally {
+      await deleteSeededUser(admin, user.userId);
+    }
+  });
+
+  test('with no income configured, the impact shows the income-setup hint', async ({ page }) => {
+    if (!admin) return;
+    const user = await seedOnboardedUser(admin, [
+      {
+        label: 'Forfait mobile',
+        amount: 40,
+        frequency: 'monthly',
+        dueMonth: 1,
+        paidFrom: 'principal',
+      },
+    ]);
+    try {
+      // No income seeded → snapshot.monthlyIncome is null → money(0) →
+      // incomeMissing: "Reste disponible" can't be framed, show the setup hint.
+      await login(page, user.email, user.password);
+      await page.getByTestId('simulator-drawer-trigger').click();
+      const drawer = page.getByTestId('simulator-drawer');
+      await expect(drawer).toBeVisible();
+      await drawer.locator('#chargeId').click();
+      await page.getByRole('option', { name: /Forfait mobile/ }).click();
+
+      // The income-setup CTA replaces the "Reste disponible" framing.
+      await expect(drawer.getByRole('link', { name: /revenus/i })).toBeVisible();
+      await expect(page.getByTestId('simulator-reserve')).toHaveCount(0);
+      await expect(page.getByTestId('simulator-annual-savings')).toBeVisible();
+    } finally {
+      await deleteSeededUser(admin, user.userId);
+    }
+  });
+
   test('the /app/simulator route fallback still renders its full header', async ({ page }) => {
     if (!admin) return;
     const user = await seedOnboardedUser(admin);

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -888,7 +888,8 @@
       },
       "fields": {
         "charge": "Fixkosten",
-        "chargePlaceholder": "Auswählen…",
+        "chargePlaceholder": "Wähle einen Posten zum Simulieren",
+        "chargeExample": "z. B. deinen Handytarif neu verhandeln, ein Streaming-Abo kündigen…",
         "newAmount": "Neuer Betrag (€)",
         "label": "Bezeichnung",
         "amount": "Betrag (€)",
@@ -897,11 +898,14 @@
       },
       "impact": {
         "title": "Auswirkung",
-        "empty": "Vervollständige das Szenario, um die Auswirkung zu sehen.",
-        "currentMonthly": "Aktuell / Monat",
-        "projectedMonthly": "Prognose / Monat",
+        "empty": "Wähle einen Posten, um die Auswirkung zu sehen.",
+        "resteDisponible": "Verfügbar",
+        "resteDisponibleRange": "Verfügbar: von {from} auf {to} pro Monat",
+        "perMonth": "/ Monat",
         "annualSavings": "Jährliche Ersparnis",
-        "monthlyChange": "{sign}{percent}% / Monat"
+        "effortAnchor": "Geglätteter Aufwand: {current} → {projected}",
+        "incomeHint": "Füge dein Einkommen hinzu, um die Auswirkung auf dein verfügbares Budget zu sehen.",
+        "incomeHintCta": "Einkommen einrichten"
       }
     },
     "deletionStatus": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -888,7 +888,8 @@
       },
       "fields": {
         "charge": "Bill",
-        "chargePlaceholder": "Select…",
+        "chargePlaceholder": "Choose a bill to simulate",
+        "chargeExample": "e.g. renegotiate your phone plan, cut a streaming sub…",
         "newAmount": "New amount (€)",
         "label": "Label",
         "amount": "Amount (€)",
@@ -897,11 +898,14 @@
       },
       "impact": {
         "title": "Impact",
-        "empty": "Complete the scenario to see the impact.",
-        "currentMonthly": "Current / month",
-        "projectedMonthly": "Projected / month",
+        "empty": "Choose a bill to see the impact.",
+        "resteDisponible": "Available leftover",
+        "resteDisponibleRange": "Available leftover: from {from} to {to} per month",
+        "perMonth": "/ month",
         "annualSavings": "Annual savings",
-        "monthlyChange": "{sign}{percent}% / month"
+        "effortAnchor": "Smoothed effort: {current} → {projected}",
+        "incomeHint": "Add your income to see the impact on your available leftover.",
+        "incomeHintCta": "Set up my income"
       }
     },
     "deletionStatus": {

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -888,7 +888,8 @@
       },
       "fields": {
         "charge": "Gasto fijo",
-        "chargePlaceholder": "Selecciona…",
+        "chargePlaceholder": "Elige un gasto fijo para simular",
+        "chargeExample": "p. ej. renegociar tu tarifa móvil, cancelar un streaming…",
         "newAmount": "Nuevo importe (€)",
         "label": "Etiqueta",
         "amount": "Importe (€)",
@@ -897,11 +898,14 @@
       },
       "impact": {
         "title": "Impacto",
-        "empty": "Completa el escenario para ver el impacto.",
-        "currentMonthly": "Actual / mes",
-        "projectedMonthly": "Proyectado / mes",
+        "empty": "Elige un gasto para ver el impacto.",
+        "resteDisponible": "Disponible",
+        "resteDisponibleRange": "Disponible: de {from} a {to} al mes",
+        "perMonth": "/ mes",
         "annualSavings": "Ahorro anual",
-        "monthlyChange": "{sign}{percent}% / mes"
+        "effortAnchor": "Esfuerzo suavizado: {current} → {projected}",
+        "incomeHint": "Añade tus ingresos para ver el impacto en tu disponible.",
+        "incomeHintCta": "Configurar mis ingresos"
       }
     },
     "deletionStatus": {

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -888,7 +888,8 @@
       },
       "fields": {
         "charge": "Charge",
-        "chargePlaceholder": "Sélectionne…",
+        "chargePlaceholder": "Choisis une charge à simuler",
+        "chargeExample": "ex : renégocier ton forfait, couper un streaming…",
         "newAmount": "Nouveau montant (€)",
         "label": "Libellé",
         "amount": "Montant (€)",
@@ -897,11 +898,14 @@
       },
       "impact": {
         "title": "Impact",
-        "empty": "Complète le scénario pour voir l'impact.",
-        "currentMonthly": "Actuel / mois",
-        "projectedMonthly": "Projeté / mois",
+        "empty": "Choisis une charge pour voir l'impact.",
+        "resteDisponible": "Reste disponible",
+        "resteDisponibleRange": "Reste disponible : de {from} à {to} par mois",
+        "perMonth": "/ mois",
         "annualSavings": "Économie annuelle",
-        "monthlyChange": "{sign}{percent}% / mois"
+        "effortAnchor": "Effort lissé : {current} → {projected}",
+        "incomeHint": "Ajoute tes revenus pour voir l'impact sur ton reste disponible.",
+        "incomeHintCta": "Configurer mes revenus"
       }
     },
     "deletionStatus": {

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -888,7 +888,8 @@
       },
       "fields": {
         "charge": "Vaste kost",
-        "chargePlaceholder": "Selecteer…",
+        "chargePlaceholder": "Kies een vaste kost om te simuleren",
+        "chargeExample": "bv. je gsm-abonnement heronderhandelen, een streamingdienst opzeggen…",
         "newAmount": "Nieuw bedrag (€)",
         "label": "Omschrijving",
         "amount": "Bedrag (€)",
@@ -897,11 +898,14 @@
       },
       "impact": {
         "title": "Impact",
-        "empty": "Vul het scenario aan om de impact te zien.",
-        "currentMonthly": "Huidig / maand",
-        "projectedMonthly": "Verwacht / maand",
+        "empty": "Kies een vaste kost om de impact te zien.",
+        "resteDisponible": "Beschikbaar saldo",
+        "resteDisponibleRange": "Beschikbaar saldo: van {from} tot {to} per maand",
+        "perMonth": "/ maand",
         "annualSavings": "Jaarlijkse besparing",
-        "monthlyChange": "{sign}{percent}% / maand"
+        "effortAnchor": "Vereffende inspanning: {current} → {projected}",
+        "incomeHint": "Voeg je inkomen toe om de impact op je beschikbaar saldo te zien.",
+        "incomeHintCta": "Mijn inkomen instellen"
       }
     },
     "deletionStatus": {

--- a/src/app/[locale]/app/page.tsx
+++ b/src/app/[locale]/app/page.tsx
@@ -392,7 +392,7 @@ export default async function DashboardPage() {
         </Button>
         {/* THI-195: opens the what-if simulator in a drawer in-page.
             The /app/simulator route is preserved as a fallback. */}
-        <SimulatorDrawer charges={snapshot.rawCharges} />
+        <SimulatorDrawer charges={snapshot.rawCharges} revenus={monthlyIncome} />
       </div>
     </div>
   );

--- a/src/app/[locale]/app/page.tsx
+++ b/src/app/[locale]/app/page.tsx
@@ -10,6 +10,7 @@ import { EffortFinancierCard } from '@/components/dashboard/EffortFinancierCard'
 import { CapaciteEpargneCard } from '@/components/dashboard/CapaciteEpargneCard';
 import { ProvisionHealthGaugeCard } from '@/components/dashboard/ProvisionHealthGaugeCard';
 import { ProchainesFacturesCard } from '@/components/dashboard/ProchainesFacturesCard';
+import { SimulatorDrawer } from '@/components/dashboard/SimulatorDrawer';
 import { Expenses, Transfer, money } from '@/lib/domain';
 import { paymentKey, type PaymentLedger } from '@/lib/domain/cockpit';
 import { getWorkspaceSnapshot, toCockpitCharges } from '@/lib/data/workspace-snapshot';
@@ -389,9 +390,9 @@ export default async function DashboardPage() {
         <Button asChild variant="outline" size="lg">
           <Link href="/app/expenses">{t('ctaExpenses')}</Link>
         </Button>
-        <Button asChild variant="outline" size="lg">
-          <Link href="/app/simulator">{t('ctaSimulator')}</Link>
-        </Button>
+        {/* THI-195: opens the what-if simulator in a drawer in-page.
+            The /app/simulator route is preserved as a fallback. */}
+        <SimulatorDrawer charges={snapshot.rawCharges} />
       </div>
     </div>
   );

--- a/src/app/[locale]/app/simulator/SimulatorClient.tsx
+++ b/src/app/[locale]/app/simulator/SimulatorClient.tsx
@@ -18,7 +18,7 @@ import type { Locale } from '@/i18n/routing';
 import { Simulation, money, type Charge, type ChargePaidFrom } from '@/lib/domain';
 import { formatCurrency } from '@/lib/i18n/formatters';
 
-type RawCharge = {
+export type RawCharge = {
   id: string;
   label: string;
   amount: number;
@@ -36,7 +36,20 @@ const MONTHS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const;
 const FREQUENCIES: readonly Frequency[] = ['monthly', 'quarterly', 'semiannual', 'annual'];
 const MODES: readonly Mode[] = ['cancel', 'negotiate', 'add'];
 
-export function SimulatorClient({ charges }: { charges: RawCharge[] }) {
+/**
+ * @param hideHeader  Suppress the page `<header>` (h1 + subtitle) when the
+ *   simulator is rendered inside the dashboard drawer (THI-195). The drawer
+ *   supplies its own `<h2>` header, so rendering the `<h1>` here would create
+ *   a duplicate top-level heading. Defaults to `false` so the standalone
+ *   `/app/simulator` route keeps its full header untouched.
+ */
+export function SimulatorClient({
+  charges,
+  hideHeader = false,
+}: {
+  charges: RawCharge[];
+  hideHeader?: boolean;
+}) {
   const t = useTranslations('app.simulator');
   const locale = useLocale() as Locale;
   const fmtMoney = (value: Parameters<typeof formatCurrency>[0]) => formatCurrency(value, locale);
@@ -116,10 +129,12 @@ export function SimulatorClient({ charges }: { charges: RawCharge[] }) {
 
   return (
     <div className="flex flex-col gap-6">
-      <header>
-        <h1 className="text-3xl font-bold tracking-tight md:text-4xl">{t('title')}</h1>
-        <p className="text-muted-foreground mt-1">{t('subtitle')}</p>
-      </header>
+      {!hideHeader && (
+        <header>
+          <h1 className="text-3xl font-bold tracking-tight md:text-4xl">{t('title')}</h1>
+          <p className="text-muted-foreground mt-1">{t('subtitle')}</p>
+        </header>
+      )}
 
       <Card>
         <CardHeader>

--- a/src/app/[locale]/app/simulator/SimulatorClient.tsx
+++ b/src/app/[locale]/app/simulator/SimulatorClient.tsx
@@ -14,8 +14,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { Link } from '@/i18n/navigation';
 import type { Locale } from '@/i18n/routing';
-import { Simulation, money, type Charge, type ChargePaidFrom } from '@/lib/domain';
+import { Simulation, money, type Charge, type ChargePaidFrom, type Money } from '@/lib/domain';
 import { formatCurrency } from '@/lib/i18n/formatters';
 
 export type RawCharge = {
@@ -45,9 +46,12 @@ const MODES: readonly Mode[] = ['cancel', 'negotiate', 'add'];
  */
 export function SimulatorClient({
   charges,
+  revenus,
   hideHeader = false,
 }: {
   charges: RawCharge[];
+  /** Monthly income — drives the "Reste disponible" (réserve libre) framing. */
+  revenus: Money;
   hideHeader?: boolean;
 }) {
   const t = useTranslations('app.simulator');
@@ -61,7 +65,10 @@ export function SimulatorClient({
   const tMonths = useTranslations('common.months');
 
   const [mode, setMode] = useState<Mode>('cancel');
-  const [chargeId, setChargeId] = useState<string>(charges[0]?.id ?? '');
+  // THI-195 (Q3): no auto-selection. A guided empty placeholder ("Choisis une
+  // charge…") avoids defaulting onto rent/tax (the audit's broken default) and
+  // stays FSMA-neutral — we never pre-pick what the user should cut.
+  const [chargeId, setChargeId] = useState<string>('');
   const [newAmount, setNewAmount] = useState('');
   const [newLabel, setNewLabel] = useState('');
   const [newFrequency, setNewFrequency] = useState<Frequency>('monthly');
@@ -125,7 +132,14 @@ export function SimulatorClient({
     });
   }, [mode, chargeId, newAmount, newLabel, newFrequency, newDueMonth, domainCharges]);
 
+  // THI-195: reframe the impact on "Reste disponible" (réserve libre =
+  // revenus − effort lissé), the cockpit hero metric — not on raw effort.
+  const reserveView = result ? Simulation.resteDisponibleView(revenus, result) : null;
   const deltaPositive = result?.monthlyDelta.gt(0);
+  // Income not configured (e.g. the standalone /app/simulator route has no
+  // `missingSetup` guard): a "Reste disponible" computed from revenus = 0 is
+  // misleading, so we surface a setup hint instead.
+  const incomeMissing = revenus.lte(0);
 
   return (
     <div className="flex flex-col gap-6">
@@ -174,6 +188,7 @@ export function SimulatorClient({
                   ))}
                 </SelectContent>
               </Select>
+              <p className="text-muted-foreground text-xs">{tFields('chargeExample')}</p>
             </div>
           )}
 
@@ -259,38 +274,84 @@ export function SimulatorClient({
           <CardTitle>{tImpact('title')}</CardTitle>
         </CardHeader>
         <CardContent>
-          {!result ? (
+          {/* `!reserveView` also narrows the type for the else branch; it is
+              null iff `!result`, so this never adds a reachable extra path. */}
+          {!result || !reserveView ? (
             <p className="text-muted-foreground text-sm">{tImpact('empty')}</p>
-          ) : (
-            <div className="grid gap-4 md:grid-cols-3">
-              <div>
-                <p className="text-muted-foreground text-xs">{tImpact('currentMonthly')}</p>
-                <p className="mt-1 text-xl font-bold tabular-nums">
-                  {fmtMoney(result.currentMonthlyProvision)}
-                </p>
-              </div>
-              <div>
-                <p className="text-muted-foreground text-xs">{tImpact('projectedMonthly')}</p>
-                <p className="mt-1 text-xl font-bold tabular-nums">
-                  {fmtMoney(result.projectedMonthlyProvision)}
-                </p>
-              </div>
+          ) : incomeMissing ? (
+            // Income not configured → "Reste disponible" would be misleading.
+            // Show the annual saving only + a setup CTA.
+            <div className="flex flex-col gap-3">
               <div>
                 <p className="text-muted-foreground text-xs">{tImpact('annualSavings')}</p>
                 <p
-                  className={`mt-1 text-xl font-bold tabular-nums ${
+                  className={`mt-1 text-2xl font-bold tabular-nums ${
                     deltaPositive ? 'text-success' : 'text-danger'
                   }`}
+                  data-testid="simulator-annual-savings"
                 >
                   {fmtMoney(result.annualDelta)}
                 </p>
-                <p className="text-muted-foreground mt-1 text-xs">
-                  {tImpact('monthlyChange', {
-                    sign: result.changePercent > 0 ? '+' : '',
-                    percent: result.changePercent,
-                  })}
+              </div>
+              <p className="text-muted-foreground text-sm">{tImpact('incomeHint')}</p>
+              {/* min-h-11 lifts the tap target to 44px (WCAG 2.5.8) — `sm` is 36px. */}
+              <Button asChild variant="outline" size="sm" className="min-h-11 self-start px-4">
+                <Link href="/app/accounts">{tImpact('incomeHintCta')}</Link>
+              </Button>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-4">
+              {/* Hero — Reste disponible (réserve libre) actuel → projeté.
+                  Same metric + wording as the dashboard CapaciteEpargneCard
+                  "Reste disponible" sub-stat (anchoring, audit §2). */}
+              <div>
+                <p className="text-muted-foreground text-xs">{tImpact('resteDisponible')}</p>
+                <p
+                  className="mt-1 flex flex-wrap items-baseline gap-x-2 gap-y-1 text-xl font-bold tabular-nums"
+                  data-testid="simulator-reserve"
+                >
+                  {/* Screen readers get one clean "de X à Y par mois" utterance;
+                      the visual "X → Y" sequence is aria-hidden (the bare arrow
+                      would otherwise be read as "flèche"). */}
+                  <span className="sr-only">
+                    {tImpact('resteDisponibleRange', {
+                      from: fmtMoney(reserveView.current),
+                      to: fmtMoney(reserveView.projected),
+                    })}
+                  </span>
+                  <span aria-hidden>{fmtMoney(reserveView.current)}</span>
+                  <span aria-hidden className="text-muted-foreground">
+                    →
+                  </span>
+                  <span aria-hidden className={deltaPositive ? 'text-success' : 'text-danger'}>
+                    {fmtMoney(reserveView.projected)}
+                  </span>
+                  <span aria-hidden className="text-muted-foreground text-xs font-normal">
+                    {tImpact('perMonth')}
+                  </span>
                 </p>
               </div>
+
+              {/* Secondary — annual saving. */}
+              <div>
+                <p className="text-muted-foreground text-xs">{tImpact('annualSavings')}</p>
+                <p
+                  className={`mt-1 text-lg font-semibold tabular-nums ${
+                    deltaPositive ? 'text-success' : 'text-danger'
+                  }`}
+                  data-testid="simulator-annual-savings"
+                >
+                  {fmtMoney(result.annualDelta)}
+                </p>
+              </div>
+
+              {/* Anchor — demoted effort-lissé sub-text (== dashboard "Effort lissé"). */}
+              <p className="text-muted-foreground border-border border-t pt-3 text-xs">
+                {tImpact('effortAnchor', {
+                  current: fmtMoney(result.currentMonthlyProvision),
+                  projected: fmtMoney(result.projectedMonthlyProvision),
+                })}
+              </p>
             </div>
           )}
         </CardContent>

--- a/src/app/[locale]/app/simulator/page.tsx
+++ b/src/app/[locale]/app/simulator/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
+import { money } from '@/lib/domain';
 import { getWorkspaceSnapshot } from '@/lib/data/workspace-snapshot';
 import { SimulatorClient } from './SimulatorClient';
 
@@ -12,5 +13,7 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function SimulatorPage() {
   const snapshot = await getWorkspaceSnapshot();
-  return <SimulatorClient charges={snapshot.rawCharges} />;
+  return (
+    <SimulatorClient charges={snapshot.rawCharges} revenus={money(snapshot.monthlyIncome ?? 0)} />
+  );
 }

--- a/src/components/dashboard/SimulatorDrawer.tsx
+++ b/src/components/dashboard/SimulatorDrawer.tsx
@@ -6,10 +6,13 @@ import { useTranslations } from 'next-intl';
 
 import { SimulatorClient, type RawCharge } from '@/app/[locale]/app/simulator/SimulatorClient';
 import { Button } from '@/components/ui/button';
+import type { Money } from '@/lib/domain';
 import { cn } from '@/lib/utils';
 
 type Props = {
   charges: RawCharge[];
+  /** Monthly income — drives the "Reste disponible" framing (THI-195). */
+  revenus: Money;
 };
 
 /**
@@ -33,7 +36,7 @@ type Props = {
  * No re-fetch on open: `charges` is passed down from the dashboard server
  * component (`snapshot.rawCharges`), already in memory.
  */
-export function SimulatorDrawer({ charges }: Props) {
+export function SimulatorDrawer({ charges, revenus }: Props) {
   const t = useTranslations('app.dashboard');
   const tSimulator = useTranslations('app.simulator');
   const tClose = useTranslations('ui.action');
@@ -188,7 +191,7 @@ export function SimulatorDrawer({ charges }: Props) {
             {/* `pb-safe`: reserve the iOS home-indicator inset so the last
                 result card is never hidden behind it on a full-screen PWA. */}
             <div className="flex-1 overflow-y-auto px-5 py-6 pb-[max(1.5rem,env(safe-area-inset-bottom))]">
-              <SimulatorClient hideHeader charges={charges} />
+              <SimulatorClient hideHeader charges={charges} revenus={revenus} />
             </div>
           </div>
         </div>

--- a/src/components/dashboard/SimulatorDrawer.tsx
+++ b/src/components/dashboard/SimulatorDrawer.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { X } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+import { SimulatorClient, type RawCharge } from '@/app/[locale]/app/simulator/SimulatorClient';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+type Props = {
+  charges: RawCharge[];
+};
+
+/**
+ * THI-195 — What-if simulator drawer (3rd essential Beta cockpit section).
+ *
+ * Surfaces the existing `SimulatorClient` calculator in-page from the
+ * dashboard, without navigating away. The standalone `/app/simulator`
+ * route is preserved as a fallback (SEO + direct link).
+ *
+ * Home-grown drawer pattern (no `vaul` dependency — budget 0 €), mirroring
+ * the proven idiom of `AjusterResteAVivreDrawer` / `ChargeEditDrawer`:
+ *   - mobile: full-screen, slide from bottom (iOS Settings pattern)
+ *   - desktop (≥640px): slide from right, fixed 28rem width
+ *   - ESC closes, backdrop closes, body scroll lock while open
+ *
+ * a11y hardening beyond the sibling drawers (WCAG 2.4.3 / 4.1.2 — a modal
+ * `aria-modal` dialog MUST contain focus):
+ *   - Tab / Shift+Tab cycle is trapped inside the panel
+ *   - on close (ESC, backdrop, X, save), focus returns to the trigger
+ *
+ * No re-fetch on open: `charges` is passed down from the dashboard server
+ * component (`snapshot.rawCharges`), already in memory.
+ */
+export function SimulatorDrawer({ charges }: Props) {
+  const t = useTranslations('app.dashboard');
+  const tSimulator = useTranslations('app.simulator');
+  const tClose = useTranslations('ui.action');
+  const titleId = useId();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const [open, setOpen] = useState(false);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    // Return focus to the trigger once the drawer unmounts (rAF defers past
+    // the unmount commit). Keeps keyboard users anchored where they started.
+    requestAnimationFrame(() => triggerRef.current?.focus());
+  }, []);
+
+  // ESC closes.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, close]);
+
+  // Lock body scroll while open (mobile full-screen UX). iOS Safari ignores
+  // `overflow: hidden` on <body> for rubber-band scroll, so we pin the body
+  // with `position: fixed` and restore the scroll offset on close — the same
+  // ITP-safe pattern already used by `MoreSheet`.
+  useEffect(() => {
+    if (!open) return;
+    const { body } = document;
+    const { scrollY } = window;
+    body.style.position = 'fixed';
+    body.style.top = `-${scrollY}px`;
+    body.style.width = '100%';
+    body.style.overflow = 'hidden';
+    return () => {
+      body.style.position = '';
+      body.style.top = '';
+      body.style.width = '';
+      body.style.overflow = '';
+      window.scrollTo({ top: scrollY, left: 0, behavior: 'instant' });
+    };
+  }, [open]);
+
+  // Auto-focus the first focusable element in the panel when opened, and
+  // trap Tab / Shift+Tab within the panel (focus containment).
+  useEffect(() => {
+    if (!open) return;
+    const panel = panelRef.current;
+    if (!panel) return;
+
+    const getFocusable = () =>
+      Array.from(
+        panel.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      ).filter((el) => el.offsetParent !== null || el === document.activeElement);
+
+    const focusId = requestAnimationFrame(() => {
+      const focusable = getFocusable();
+      (focusable[0] ?? panel).focus();
+    });
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+      const focusable = getFocusable();
+      if (focusable.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = focusable[0]!;
+      const last = focusable[focusable.length - 1]!;
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey) {
+        if (active === first || !panel.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (active === last || !panel.contains(active)) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    panel.addEventListener('keydown', onKey);
+    return () => {
+      cancelAnimationFrame(focusId);
+      panel.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  return (
+    <>
+      <Button
+        ref={triggerRef}
+        type="button"
+        variant="outline"
+        size="lg"
+        onClick={() => setOpen(true)}
+        data-testid="simulator-drawer-trigger"
+      >
+        {t('ctaSimulator')}
+      </Button>
+
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-end justify-end sm:items-stretch">
+          <button
+            type="button"
+            aria-label={tClose('close')}
+            className="bg-foreground/40 absolute inset-0 backdrop-blur-sm"
+            onClick={close}
+            data-testid="simulator-drawer-backdrop"
+          />
+          {/* The dialog role lives on the panel itself (not the overlay), so
+              the backdrop button is NOT announced as dialog content and the
+              landmark tree stays clean (a plain <div>, not an <aside>). */}
+          <div
+            ref={panelRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+            data-testid="simulator-drawer"
+            className={cn(
+              'bg-card text-foreground border-border relative flex w-full flex-col border shadow-xl',
+              // Mobile: full-screen, slide from bottom.
+              'h-dvh max-h-dvh',
+              // Desktop: slide from right, fixed width.
+              'sm:h-full sm:max-w-md sm:border-l',
+            )}
+          >
+            <header className="border-border flex items-center justify-between gap-3 border-b px-5 py-4">
+              <h2 id={titleId} className="text-lg font-semibold tracking-tight">
+                {tSimulator('title')}
+              </h2>
+              <button
+                type="button"
+                onClick={close}
+                className="text-muted-foreground hover:text-foreground focus-visible:ring-brand-700 -mr-1 rounded-md p-2 focus-visible:ring-2 focus-visible:outline-none"
+                aria-label={tClose('close')}
+                data-testid="simulator-drawer-close"
+              >
+                <X className="h-5 w-5" aria-hidden />
+              </button>
+            </header>
+
+            {/* `pb-safe`: reserve the iOS home-indicator inset so the last
+                result card is never hidden behind it on a full-screen PWA. */}
+            <div className="flex-1 overflow-y-auto px-5 py-6 pb-[max(1.5rem,env(safe-area-inset-bottom))]">
+              <SimulatorClient hideHeader charges={charges} />
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/dashboard/__tests__/SimulatorDrawer.test.tsx
+++ b/src/components/dashboard/__tests__/SimulatorDrawer.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+
+import messages from '../../../../messages/fr-BE.json';
+import { SimulatorDrawer } from '../SimulatorDrawer';
+import type { RawCharge } from '@/app/[locale]/app/simulator/SimulatorClient';
+
+function renderWithIntl(ui: React.ReactNode) {
+  return render(
+    <NextIntlClientProvider locale="fr-BE" messages={messages} timeZone="Europe/Brussels">
+      {ui}
+    </NextIntlClientProvider>,
+  );
+}
+
+const charges: RawCharge[] = [
+  {
+    id: 'charge-1',
+    label: 'Assurance auto',
+    amount: 120,
+    frequency: 'monthly',
+    dueMonth: 1,
+    categoryId: null,
+    isActive: true,
+    paidFrom: 'principal',
+  },
+];
+
+const sim = messages.app.simulator;
+
+describe('<SimulatorDrawer /> — closed state', () => {
+  it('renders the trigger labelled "Simuler"', () => {
+    renderWithIntl(<SimulatorDrawer charges={charges} />);
+    const trigger = screen.getByTestId('simulator-drawer-trigger');
+    expect(trigger).toBeInTheDocument();
+    expect(trigger.textContent ?? '').toContain(messages.app.dashboard.ctaSimulator);
+  });
+
+  it('does not render the dialog until the trigger is clicked', () => {
+    renderWithIntl(<SimulatorDrawer charges={charges} />);
+    expect(screen.queryByTestId('simulator-drawer')).toBeNull();
+  });
+});
+
+describe('<SimulatorDrawer /> — open state', () => {
+  it('opens the dialog on trigger click', async () => {
+    renderWithIntl(<SimulatorDrawer charges={charges} />);
+    fireEvent.click(screen.getByTestId('simulator-drawer-trigger'));
+    expect(await screen.findByTestId('simulator-drawer')).toBeInTheDocument();
+  });
+
+  it('exposes role="dialog" and aria-modal on the open drawer', async () => {
+    renderWithIntl(<SimulatorDrawer charges={charges} />);
+    fireEvent.click(screen.getByTestId('simulator-drawer-trigger'));
+    const dialog = await screen.findByTestId('simulator-drawer');
+    expect(dialog).toHaveAttribute('role', 'dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+  });
+
+  it('renders the drawer title from i18n (app.simulator.title)', async () => {
+    renderWithIntl(<SimulatorDrawer charges={charges} />);
+    fireEvent.click(screen.getByTestId('simulator-drawer-trigger'));
+    const heading = await screen.findByRole('heading', { name: sim.title });
+    expect(heading.tagName).toBe('H2');
+  });
+
+  it('hides the SimulatorClient page header (hideHeader): subtitle is not rendered', async () => {
+    renderWithIntl(<SimulatorDrawer charges={charges} />);
+    fireEvent.click(screen.getByTestId('simulator-drawer-trigger'));
+    await screen.findByTestId('simulator-drawer');
+    // The standalone page renders a <p> subtitle; inside the drawer the
+    // header is suppressed so it must be absent.
+    expect(screen.queryByText(sim.subtitle)).toBeNull();
+  });
+
+  it('renders the SimulatorClient with the passed charges (mode pills + charge label visible)', async () => {
+    renderWithIntl(<SimulatorDrawer charges={charges} />);
+    fireEvent.click(screen.getByTestId('simulator-drawer-trigger'));
+    await screen.findByTestId('simulator-drawer');
+    // Mode pills come from SimulatorClient → proves the calculator mounted.
+    expect(screen.getByRole('button', { name: sim.scenario.modes.cancel })).toBeInTheDocument();
+    // The charge passed in prop is selectable (no re-fetch needed).
+    expect(screen.getByText(/Assurance auto/)).toBeInTheDocument();
+  });
+});
+
+describe('<SimulatorDrawer /> — dismiss + focus management', () => {
+  beforeEach(() => {
+    document.body.style.overflow = '';
+  });
+
+  it('closes the drawer when the backdrop is clicked', async () => {
+    renderWithIntl(<SimulatorDrawer charges={charges} />);
+    fireEvent.click(screen.getByTestId('simulator-drawer-trigger'));
+    await screen.findByTestId('simulator-drawer');
+    fireEvent.click(screen.getByTestId('simulator-drawer-backdrop'));
+    await waitFor(() => expect(screen.queryByTestId('simulator-drawer')).toBeNull());
+  });
+
+  it('closes the drawer when the X button is clicked', async () => {
+    renderWithIntl(<SimulatorDrawer charges={charges} />);
+    fireEvent.click(screen.getByTestId('simulator-drawer-trigger'));
+    await screen.findByTestId('simulator-drawer');
+    fireEvent.click(screen.getByTestId('simulator-drawer-close'));
+    await waitFor(() => expect(screen.queryByTestId('simulator-drawer')).toBeNull());
+  });
+
+  it('closes the drawer on Escape', async () => {
+    renderWithIntl(<SimulatorDrawer charges={charges} />);
+    fireEvent.click(screen.getByTestId('simulator-drawer-trigger'));
+    await screen.findByTestId('simulator-drawer');
+    fireEvent.keyDown(window, { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByTestId('simulator-drawer')).toBeNull());
+  });
+
+  it('returns focus to the trigger after closing (WCAG 2.4.3)', async () => {
+    renderWithIntl(<SimulatorDrawer charges={charges} />);
+    const trigger = screen.getByTestId('simulator-drawer-trigger');
+    fireEvent.click(trigger);
+    await screen.findByTestId('simulator-drawer');
+    fireEvent.keyDown(window, { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByTestId('simulator-drawer')).toBeNull());
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
+  });
+
+  it('pins the body (iOS-safe scroll lock) while open and restores it on close', async () => {
+    renderWithIntl(<SimulatorDrawer charges={charges} />);
+    fireEvent.click(screen.getByTestId('simulator-drawer-trigger'));
+    await screen.findByTestId('simulator-drawer');
+    // iOS-safe lock: body is pinned with position:fixed (rubber-band proof),
+    // not just overflow:hidden.
+    expect(document.body.style.overflow).toBe('hidden');
+    expect(document.body.style.position).toBe('fixed');
+    fireEvent.keyDown(window, { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByTestId('simulator-drawer')).toBeNull());
+    expect(document.body.style.overflow).toBe('');
+    expect(document.body.style.position).toBe('');
+  });
+});

--- a/src/components/dashboard/__tests__/SimulatorDrawer.test.tsx
+++ b/src/components/dashboard/__tests__/SimulatorDrawer.test.tsx
@@ -1,10 +1,23 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { NextIntlClientProvider } from 'next-intl';
 
 import messages from '../../../../messages/fr-BE.json';
 import { SimulatorDrawer } from '../SimulatorDrawer';
+import { money } from '@/lib/domain';
 import type { RawCharge } from '@/app/[locale]/app/simulator/SimulatorClient';
+
+// SimulatorClient pulls in the locale-aware `Link` (income-hint CTA). next-intl's
+// real `createNavigation` imports `next/navigation`, unresolvable under jsdom —
+// mock it to a plain anchor, same pattern as the sibling card tests.
+vi.mock('@/i18n/navigation', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Link: ({ href, children, ...rest }: any) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
 
 function renderWithIntl(ui: React.ReactNode) {
   return render(
@@ -28,30 +41,31 @@ const charges: RawCharge[] = [
 ];
 
 const sim = messages.app.simulator;
+const revenus = money(2466);
 
 describe('<SimulatorDrawer /> — closed state', () => {
   it('renders the trigger labelled "Simuler"', () => {
-    renderWithIntl(<SimulatorDrawer charges={charges} />);
+    renderWithIntl(<SimulatorDrawer charges={charges} revenus={revenus} />);
     const trigger = screen.getByTestId('simulator-drawer-trigger');
     expect(trigger).toBeInTheDocument();
     expect(trigger.textContent ?? '').toContain(messages.app.dashboard.ctaSimulator);
   });
 
   it('does not render the dialog until the trigger is clicked', () => {
-    renderWithIntl(<SimulatorDrawer charges={charges} />);
+    renderWithIntl(<SimulatorDrawer charges={charges} revenus={revenus} />);
     expect(screen.queryByTestId('simulator-drawer')).toBeNull();
   });
 });
 
 describe('<SimulatorDrawer /> — open state', () => {
   it('opens the dialog on trigger click', async () => {
-    renderWithIntl(<SimulatorDrawer charges={charges} />);
+    renderWithIntl(<SimulatorDrawer charges={charges} revenus={revenus} />);
     fireEvent.click(screen.getByTestId('simulator-drawer-trigger'));
     expect(await screen.findByTestId('simulator-drawer')).toBeInTheDocument();
   });
 
   it('exposes role="dialog" and aria-modal on the open drawer', async () => {
-    renderWithIntl(<SimulatorDrawer charges={charges} />);
+    renderWithIntl(<SimulatorDrawer charges={charges} revenus={revenus} />);
     fireEvent.click(screen.getByTestId('simulator-drawer-trigger'));
     const dialog = await screen.findByTestId('simulator-drawer');
     expect(dialog).toHaveAttribute('role', 'dialog');
@@ -59,14 +73,14 @@ describe('<SimulatorDrawer /> — open state', () => {
   });
 
   it('renders the drawer title from i18n (app.simulator.title)', async () => {
-    renderWithIntl(<SimulatorDrawer charges={charges} />);
+    renderWithIntl(<SimulatorDrawer charges={charges} revenus={revenus} />);
     fireEvent.click(screen.getByTestId('simulator-drawer-trigger'));
     const heading = await screen.findByRole('heading', { name: sim.title });
     expect(heading.tagName).toBe('H2');
   });
 
   it('hides the SimulatorClient page header (hideHeader): subtitle is not rendered', async () => {
-    renderWithIntl(<SimulatorDrawer charges={charges} />);
+    renderWithIntl(<SimulatorDrawer charges={charges} revenus={revenus} />);
     fireEvent.click(screen.getByTestId('simulator-drawer-trigger'));
     await screen.findByTestId('simulator-drawer');
     // The standalone page renders a <p> subtitle; inside the drawer the
@@ -74,14 +88,17 @@ describe('<SimulatorDrawer /> — open state', () => {
     expect(screen.queryByText(sim.subtitle)).toBeNull();
   });
 
-  it('renders the SimulatorClient with the passed charges (mode pills + charge label visible)', async () => {
-    renderWithIntl(<SimulatorDrawer charges={charges} />);
+  it('mounts the calculator with a guided empty default (Q3: no charge auto-selected)', async () => {
+    renderWithIntl(<SimulatorDrawer charges={charges} revenus={revenus} />);
     fireEvent.click(screen.getByTestId('simulator-drawer-trigger'));
     await screen.findByTestId('simulator-drawer');
     // Mode pills come from SimulatorClient → proves the calculator mounted.
     expect(screen.getByRole('button', { name: sim.scenario.modes.cancel })).toBeInTheDocument();
-    // The charge passed in prop is selectable (no re-fetch needed).
-    expect(screen.getByText(/Assurance auto/)).toBeInTheDocument();
+    // THI-195 (Q3): no charge is pre-selected (the audit's broken "Annuler le
+    // Loyer" default is gone) — the guided placeholder shows and the impact
+    // stays empty until the user picks their own charge.
+    expect(screen.getByText(sim.fields.chargePlaceholder)).toBeInTheDocument();
+    expect(screen.getByText(sim.impact.empty)).toBeInTheDocument();
   });
 });
 
@@ -91,7 +108,7 @@ describe('<SimulatorDrawer /> — dismiss + focus management', () => {
   });
 
   it('closes the drawer when the backdrop is clicked', async () => {
-    renderWithIntl(<SimulatorDrawer charges={charges} />);
+    renderWithIntl(<SimulatorDrawer charges={charges} revenus={revenus} />);
     fireEvent.click(screen.getByTestId('simulator-drawer-trigger'));
     await screen.findByTestId('simulator-drawer');
     fireEvent.click(screen.getByTestId('simulator-drawer-backdrop'));
@@ -99,7 +116,7 @@ describe('<SimulatorDrawer /> — dismiss + focus management', () => {
   });
 
   it('closes the drawer when the X button is clicked', async () => {
-    renderWithIntl(<SimulatorDrawer charges={charges} />);
+    renderWithIntl(<SimulatorDrawer charges={charges} revenus={revenus} />);
     fireEvent.click(screen.getByTestId('simulator-drawer-trigger'));
     await screen.findByTestId('simulator-drawer');
     fireEvent.click(screen.getByTestId('simulator-drawer-close'));
@@ -107,7 +124,7 @@ describe('<SimulatorDrawer /> — dismiss + focus management', () => {
   });
 
   it('closes the drawer on Escape', async () => {
-    renderWithIntl(<SimulatorDrawer charges={charges} />);
+    renderWithIntl(<SimulatorDrawer charges={charges} revenus={revenus} />);
     fireEvent.click(screen.getByTestId('simulator-drawer-trigger'));
     await screen.findByTestId('simulator-drawer');
     fireEvent.keyDown(window, { key: 'Escape' });
@@ -115,7 +132,7 @@ describe('<SimulatorDrawer /> — dismiss + focus management', () => {
   });
 
   it('returns focus to the trigger after closing (WCAG 2.4.3)', async () => {
-    renderWithIntl(<SimulatorDrawer charges={charges} />);
+    renderWithIntl(<SimulatorDrawer charges={charges} revenus={revenus} />);
     const trigger = screen.getByTestId('simulator-drawer-trigger');
     fireEvent.click(trigger);
     await screen.findByTestId('simulator-drawer');
@@ -125,7 +142,7 @@ describe('<SimulatorDrawer /> — dismiss + focus management', () => {
   });
 
   it('pins the body (iOS-safe scroll lock) while open and restores it on close', async () => {
-    renderWithIntl(<SimulatorDrawer charges={charges} />);
+    renderWithIntl(<SimulatorDrawer charges={charges} revenus={revenus} />);
     fireEvent.click(screen.getByTestId('simulator-drawer-trigger'));
     await screen.findByTestId('simulator-drawer');
     // iOS-safe lock: body is pinned with position:fixed (rubber-band proof),

--- a/src/lib/domain/__tests__/simulation.test.ts
+++ b/src/lib/domain/__tests__/simulation.test.ts
@@ -1,7 +1,26 @@
 import { describe, it, expect } from 'vitest';
 import { money } from '@/lib/domain/types';
-import { simulate, projectCumulative } from '@/lib/domain/simulation';
+import { simulate, projectCumulative, resteDisponibleView } from '@/lib/domain/simulation';
+import { monthlyProvisionTotal } from '@/lib/domain/budget';
+import { effortFinancierLisse } from '@/lib/domain/cockpit/effort-financier-lisse';
+import type { CockpitCharge } from '@/lib/domain/cockpit/types';
 import type { Charge } from '@/lib/domain/types';
+
+/**
+ * Maps a domain `Charge` to the cockpit `CockpitCharge` shape, locally so the
+ * test stays free of the DB-bound `toCockpitCharges` snapshot helper.
+ */
+function toCockpit(c: Charge): CockpitCharge {
+  return {
+    id: c.id,
+    label: c.label,
+    amount: c.amount,
+    frequency: c.frequency,
+    paymentMonths: c.paymentMonths,
+    paymentDay: c.paymentDay,
+    isActive: c.isActive,
+  };
+}
 
 const charges: Charge[] = [
   {
@@ -37,7 +56,6 @@ describe('simulate / cancel', () => {
     expect(result.projectedMonthlyProvision.toNumber()).toBe(100);
     expect(result.monthlyDelta.toNumber()).toBe(50);
     expect(result.annualDelta.toNumber()).toBe(600);
-    expect(result.changePercent).toBeCloseTo((50 / 150) * 100, 2);
   });
 
   it('returns no change if chargeId is unknown', () => {
@@ -117,5 +135,80 @@ describe('projectCumulative', () => {
   });
   it('rejects negative months', () => {
     expect(() => projectCumulative(money(10), -1)).toThrow(RangeError);
+  });
+});
+
+describe('resteDisponibleView (réserve libre = revenus − effort lissé)', () => {
+  it('raises reste disponible when a charge is cancelled', () => {
+    const result = simulate(charges, { kind: 'cancel', chargeId: 'c1' });
+    const view = resteDisponibleView(money(2000), result);
+    // current = 2000 − 150 ; projected = 2000 − 100 (50 freed)
+    expect(view.current.toNumber()).toBe(1850);
+    expect(view.projected.toNumber()).toBe(1900);
+    expect(view.projected.gt(view.current)).toBe(true);
+    expect(view.monthlyDelta.toNumber()).toBe(50);
+  });
+
+  it('shifts reste disponible by the negotiated monthly gap', () => {
+    const result = simulate(charges, { kind: 'negotiate', chargeId: 'c1', newAmount: money(30) });
+    const view = resteDisponibleView(money(2000), result);
+    // 50 → 30 on a monthly charge frees 20/month of reste disponible.
+    expect(view.projected.minus(view.current).toNumber()).toBe(20);
+  });
+
+  it('lowers reste disponible when a charge is added', () => {
+    const result = simulate(charges, {
+      kind: 'add',
+      charge: {
+        label: 'Streaming',
+        amount: money(15),
+        frequency: 'monthly',
+        dueMonth: 1,
+        paymentMonths: [1],
+        paymentDay: 1,
+        categoryId: null,
+        isActive: true,
+        paidFrom: 'principal',
+      },
+    });
+    const view = resteDisponibleView(money(2000), result);
+    expect(view.projected.lt(view.current)).toBe(true);
+    expect(view.monthlyDelta.toNumber()).toBe(-15);
+  });
+
+  it('returns negative reste disponible when revenus is 0 (income not configured)', () => {
+    const result = simulate(charges, { kind: 'cancel', chargeId: 'c1' });
+    const view = resteDisponibleView(money(0), result);
+    // No clamping: −150 → −100. The UI layer surfaces the "configure income" hint.
+    expect(view.current.toNumber()).toBe(-150);
+    expect(view.projected.toNumber()).toBe(-100);
+  });
+
+  it('keeps monthlyDelta invariant under the revenus shift', () => {
+    const result = simulate(charges, { kind: 'cancel', chargeId: 'c1' });
+    expect(resteDisponibleView(money(2000), result).monthlyDelta.toNumber()).toBe(
+      result.monthlyDelta.toNumber(),
+    );
+  });
+});
+
+describe('anchoring (D3) — monthlyProvisionTotal ≡ effortFinancierLisse', () => {
+  it('matches for the mixed monthly + annual fixture', () => {
+    const budget = monthlyProvisionTotal(charges);
+    const cockpit = effortFinancierLisse(charges.map(toCockpit));
+    expect(budget.toNumber()).toBeCloseTo(cockpit.toNumber(), 10);
+  });
+
+  it('matches across every frequency, including inactive charges', () => {
+    const mixed: Charge[] = [
+      { ...charges[0]!, id: 'm', amount: money(53), frequency: 'monthly' },
+      { ...charges[0]!, id: 'q', amount: money(90), frequency: 'quarterly' },
+      { ...charges[0]!, id: 's', amount: money(120), frequency: 'semiannual' },
+      { ...charges[0]!, id: 'a', amount: money(1200), frequency: 'annual' },
+      { ...charges[0]!, id: 'x', amount: money(999), frequency: 'monthly', isActive: false },
+    ];
+    const budget = monthlyProvisionTotal(mixed);
+    const cockpit = effortFinancierLisse(mixed.map(toCockpit));
+    expect(budget.toNumber()).toBeCloseTo(cockpit.toNumber(), 10);
   });
 });

--- a/src/lib/domain/simulation.ts
+++ b/src/lib/domain/simulation.ts
@@ -11,13 +11,17 @@ export type SimulationResult = {
   projectedMonthlyProvision: Money;
   monthlyDelta: Money;
   annualDelta: Money;
-  /** Percent change, rounded to 2 decimals. */
-  changePercent: number;
 };
 
 /**
  * Estimate the monthly-savings impact of a what-if action.
  * Pure function — does not mutate input charges.
+ *
+ * Note: `currentMonthlyProvision` is the smoothed monthly effort
+ * (`monthlyProvisionTotal`), provably equal to the cockpit's
+ * `effortFinancierLisse` for the same charges — see the equivalence test in
+ * `simulation.test.ts`. The "Actuel" shown by the simulator therefore matches
+ * the dashboard's "Effort lissé" (anchoring, THI-195 audit §2).
  */
 export function simulate(charges: readonly Charge[], input: SimulationInput): SimulationResult {
   const current = monthlyProvisionTotal(charges);
@@ -26,16 +30,39 @@ export function simulate(charges: readonly Charge[], input: SimulationInput): Si
   const monthlyDelta = current.minus(projected);
   const annualDelta = monthlyDelta.times(12);
 
-  const changePercent = current.isZero()
-    ? 0
-    : Number(monthlyDelta.div(current).times(100).toFixed(2));
-
   return {
     currentMonthlyProvision: current,
     projectedMonthlyProvision: projected,
     monthlyDelta,
     annualDelta,
-    changePercent,
+  };
+}
+
+/**
+ * "Reste disponible" (réserve libre) view of a simulation — the signature
+ * metric of Ankora: `revenus − effort financier lissé`. THI-195 reframes the
+ * simulator on this (not on the raw "effort"/total charges) so the user sees
+ * the impact on the same number the cockpit hero shows.
+ *
+ *   resteDisponible = revenus − monthlyProvision (== revenus − effortFinancierLisse)
+ *
+ * `monthlyDelta` is invariant under the revenus shift (it cancels), so the
+ * projected/current gap equals `simulate(...).monthlyDelta`.
+ *
+ * Pure — no clamping. If `revenus` is 0 (income not configured), `current` is
+ * negative and the UI layer is responsible for the messaging.
+ */
+export type ResteDisponibleView = {
+  current: Money;
+  projected: Money;
+  monthlyDelta: Money;
+};
+
+export function resteDisponibleView(revenus: Money, result: SimulationResult): ResteDisponibleView {
+  return {
+    current: revenus.minus(result.currentMonthlyProvision),
+    projected: revenus.minus(result.projectedMonthlyProvision),
+    monthlyDelta: result.monthlyDelta,
   };
 }
 


### PR DESCRIPTION
## Motivation

The first iteration of this drawer (frozen) passed the technical smoke test but **did not deliver the landing's promise**: it defaulted to an absurd "Annuler le Loyer" scenario, framed its impact on raw **effort** instead of the cockpit's signature metric (**réserve libre**), and showed a misleading "+37,26 %/mois". This rework amends the PR for the **P0** scope of the @cowork audit.

Full report: `docs/prs/PR-THI-195-v2-report.md` · Spec: `docs/design/audit-simulateur-nav-2026-05-30.md`.

## Locked decisions (D1–D5, @cowork)

- **D1** — recable the **shared** `SimulatorClient` once (the drawer **and** the standalone `/app/simulator` route both inherit it).
- **D2** — réserve libre = `resteDisponible` = revenus − effort lissé (**not** `capacite`); label matches the dashboard hero ("Reste disponible").
- **D3** — `budget.monthlyProvisionTotal` is provably ≡ `effortFinancierLisse` → the recable is **framing + threading `revenus`, not a math rewrite**. An equivalence test locks this against future drift.
- **D4** — scenarios = **Option D**: no category chips (no Télécom/Énergie categories, no stable slug). Default = guided empty placeholder; the user picks their real charge.
- **D5** — FSMA: no suggested amounts. "Cancel" = full amount; "Negotiate" = user-entered.

## What changed

- **domain** — drop the misleading `changePercent`; add pure `resteDisponibleView(revenus, result)`; equivalence test `monthlyProvisionTotal ≈ effortFinancierLisse`.
- **SimulatorClient** — `revenus` prop; Impact = hero "Reste disponible: current → projected" + annual saving + demoted "Effort lissé" anchor; guided default (no rent auto-select); `revenus ≤ 0` → income-setup hint (covers the standalone route, which has no `missingSetup` guard).
- **a11y** — sr-only "de X à Y" bridge for the hero (the bare arrow is `aria-hidden`); income CTA `min-h-11` (WCAG 2.5.8).
- **i18n** — `app.simulator.impact` recabled across 5 locales, `monthlyChange` removed, parity kept.
- **tests** — +6 domain tests, drawer test updated (Q3), +2 e2e (with/without income).

## QA

`financial-formula-validator` **PASS** · `dashboard-ux-auditor` **GO** · `ui-auditor` **PASS_WITH_NOTES** (F1 sr-only + F3 touch target fixed) · `code-reviewer` findings addressed. `plan-reviewer` **APPROVED WITH CHANGES** (all addressed). **1356 vitest green**, typecheck/eslint/lint:use-server clean.

**Deferred (out of scope, systemic):** dark-mode contrast of `--color-success`/`--color-danger` (`globals.css`, used app-wide, not introduced here) → dedicated a11y PR (THI-202 family).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
