### PR TITLE
fix(simulator): pass revenus as a number across the RSC boundary (THI-195 hotfix)

### DIFF
--- a/docs/prs/PR-THI-195-hotfix-revenus-rsc-boundary-report.md
+++ b/docs/prs/PR-THI-195-hotfix-revenus-rsc-boundary-report.md
@@ -1,0 +1,50 @@
+# Hotfix THI-195 — crash drawer simulateur (frontière RSC `revenus`)
+
+> **Branche** : `hotfix/thi-195-revenus-rsc-boundary` · **Date** : 2026-05-30 · **Auteur** : @cc-ankora (Opus 4.8)
+> **Sévérité** : 🔴 critique — crash à l'ouverture du drawer « Simuler », live sur main (`1a56a0d`, ex-#199).
+
+## Symptôme
+
+Ouvrir le drawer « Simuler » depuis le dashboard déclenche l'error boundary :
+`TypeError: revenus.lte is not a function` dans `SimulatorClient.tsx`.
+
+## Cause racine (confirmée)
+
+`revenus` était passé en **`Money` (Decimal.js)** à travers la frontière RSC **server → client** :
+
+- `page.tsx` (server) → `<SimulatorDrawer revenus={money(...)}>` (client) → `SimulatorClient` (client)
+- `simulator/page.tsx` (server) → `<SimulatorClient revenus={money(...)}>` (client)
+
+Next sérialise les props des client components : une instance `Decimal` **perd son prototype** → arrive sans `.lte`/`.minus` → crash dès le render (`const incomeMissing = revenus.lte(0)` est évalué inconditionnellement).
+
+Le pattern `charges` ne crashait pas car `RawCharge.amount` traverse en **`number`** brut, re-wrappé `money(c.amount)` **dans** le client. `revenus` était la seule exception — il traversait en Decimal.
+
+## Fix
+
+Faire traverser `revenus` en **`number`** brut, et le wrapper `money()` **à l'intérieur** de `SimulatorClient` (mirror exact de `domainCharges`). **Aucun Decimal ne traverse une frontière RSC.**
+
+- `SimulatorClient.tsx` — prop `revenus: Money` → `revenus: number` ; `const revenusMoney = money(revenus)` en tête ; `resteDisponibleView(revenusMoney, …)` + `incomeMissing = revenusMoney.lte(0)`.
+- `SimulatorDrawer.tsx` — prop `revenus: Money` → `revenus: number` (passe-plat).
+- `page.tsx` (dashboard) — `revenus={snapshot.monthlyIncome ?? 0}` (number brut). `monthlyIncome` (Money) reste pour `CapaciteEpargneCard` (server, pas de frontière) + le plan Transfer.
+- `simulator/page.tsx` — `revenus={snapshot.monthlyIncome ?? 0}` ; import `money` retiré.
+
+**Math inchangée** : `resteDisponibleView` prend toujours un `Money` ; seul l'endroit du wrap change. **Rendu inchangé.**
+
+## Garde-fous
+
+- **Type-level** : le typecheck passe avec `revenus: number` → preuve qu'aucun appel de méthode Decimal ne subsiste sur le `revenus` brut (TS errorerait sur `.lte`/`.minus`).
+- **Test unitaire de régression** : `SimulatorDrawer.test.tsx` passe désormais `revenus={2466}` (number, mirror de la vraie frontière — un Decimal masquait le bug) + test dédié « renders without crashing when revenus arrives as a raw number (RSC boundary) » qui ouvre le drawer et force le chemin `money(revenus).lte(0)`.
+- **E2E** (déjà présent sur main via #199) : `dashboard-simulator-drawer.spec.ts` ouvre réellement le drawer + sélectionne une charge + assert que l'Impact rend → reproduction navigateur réelle de la sérialisation.
+
+## Audit « autres Money vers le drawer »
+
+- `charges` : `number` (OK). `revenus` : corrigé. Aucun autre Money vers `SimulatorDrawer`/`SimulatorClient`.
+- Convention confirmée : `CapaciteEpargneCard` → `AjusterResteAVivreDrawer` passe déjà des numbers (`revenus.toNumber()`, `initialResteAVivre.toNumber()`). Le fix s'aligne sur le pattern établi du repo.
+
+## Pourquoi pas de re-run agents QA
+
+Ce hotfix ne change **aucune formule** (`financial-formula-validator` : rien à auditer, math identique) ni **aucun rendu** (`dashboard-ux` : sortie identique). Le risque est purement la frontière de sérialisation, couvert par typecheck + test de reproduction + suite complète. `test-runner` = **1357 vitest verts**.
+
+## Évidence DoD
+
+`typecheck` ✅ · `eslint` (fichiers changés) ✅ · `lint:use-server` ✅ · `npm run test` → **1357 passed** · Sourcery + CI verte ⏳ après push.

--- a/docs/prs/PR-THI-195-hotfix-revenus-rsc-boundary-report.md
+++ b/docs/prs/PR-THI-195-hotfix-revenus-rsc-boundary-report.md
@@ -41,7 +41,7 @@ Faire traverser `revenus` en **`number`** brut, et le wrapper `money()` **à l'i
 - `charges` : `number` (OK). `revenus` : corrigé. Aucun autre Money vers `SimulatorDrawer`/`SimulatorClient`.
 - Convention confirmée : `CapaciteEpargneCard` → `AjusterResteAVivreDrawer` passe déjà des numbers (`revenus.toNumber()`, `initialResteAVivre.toNumber()`). Le fix s'aligne sur le pattern établi du repo.
 
-## Pourquoi pas de re-run agents QA
+## Pourquoi pas de re-run des agents QA
 
 Ce hotfix ne change **aucune formule** (`financial-formula-validator` : rien à auditer, math identique) ni **aucun rendu** (`dashboard-ux` : sortie identique). Le risque est purement la frontière de sérialisation, couvert par typecheck + test de reproduction + suite complète. `test-runner` = **1357 vitest verts**.
 

--- a/src/app/[locale]/app/page.tsx
+++ b/src/app/[locale]/app/page.tsx
@@ -392,7 +392,9 @@ export default async function DashboardPage() {
         </Button>
         {/* THI-195: opens the what-if simulator in a drawer in-page.
             The /app/simulator route is preserved as a fallback. */}
-        <SimulatorDrawer charges={snapshot.rawCharges} revenus={monthlyIncome} />
+        {/* Pass income as a raw number — a Decimal can't cross the RSC
+            boundary into the client drawer (it loses its prototype). */}
+        <SimulatorDrawer charges={snapshot.rawCharges} revenus={snapshot.monthlyIncome ?? 0} />
       </div>
     </div>
   );

--- a/src/app/[locale]/app/simulator/SimulatorClient.tsx
+++ b/src/app/[locale]/app/simulator/SimulatorClient.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/components/ui/select';
 import { Link } from '@/i18n/navigation';
 import type { Locale } from '@/i18n/routing';
-import { Simulation, money, type Charge, type ChargePaidFrom, type Money } from '@/lib/domain';
+import { Simulation, money, type Charge, type ChargePaidFrom } from '@/lib/domain';
 import { formatCurrency } from '@/lib/i18n/formatters';
 
 export type RawCharge = {
@@ -50,8 +50,14 @@ export function SimulatorClient({
   hideHeader = false,
 }: {
   charges: RawCharge[];
-  /** Monthly income — drives the "Reste disponible" (réserve libre) framing. */
-  revenus: Money;
+  /**
+   * Monthly income as a raw `number` — drives the "Reste disponible" (réserve
+   * libre) framing. MUST stay a plain number: a `Decimal` loses its prototype
+   * crossing the RSC server→client boundary (`.lte`/`.minus` become undefined →
+   * runtime crash). It is re-wrapped with `money()` inside the client, exactly
+   * like `domainCharges` does with `money(c.amount)`.
+   */
+  revenus: number;
   hideHeader?: boolean;
 }) {
   const t = useTranslations('app.simulator');
@@ -134,12 +140,15 @@ export function SimulatorClient({
 
   // THI-195: reframe the impact on "Reste disponible" (réserve libre =
   // revenus − effort lissé), the cockpit hero metric — not on raw effort.
-  const reserveView = result ? Simulation.resteDisponibleView(revenus, result) : null;
+  // Re-wrap `revenus` (a raw number across the RSC boundary) into a Decimal
+  // here, mirroring `domainCharges`. Never let a Decimal cross the boundary.
+  const revenusMoney = money(revenus);
+  const reserveView = result ? Simulation.resteDisponibleView(revenusMoney, result) : null;
   const deltaPositive = result?.monthlyDelta.gt(0);
   // Income not configured (e.g. the standalone /app/simulator route has no
   // `missingSetup` guard): a "Reste disponible" computed from revenus = 0 is
   // misleading, so we surface a setup hint instead.
-  const incomeMissing = revenus.lte(0);
+  const incomeMissing = revenusMoney.lte(0);
 
   return (
     <div className="flex flex-col gap-6">

--- a/src/app/[locale]/app/simulator/page.tsx
+++ b/src/app/[locale]/app/simulator/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
-import { money } from '@/lib/domain';
 import { getWorkspaceSnapshot } from '@/lib/data/workspace-snapshot';
 import { SimulatorClient } from './SimulatorClient';
 
@@ -13,7 +12,5 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function SimulatorPage() {
   const snapshot = await getWorkspaceSnapshot();
-  return (
-    <SimulatorClient charges={snapshot.rawCharges} revenus={money(snapshot.monthlyIncome ?? 0)} />
-  );
+  return <SimulatorClient charges={snapshot.rawCharges} revenus={snapshot.monthlyIncome ?? 0} />;
 }

--- a/src/components/dashboard/SimulatorDrawer.tsx
+++ b/src/components/dashboard/SimulatorDrawer.tsx
@@ -6,13 +6,16 @@ import { useTranslations } from 'next-intl';
 
 import { SimulatorClient, type RawCharge } from '@/app/[locale]/app/simulator/SimulatorClient';
 import { Button } from '@/components/ui/button';
-import type { Money } from '@/lib/domain';
 import { cn } from '@/lib/utils';
 
 type Props = {
   charges: RawCharge[];
-  /** Monthly income — drives the "Reste disponible" framing (THI-195). */
-  revenus: Money;
+  /**
+   * Monthly income as a raw `number` (not a `Decimal`). A Decimal loses its
+   * prototype crossing the RSC boundary into this client component, so the
+   * server passes the plain number and `SimulatorClient` re-wraps it.
+   */
+  revenus: number;
 };
 
 /**

--- a/src/components/dashboard/__tests__/SimulatorDrawer.test.tsx
+++ b/src/components/dashboard/__tests__/SimulatorDrawer.test.tsx
@@ -4,7 +4,6 @@ import { NextIntlClientProvider } from 'next-intl';
 
 import messages from '../../../../messages/fr-BE.json';
 import { SimulatorDrawer } from '../SimulatorDrawer';
-import { money } from '@/lib/domain';
 import type { RawCharge } from '@/app/[locale]/app/simulator/SimulatorClient';
 
 // SimulatorClient pulls in the locale-aware `Link` (income-hint CTA). next-intl's
@@ -41,7 +40,11 @@ const charges: RawCharge[] = [
 ];
 
 const sim = messages.app.simulator;
-const revenus = money(2466);
+// Raw number, NOT money(2466): mirrors the real RSC boundary. A Decimal loses
+// its prototype when serialized into the client drawer, so production passes a
+// plain number — passing a Decimal here would mask the `.lte is not a function`
+// crash (regression guard for the revenus RSC-boundary hotfix).
+const revenus = 2466;
 
 describe('<SimulatorDrawer /> — closed state', () => {
   it('renders the trigger labelled "Simuler"', () => {
@@ -98,6 +101,17 @@ describe('<SimulatorDrawer /> — open state', () => {
     // Loyer" default is gone) — the guided placeholder shows and the impact
     // stays empty until the user picks their own charge.
     expect(screen.getByText(sim.fields.chargePlaceholder)).toBeInTheDocument();
+    expect(screen.getByText(sim.impact.empty)).toBeInTheDocument();
+  });
+
+  it('renders without crashing when revenus arrives as a raw number (RSC boundary)', async () => {
+    // Regression: `revenus` crosses server→client as a plain number; the client
+    // re-wraps it with money(). Passing a Decimal used to reach the client as a
+    // prototype-less object and crash at `revenus.lte(0)`. Opening the drawer
+    // forces that code path; the empty impact state proves a full render.
+    renderWithIntl(<SimulatorDrawer charges={charges} revenus={2466} />);
+    fireEvent.click(screen.getByTestId('simulator-drawer-trigger'));
+    await screen.findByTestId('simulator-drawer');
     expect(screen.getByText(sim.impact.empty)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 🔴 Critical hotfix — simulator drawer crash on open (live on main)

Opening the dashboard **"Simuler"** drawer crashes with an error boundary:
`TypeError: revenus.lte is not a function` (`SimulatorClient.tsx`).

### Root cause

`revenus` was passed as a **`Money` (Decimal.js)** across the RSC **server→client** boundary (`page.tsx` → `SimulatorDrawer`; `simulator/page.tsx` → `SimulatorClient`). Next serializes client-component props — a `Decimal` instance **loses its prototype**, so `revenus` arrived without `.lte`/`.minus` and crashed at render. The `charges` path didn't crash because `RawCharge.amount` crosses as a plain **number**, re-wrapped with `money()` inside the client; `revenus` was the lone exception.

### Fix

Pass `revenus` as a raw **number** across the boundary and re-wrap with `money()` **inside** `SimulatorClient`, mirroring `domainCharges` (`money(c.amount)`). No Decimal crosses an RSC boundary. **Math and rendered output unchanged.**

- `SimulatorClient.tsx` — `revenus: number`; `const revenusMoney = money(revenus)`; uses `revenusMoney` for `resteDisponibleView` + `incomeMissing`.
- `SimulatorDrawer.tsx` — `revenus: number` (pass-through).
- `page.tsx` / `simulator/page.tsx` — pass `snapshot.monthlyIncome ?? 0` (number).

### Guards

- **Type-level**: typecheck passes with `revenus: number` → proves no Decimal method remains on the raw prop (TS would error on `.lte`/`.minus`).
- **Unit regression**: drawer test now passes `revenus={2466}` (a number — a Decimal masked the bug) + a dedicated "raw number across RSC boundary" test opening the drawer.
- **E2E** (already on main from #199): opens the drawer + selects a charge → real-browser reproduction.

### Why no QA-agent re-run

Zero formula change (`financial-formula-validator`: nothing to audit) and zero render change (`dashboard-ux`: identical output). The risk is purely serialization, covered by typecheck + reproduction test + suite. `test-runner` = **1357 vitest green**.

Report: `docs/prs/PR-THI-195-hotfix-revenus-rsc-boundary-report.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Garantir que le tiroir du simulateur gère le revenu mensuel en toute sécurité à travers la frontière serveur–client afin d’éviter les crashs au moment de l’ouverture du tiroir.

Bug Fixes:
- Empêcher les crashs du tiroir du simulateur en faisant transiter le revenu mensuel (`revenus`) sous forme de nombre brut à travers la frontière RSC, puis en le reconditionnant en valeur monétaire côté client.

Enhancements:
- Aligner les composants du simulateur sur une convention cohérente consistant à utiliser des nombres bruts à travers la frontière RSC, puis à les convertir en types monétaires métiers dans les composants côté client, pour une meilleure résilience à la sérialisation.
- Clarifier les contrats de props et les attentes liées à la frontière RSC dans les composants liés au simulateur grâce à des commentaires de documentation améliorés.

Documentation:
- Ajouter un rapport de hotfix détaillé documentant le crash à la frontière RSC, la cause racine, la correction et les garde-fous de non-régression pour le tiroir du simulateur.

Tests:
- Mettre à jour les tests du tiroir du simulateur pour transmettre `revenus` sous forme de nombre brut et ajouter un test de non-régression garantissant que le tiroir s’affiche correctement lorsque le revenu mensuel traverse la frontière RSC en tant que nombre.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the simulator drawer handles monthly income safely across the server–client boundary to prevent runtime crashes when opening the drawer.

Bug Fixes:
- Prevent simulator drawer crashes by passing monthly income (`revenus`) as a plain number across the RSC boundary and re-wrapping it as money on the client.

Enhancements:
- Align simulator components on a consistent convention of using raw numbers over the RSC boundary and converting to domain money types within client components for resilience to serialization.
- Clarify prop contracts and RSC-boundary expectations in simulator-related components via improved documentation comments.

Documentation:
- Add a detailed hotfix report documenting the RSC boundary crash, root cause, fix, and regression safeguards for the simulator drawer.

Tests:
- Update simulator drawer tests to pass `revenus` as a raw number and add a regression test ensuring the drawer renders correctly when monthly income crosses the RSC boundary as a number.

</details>