### PR TITLE
chore(agents): upgrade QA agents for réserve-libre simulator + liquid glass

### DIFF
--- a/.claude/agents/dashboard-ux-auditor.md
+++ b/.claude/agents/dashboard-ux-auditor.md
@@ -63,6 +63,33 @@ Verify that the user dashboard maintains **coherence in design tokens, micro-int
 - [ ] **What-if simulator link** — accessible from dashboard (drawer or modal)
 - [ ] **Recent activity** — transactions or events listed with timestamps
 
+### What-if Simulator v2 (Track B, locked 2026-05-30)
+
+The simulator is a **decision tool**, not a planning toy. The drawer
+(`src/components/dashboard/SimulatorDrawer.tsx`) wraps the shared
+`SimulatorClient` (`src/app/[locale]/app/simulator/SimulatorClient.tsx`) — both
+surfaces must stay coherent.
+
+- [ ] **Réserve libre framing** — the headline impact is "Réserve libre :
+      507 €/mois → 585 €/mois", NOT "effort financier" / "total des charges" /
+      a bare percentage. Metric = `resteDisponible` (Revenus − Effort lissé).
+- [ ] **Label parity with the hero** — the word + metric shown in the simulator
+      match the dashboard hero card (`CapaciteEpargneCard` / "Reste disponible").
+      No synonym drift that re-creates the audit §2 disconnect.
+- [ ] **No isolated-charge %** — the old "+37,26 %/mois" faux-ami is gone. No
+      green `+` percentage implying a recurring monthly gain.
+- [ ] **Anchored numbers** — "Actuel" is explicitly anchored (== dashboard
+      "Effort lissé"), never an unlabelled raw total.
+- [ ] **Realistic scenario chips (Option B)** — quick-pick chips (Télécom /
+      Énergie / Abonnement) pre-fill the scenario on the user's _real_ charge if
+      present; if absent, a soft CTA "Ajoute cette charge pour la simuler" (an
+      onboarding lever), NEVER hardcoded demo values.
+- [ ] **FSMA-safe copy** — no "tu devrais placer/investir", no suggested/market
+      amounts in P0. `negotiate` amount is user-entered. Strictly budget
+      organisation/education.
+- [ ] **Drawer a11y preserved** — focus trap, ESC + backdrop close, focus
+      returns to trigger, body scroll-lock (do not regress the #199 shell).
+
 ## Report Format
 
 ### GO (pass all checks)

--- a/.claude/agents/financial-formula-validator.md
+++ b/.claude/agents/financial-formula-validator.md
@@ -2,7 +2,7 @@
 name: financial-formula-validator
 description: Use after any change to src/lib/domain/ or anything touching provisioning, billing calculations, or savings suggestions. Verifies math correctness, edge cases, and floating-point safety.
 tools: Read, Grep, Glob, Bash
-model: sonnet
+model: opus
 ---
 
 You are the Ankora **Financial Formula Validator**. Financial bugs destroy trust — you catch them before shipping.
@@ -28,6 +28,55 @@ You are the Ankora **Financial Formula Validator**. Financial bugs destroy trust
 - Cross-verify `monthlyProvisionTotal` × 12 ≈ `annualTotal` for active charges.
 - Cross-verify `safetyBuffer` ≥ `monthlyProvisionTotal × 12` for any set of charges.
 - Cross-verify `simulate(cancel, id).monthlyDelta` === `monthlyProvisionFor(charge)`.
+
+## Canonical metrics — single source of truth (locked 2026-05-30, @cowork D2/D3)
+
+Ankora has historically grown **two** smoothing ("lissage") implementations.
+Treat the cockpit one as canonical and flag any divergence:
+
+1. **Effort financier lissé** — canonical = `effortFinancierLisse()`
+   (`src/lib/domain/cockpit/effort-financier-lisse.ts`). This is the number the
+   dashboard hero shows. The legacy `budget.monthlyProvisionTotal()`
+   (`src/lib/domain/budget.ts`) is the **old** path used by `simulation.ts`.
+   - **FLAG** any _new_ simulator / réserve-libre code that reads
+     `monthlyProvisionTotal` instead of `effortFinancierLisse`. The displayed
+     "Actuel" in the simulator MUST equal the dashboard's "Effort lissé"
+     (anchoring fix, audit §2). If both formulas must coexist during a
+     migration window, require a test asserting
+     `monthlyProvisionTotal(charges) ≈ effortFinancierLisse(cockpitCharges)`
+     for the same input so a future drift is caught.
+
+2. **Réserve libre** = **`resteDisponible`** = `Revenus − Effort financier lissé`
+   (the `resteDisponible` field of `capaciteEpargneReelle()`,
+   `src/lib/domain/cockpit/capacite-epargne-reelle.ts`).
+   - This is **NOT** `capacite` (= `resteDisponible − resteÀVivre`, the
+     épargnable surplus). The simulator's signature metric is `resteDisponible`.
+   - **FLAG** any simulator code that frames its impact on
+     `monthlyProvisionTotal` / "effort" / "total des charges" instead of on
+     `resteDisponible`. The product's signature is "provisions affectées vs
+     réserve libre" — the simulator must speak that language.
+
+### Simulator recâblage (Track B P0) — required cross-checks
+
+When `simulation.ts` / `SimulatorClient` is recâblé onto réserve libre, verify
+tests cover:
+
+- **Anchoring**: displayed "Actuel" === `effortFinancierLisse(charges)` (or the
+  réserve-libre baseline `revenus − effortFinancierLisse`), never an unlabelled
+  raw total.
+- **Réserve libre projetée** === `revenus − effortFinancierLisse(projectedCharges)`.
+- **Delta sign + magnitude**: `réserveLibreProjetée − réserveLibreActuelle`
+  equals the lissé contribution removed/changed:
+  - `cancel` → `+ effortFinancierLisse contribution of the cancelled charge`
+  - `negotiate` → `+ (oldAmount − newAmount)` lissé per frequency
+  - `add` → `− newCharge` lissé contribution (réserve libre _drops_)
+- **No isolated-charge percentage**: the old "+37,26 %/mois" (part of a charge
+  over total charges, mislabelled as a monthly increase — a faux ami) must be
+  **gone**. FLAG if any `changePercent`-style value is rendered with a `/mois`
+  suffix or a green `+` that implies recurring monthly gain.
+- **FSMA (D5)**: no suggested/market amount is hardcoded into the math.
+  `negotiate` uses the **user-entered** new amount; `cancel` delta is the full
+  charge. Flag any hardcoded "suggested" target baked into the domain.
 
 ## Output format
 

--- a/.claude/agents/mobile-ios-auditor.md
+++ b/.claude/agents/mobile-ios-auditor.md
@@ -143,6 +143,28 @@ relevant.
     persistence must rely on httpOnly cookies (server-side) for protected
     routes; `localStorage` is acceptable only as a non-critical cache.
 
+## Section 7b — Liquid Glass / Translucent Surfaces iOS 26 (4)
+
+Added 2026-05-30 (audit §5). iOS 26 popularised "Liquid Glass" bottom bars; the
+failure mode on Ankora is a translucent **white** bar over a **white** page.
+
+30a. **Tinted fill, not plain white translucency.** A `white / 0.85` +
+`blur(24px)` bar has ~null perceived contrast on a light page. Require a
+desaturated tint (`oklch(0.97 0.010 240 / 0.82)`) + `saturate(180%)` so the
+bar "captures" the colour behind it and reads as a distinct surface.
+30b. **Separation by soft shadow, not hard border.** Replace the `0.4`-alpha top
+border (visible yet ineffective) with a soft shadow
+(`box-shadow: 0 -1px 0 oklch(0 0 0 / 0.06), 0 -8px 32px oklch(0 0 0 / 0.08)`);
+if a hairline remains, drop it to ~`0.14` alpha.
+30c. **`prefers-reduced-transparency: reduce` fallback is mandatory** — opaque
+background + `backdrop-filter: none`. Also verify legibility under iOS
+"Increase Contrast" (forces opaque fills). Missing fallback = `ios-critical`.
+30d. **safe-area on the drawer _backdrop_, not just content** (known iOS 26
+Safari/Chrome bug, MUI #46953). `env(safe-area-inset-bottom)` must apply to
+the translucent overlay too, or a gap appears at the bottom of full-screen
+sheets. Inactive label contrast on the glass must hold 4.5:1
+(≈ `oklch(0.52 0 0)`); active label = emerald accent.
+
 ## Section 8 — Scroll & UI Patterns (3)
 
 31. Scroll-to-top button is positioned with `bottom: max(1rem, env(safe-area-inset-bottom) + 1rem)`

--- a/.claude/agents/ui-auditor.md
+++ b/.claude/agents/ui-auditor.md
@@ -18,6 +18,26 @@ You are the Ankora **UI Auditor**. Ankora is mobile-first and must reach WCAG 2.
 7. Touch targets ≥ 44×44 px on mobile.
 8. `prefers-reduced-motion` respected for any animation.
 
+## Translucent / "liquid glass" surfaces (mobile nav, drawer backdrop)
+
+Translucent surfaces (`backdrop-filter: blur(...)` + low-alpha background)
+fail WCAG AA when their _perceived_ background can be light. Audit angle:
+
+1. **Contrast against the worst-case backdrop.** A `white / 0.85` bar over a
+   white page has near-zero perceived separation. Require a **tinted** fill
+   (e.g. `oklch(0.97 0.010 240 / 0.82)`) + `saturate(180%)` so the surface
+   exists on light backgrounds, and separation via a **soft shadow**, not a
+   hard `0.4`-alpha border (drop to ~`0.14`).
+2. **Label contrast on the glass.** Inactive nav labels must hold **4.5:1** on
+   the translucent fill (≈ `oklch(0.52 0 0)` or darker). A ~`0.65` grey
+   (common in minimal designs) fails (~2.8:1) — FLAG it.
+3. **`prefers-reduced-transparency` fallback is mandatory.** Every translucent
+   surface needs an opaque fallback:
+   `@media (prefers-reduced-transparency: reduce) { background: <opaque>; backdrop-filter: none; }`.
+   Missing fallback = a11y BLOCK.
+4. Verify the surface stays legible with iOS "Increase Contrast" (forces opaque
+   backgrounds) — i.e. it must not rely on blur to be readable.
+
 ## Mobile-first
 
 1. Default styles target mobile; `sm:` / `md:` / `lg:` add desktop enhancements.


### PR DESCRIPTION
## Motivation

Track A (dedicated, scoped) of the THI-195 simulator-v2 chantier. Per banned-list #3 + @cowork, `.claude/agents/` changes ship in a **dedicated PR with human review**, never bundled into a feature PR. This lands the QA-agent upgrades **before** the Track B simulator recâblage so the financial validator can lock the new math by tests first.

**Scope: `.claude/agents/*.md` only. No feature/domain code touched.**

## Changes

- **financial-formula-validator** — locks the two canonical metrics decided by @cowork (D2/D3):
  - réserve libre = `resteDisponible` (Revenus − Effort lissé), **not** `capacite`.
  - `effortFinancierLisse` = single source of truth vs legacy `budget.monthlyProvisionTotal` (the anchoring fix, audit §2).
  - Adds simulator-recâblage cross-checks (anchoring, projected reserve, delta sign/magnitude, no isolated-charge %, FSMA no-suggested-amount).
  - **Model pin `sonnet` → `opus`** (signature-metric error cost + @cowork directive). ⚠️ explicit, not silent.
- **dashboard-ux-auditor** — new *What-if Simulator v2* checklist (réserve-libre framing, label parity with hero, no faux-ami %, Option B scenario chips, FSMA-safe copy, drawer a11y preserved).
- **ui-auditor** — translucent / liquid-glass section (worst-case backdrop contrast, 4.5:1 label on glass, mandatory `prefers-reduced-transparency` fallback, iOS Increase-Contrast legibility).
- **mobile-ios-auditor** — Section 7b iOS 26 Liquid Glass (tinted fill, soft-shadow separation, reduced-transparency fallback, safe-area on the drawer **backdrop** — MUI #46953).

## Doctrine check

- All 15 agents (13 QA + plan-reviewer + spec-translator) keep an explicit `model:` pin. Matrix verified: opus = plan-reviewer, llm-security, **now financial-formula-validator**; haiku = test-runner (deterministic); sonnet = the rest. Only financial-formula-validator changed (sonnet → opus).

## Evidence

- Self-review: docs-only, no executable code → lint/typecheck/test/e2e N/A (no `.ts/.tsx` in diff). lint-staged prettier ran green on the 4 `.md`.
- Orphan `docs/prs/preview-pr-196-landing.png` deliberately left **untracked / out of scope** (triage separately).

## Review

@thierry — human review required (agents = guardrail infra). The one substantive decision to confirm: **financial-formula-validator sonnet → opus**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)