### PR TITLE
fix(ui): champs focus en un signal pas deux (THI-298)

### DIFF
--- a/docs/prs/PR-UI-1-report.md
+++ b/docs/prs/PR-UI-1-report.md
@@ -1,0 +1,89 @@
+# PR-UI-1 — Champs : focus/bordure « un signal pas deux » (THI-298)
+
+> **PR** : [#205](https://github.com/thierryvm/ankora/pull/205) · **Branche** : `fix/thi-298-field-focus-border` · **Ticket** : THI-298
+> **Auteur** : @cc-ankora · **Date** : 2026-05-31 · **Statut** : ✅ DoD satisfaite — en attente du merge (squash) @thierry
+
+---
+
+## 1. Objectif
+
+Supprimer le « double signal » de focus sur les champs de formulaire. Au focus, la primitive partagée empilait **deux signaux disparates** : une bordure colorée `border-brand-500` **et** un `ring-2`, lu par @thierry comme une « double bordure ». Le focus devient désormais **un signal émeraude cohérent** : bordure `brand-700` + halo `ring-brand-500/50` de la même famille teal.
+
+Surfaces touchées : primitives partagées **`Input`** et **`SelectTrigger`** → blast radius global (tous les formulaires de l'app : charges, dépenses, login, signup, onboarding, settings, accounts, simulateur, auth).
+
+---
+
+## 2. Contrat de champ final (Input + SelectTrigger, identique 1:1)
+
+| État                         | Classe                                                                                                                                       | Note                                                                                                                                                                                                                             |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Repos**                    | `border-border` (plein) + `transition-colors`                                                                                                | Affordance champ garantie clair + sombre. Un repos allégé (`/60`) a été **rejeté** par plan-reviewer (perte d'affordance en dark : border `#1e293b` sur card `#111a2e` déjà peu contrasté).                                      |
+| **Hover**                    | `hover:border-brand-500/40`                                                                                                                  | Indice de marque subtil avant focus.                                                                                                                                                                                             |
+| **Focus**                    | `focus-visible:border-brand-700 focus-visible:ring-brand-500/50 focus-visible:ring-2 focus-visible:ring-offset-0 focus-visible:outline-none` | **Un signal cohérent** : bordure `brand-700` (#0f766e, ~5:1 sur card clair ET sombre → conforme WCAG 2.4.11) + halo assorti même teinte.                                                                                         |
+| **Invalide (repos + focus)** | `aria-invalid:border-danger aria-invalid:focus-visible:border-danger aria-invalid:focus-visible:ring-danger`                                 | La bordure danger **survit au focus** : les classes `aria-invalid:focus-visible:*` sont émises après `focus-visible:border-brand-700` → le source-order Tailwind v4 garde la bordure/ring danger sur un champ invalide focalisé. |
+
+**Contrats préexistants intacts** : F2 (ring soft) · F3 (spin-buttons neutralisés sur `type=number`) · F4 (`dark:scheme-dark` icône date) · iOS 16px anti-zoom (`ankora-form-control-16`).
+
+### Itération du contrat (traçabilité)
+
+1. **v1** — repos allégé `/60` : rejeté (a11y dark) → repos `border-border` plein.
+2. **v2** — focus « ring seul » (`border-transparent` + ring `/30`) : rejeté avant merge — avec bordure transparente le ring devenait le **seul** indicateur, et `brand-500/30` tombe sous le seuil WCAG 2.4.11 (~1.3:1 clair, ~1.8:1 sombre).
+3. **v3 (livré)** — focus = bordure `brand-700` + ring `brand-500/50` assorti : conforme 2.4.11, un signal cohérent.
+
+---
+
+## 3. Fichiers modifiés
+
+- `src/components/ui/input.tsx` — contrat focus + JSDoc.
+- `src/components/ui/select.tsx` (SelectTrigger) — miroir 1:1 + ajout `transition-colors` (absent avant).
+- `src/components/ui/__tests__/input.test.tsx` — tests focus/hover/aria-invalid (présence classes + attribut DOM e2e).
+- `src/components/ui/__tests__/select.test.tsx` — tests contrat trigger + test dédié `aria-invalid` forwarding.
+
+---
+
+## 4. Définition de DONE — preuves
+
+| #   | Critère                              | Statut | Preuve                                                                                                                                   |
+| --- | ------------------------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | CI tous verts                        | ✅     | Playwright E2E ✅ · Lint+Typecheck+Tests ✅ · Security ✅ · Sourcery review ✅ · **check-sourcery-resolved ✅** · Vercel ✅              |
+| 2   | Sourcery silencieux (dernier commit) | ✅     | 2 suggestions tests (`aria-invalid` attribut DOM) traitées dans le code ; 2 review threads **résolus** (`isResolved:true`, 0 non résolu) |
+| 3   | Review humaine                       | ⏳     | Branch protection n'exige pas d'approbation formelle ; @thierry arbitre le merge                                                         |
+| 4   | Pas de conflit avec main             | ✅     | `mergeStateStatus = CLEAN` / `mergeable = MERGEABLE`                                                                                     |
+| 5   | Rapport final                        | ✅     | Ce document                                                                                                                              |
+
+### QA agents (tous PASS)
+
+| Agent                | Verdict            | Note                                                                                                                                                                                                    |
+| -------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `plan-reviewer`      | ✅ APPROVED        | 2 passes (contrat initial + révision focus) ; tous les faits re-vérifiés ; aria-invalid override confirmé fiable                                                                                        |
+| `ui-auditor`         | ✅ PASS            | brand-700 = 5.47:1 clair / 2.97:1 dark bordure seule (ring /50 assorti couvre le périmètre → focus compound conforme) ; pas de « double bordure »                                                       |
+| `mobile-ios-auditor` | ✅ PASS_WITH_NOTES | BLOCK initial **levé** : dépendance `:focus-visible` au tap iOS est une dette **pré-existante** (l'ancien code utilisait déjà `focus-visible:`), non régressée par cette PR. iOS 16px / F3 / F4 intacts |
+
+### Tests
+
+- `vitest` ciblé `input.test.tsx` + `select.test.tsx` : **15/15** pass.
+- `vitest` dossier `src/components/ui/__tests__/` : **72/72** pass.
+- `npm run typecheck` : 0 erreur.
+- `npm run lint` : 0 erreur (6 warnings pré-existants hors scope).
+
+### Live-test @cowork (critère bloquant)
+
+✅ **PASS** — focus input validé en live sur `/login`, **clair ET sombre** : bordure brand-700 + halo doux = un seul signal, visible et conforme 2.4.11, **zéro double cadre**. Pas de bascule sur la variante de repli (bordure seule). SelectTrigger partage le contrat 1:1 (non vu live mais couvert par QA agents + tests). `aria-invalid` couvert par les tests.
+
+---
+
+## 5. Hors scope (tracé)
+
+**Le « double cadre au repos »** (bordure de la card du formulaire + bordure du champ, même token `--color-border`) est un sujet **layout/card**, pas primitive champ. À traiter côté card en PR-UI-3a — ne pas compenser via une bordure de champ plus fine (mauvais levier + risque dark).
+
+**Dette a11y focus transverse → [THI-304](https://linear.app/thierryvm/issue/THI-304)** :
+
+- Lot A : ring `brand-500/30` seul sous WCAG 2.4.11 sur `button.tsx`, `dialog.tsx` (close), `ExpenseEditDrawer.tsx` — à corriger ensemble.
+- Lot B : fallback `:focus` (en plus de `:focus-visible`) pour iOS WebKit au tap — dette pré-existante.
+- Lot C : note contraste dark `border-brand-700` (2.97:1 bordure seule) + doc `token-usage.md`.
+
+---
+
+## 6. Suite du lot UI
+
+THI-298 (PR-UI-1) ✅ → THI-299 → THI-300 → THI-201 (UI-3b) → THI-301 (DateField : jour 1-31 + clamp dernier jour du mois). Une PR à la fois.

--- a/docs/prs/PR-UI-1-report.md
+++ b/docs/prs/PR-UI-1-report.md
@@ -2,12 +2,15 @@
 
 > **PR** : [#205](https://github.com/thierryvm/ankora/pull/205) · **Branche** : `fix/thi-298-field-focus-border` · **Ticket** : THI-298
 > **Auteur** : @cc-ankora · **Date** : 2026-05-31 · **Statut** : ✅ DoD satisfaite — en attente du merge (squash) @thierry
+> **Contrat documenté ici = commit livré `b0d74ce`** (les itérations v1→v4 sont superseded, cf. §2).
 
 ---
 
 ## 1. Objectif
 
-Supprimer le « double signal » de focus sur les champs de formulaire. Au focus, la primitive partagée empilait **deux signaux disparates** : une bordure colorée `border-brand-500` **et** un `ring-2`, lu par @thierry comme une « double bordure ». Le focus devient désormais **un signal émeraude cohérent** : bordure `brand-700` + halo `ring-brand-500/50` de la même famille teal.
+Supprimer le « double signal » de focus sur les champs de formulaire. Au focus, la primitive partagée empilait **deux signaux disparates** : une bordure colorée **et** un `ring-2`, lu par @thierry comme une « double bordure ». De plus, la règle globale `*:focus-visible { outline: 2px }` (`globals.css:394`) ajoutait un **outline détaché** par-dessus la bordure du champ → un troisième trait concentrique.
+
+Le focus devient désormais **un seul liseré émeraude ~2px** : `border-color: brand-600` + `box-shadow: 0 0 0 1px brand-600`, **outline global neutralisé** sur les champs, **sans ring** sur un champ valide.
 
 Surfaces touchées : primitives partagées **`Input`** et **`SelectTrigger`** → blast radius global (tous les formulaires de l'app : charges, dépenses, login, signup, onboarding, settings, accounts, simulateur, auth).
 
@@ -15,75 +18,91 @@ Surfaces touchées : primitives partagées **`Input`** et **`SelectTrigger`** �
 
 ## 2. Contrat de champ final (Input + SelectTrigger, identique 1:1)
 
-| État                         | Classe                                                                                                                                       | Note                                                                                                                                                                                                                             |
-| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Repos**                    | `border-border` (plein) + `transition-colors`                                                                                                | Affordance champ garantie clair + sombre. Un repos allégé (`/60`) a été **rejeté** par plan-reviewer (perte d'affordance en dark : border `#1e293b` sur card `#111a2e` déjà peu contrasté).                                      |
-| **Hover**                    | `hover:border-brand-500/40`                                                                                                                  | Indice de marque subtil avant focus.                                                                                                                                                                                             |
-| **Focus**                    | `focus-visible:border-brand-700 focus-visible:ring-brand-500/50 focus-visible:ring-2 focus-visible:ring-offset-0 focus-visible:outline-none` | **Un signal cohérent** : bordure `brand-700` (#0f766e, ~5:1 sur card clair ET sombre → conforme WCAG 2.4.11) + halo assorti même teinte.                                                                                         |
-| **Invalide (repos + focus)** | `aria-invalid:border-danger aria-invalid:focus-visible:border-danger aria-invalid:focus-visible:ring-danger`                                 | La bordure danger **survit au focus** : les classes `aria-invalid:focus-visible:*` sont émises après `focus-visible:border-brand-700` → le source-order Tailwind v4 garde la bordure/ring danger sur un champ invalide focalisé. |
+| État                         | Mécanisme                                                                                                                                                                                                                                                                 | Note                                                                                                                                                                                                                                                                        |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Repos**                    | `border-border` (plein) + `transition-colors`                                                                                                                                                                                                                             | Affordance champ garantie clair + sombre. Un repos allégé (`/60`) a été **rejeté** par plan-reviewer (perte d'affordance en dark).                                                                                                                                          |
+| **Hover**                    | `hover:border-brand-500/40`                                                                                                                                                                                                                                               | Indice de marque subtil avant focus.                                                                                                                                                                                                                                        |
+| **Focus (valide)**           | **Composant** : `focus-visible:border-brand-600 focus-visible:outline-none`. **Central** (`globals.css:421-427`) : `.ankora-form-control-16:focus-visible { outline: none }` + `:not([aria-invalid='true']) { border-color: brand-600; box-shadow: 0 0 0 1px brand-600 }` | **Un seul liseré ~2px émeraude opaque**, suivant le rayon `rounded-lg`, **sans reflow** (la largeur de border ne change pas) et **sans ring/halo**. L'outline détaché global est tué sur les champs.                                                                        |
+| **Invalide (repos + focus)** | `aria-invalid:border-danger aria-invalid:focus-visible:border-danger aria-invalid:focus-visible:ring-danger aria-invalid:focus-visible:ring-2`                                                                                                                            | La bordure **et** le ring danger **survivent au focus** : le carve-out central `:not([aria-invalid='true'])` n'applique PAS le liseré émeraude aux champs invalides → le signal danger (bordure + `ring-2`) reste le seul, fort. Le ring n'existe QUE pour l'état invalide. |
 
-**Contrats préexistants intacts** : F2 (ring soft) · F3 (spin-buttons neutralisés sur `type=number`) · F4 (`dark:scheme-dark` icône date) · iOS 16px anti-zoom (`ankora-form-control-16`).
+### Pourquoi le fix vit dans `globals.css` (mécanisme cascade non-layered)
+
+La règle globale `*:focus-visible { outline: 2px solid brand-600 }` (`globals.css:394`) est **non-layered**. Le `focus-visible:outline-none` des primitives est une **utility Tailwind** (`@layer utilities`). En cascade CSS Layers, **non-layered bat layered** quelle que soit la spécificité → l'outline global s'appliquait TOUJOURS, en plus de la bordure du champ. La neutralisation **doit donc aussi être non-layered** : c'est l'exception compagne `.ankora-form-control-16:focus-visible` (`globals.css:421`), non-layered et plus spécifique, qui gagne proprement. Les classes `focus-visible:border-brand-600` des composants restent comme **couleur cosmétique** documentant l'intention, mais le mécanisme effectif (épaisseur ~2px + outline:none) vit centralement.
+
+`.ankora-form-control-16` n'est porté QUE par `Input` + `SelectTrigger` → boutons, liens, tabs, checkboxes gardent la globale `*:focus-visible` intacte (anti-régression WCAG 2.4.7). Le liseré réutilise `var(--color-brand-600)` exactement comme la globale → le remap brass admin (`[data-accent='admin']`) est honoré sans effort.
 
 ### Itération du contrat (traçabilité)
 
 1. **v1** — repos allégé `/60` : rejeté (a11y dark) → repos `border-border` plein.
-2. **v2** — focus « ring seul » (`border-transparent` + ring `/30`) : rejeté avant merge — avec bordure transparente le ring devenait le **seul** indicateur, et `brand-500/30` tombe sous le seuil WCAG 2.4.11 (~1.3:1 clair, ~1.8:1 sombre).
-3. **v3 (livré)** — focus = bordure `brand-700` + ring `brand-500/50` assorti : conforme 2.4.11, un signal cohérent.
+2. **v2** — focus « ring seul » (`border-transparent` + ring `/30`) : rejeté (ring seul indicateur, `/30` sous WCAG 2.4.11).
+3. **v3** — focus = bordure `brand-700` + ring `brand-500/50` assorti : rejeté par @thierry (le halo/ring lu comme un cadre épais).
+4. **v4** (`c0adaa6`) — focus = bordure fine seule, sans ring : corrige le halo mais l'**outline global détaché** subsistait (la bordure de champ ne pouvait pas l'annuler depuis une utility layered).
+5. **v5 livré** (`b0d74ce`) — neutralisation **centrale non-layered** de l'outline global sur les champs + liseré ~2px (`border-color` + `box-shadow 1px`, no-reflow) + carve-out `aria-invalid`. **Un seul signal, en runtime.**
 
 ---
 
-## 3. Fichiers modifiés
+## 3. Fichiers modifiés (commit `b0d74ce`)
 
-- `src/components/ui/input.tsx` — contrat focus + JSDoc.
-- `src/components/ui/select.tsx` (SelectTrigger) — miroir 1:1 + ajout `transition-colors` (absent avant).
+- `src/app/globals.css` — **mécanisme central** : exception non-layered `.ankora-form-control-16:focus-visible` (`outline:none` + carve-out `:not([aria-invalid])` → `border-color brand-600` + `box-shadow 0 0 0 1px brand-600`). C'est le cœur du fix.
+- `src/components/ui/input.tsx` — classes focus cosmétiques `focus-visible:border-brand-600 focus-visible:outline-none` + ring danger ré-ancré sur `aria-invalid` + JSDoc pointant vers le mécanisme central.
+- `src/components/ui/select.tsx` (SelectTrigger) — miroir 1:1 + `transition-colors`.
 - `src/components/ui/__tests__/input.test.tsx` — tests focus/hover/aria-invalid (présence classes + attribut DOM e2e).
-- `src/components/ui/__tests__/select.test.tsx` — tests contrat trigger + test dédié `aria-invalid` forwarding.
+- `src/components/ui/__tests__/select.test.tsx` — tests contrat trigger + `aria-invalid` forwarding.
 
 ---
 
 ## 4. Définition de DONE — preuves
 
-| #   | Critère                              | Statut | Preuve                                                                                                                                   |
-| --- | ------------------------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | CI tous verts                        | ✅     | Playwright E2E ✅ · Lint+Typecheck+Tests ✅ · Security ✅ · Sourcery review ✅ · **check-sourcery-resolved ✅** · Vercel ✅              |
-| 2   | Sourcery silencieux (dernier commit) | ✅     | 2 suggestions tests (`aria-invalid` attribut DOM) traitées dans le code ; 2 review threads **résolus** (`isResolved:true`, 0 non résolu) |
-| 3   | Review humaine                       | ⏳     | Branch protection n'exige pas d'approbation formelle ; @thierry arbitre le merge                                                         |
-| 4   | Pas de conflit avec main             | ✅     | `mergeStateStatus = CLEAN` / `mergeable = MERGEABLE`                                                                                     |
-| 5   | Rapport final                        | ✅     | Ce document                                                                                                                              |
+| #   | Critère                              | Statut | Preuve                                                                                                                            |
+| --- | ------------------------------------ | ------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | CI tous verts                        | ✅     | Playwright E2E ✅ · Lint+Typecheck+Tests ✅ · Security ✅ · **check-sourcery-resolved ✅** · Vercel ✅                            |
+| 2   | Sourcery silencieux (dernier commit) | ✅     | Suggestions tests (`aria-invalid` attribut DOM) traitées dans `95e5e62` ; review threads **résolus** (0 non résolu sur `b0d74ce`) |
+| 3   | Review humaine                       | ⏳     | Branch protection n'exige pas d'approbation formelle ; @thierry arbitre le merge                                                  |
+| 4   | Pas de conflit avec main             | ✅     | `mergeStateStatus = CLEAN` / `mergeable = MERGEABLE`                                                                              |
+| 5   | Rapport final                        | ✅     | Ce document (réécrit sur le contrat réel `b0d74ce`)                                                                               |
 
-### QA agents (tous PASS)
+### Preuve a11y du rendu FINAL — live-test @cowork sur `b0d74ce` (critère bloquant)
 
-| Agent                | Verdict            | Note                                                                                                                                                                                                    |
-| -------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `plan-reviewer`      | ✅ APPROVED        | 2 passes (contrat initial + révision focus) ; tous les faits re-vérifiés ; aria-invalid override confirmé fiable                                                                                        |
-| `ui-auditor`         | ✅ PASS            | brand-700 = 5.47:1 clair / 2.97:1 dark bordure seule (ring /50 assorti couvre le périmètre → focus compound conforme) ; pas de « double bordure »                                                       |
-| `mobile-ios-auditor` | ✅ PASS_WITH_NOTES | BLOCK initial **levé** : dépendance `:focus-visible` au tap iOS est une dette **pré-existante** (l'ancien code utilisait déjà `focus-visible:`), non régressée par cette PR. iOS 16px / F3 / F4 intacts |
+✅ **PASS** — vérifié en **runtime** par @cowork sur `b0d74ce`, **clair ET sombre** (re-vérifié après stabilisation `transition-colors`) :
+
+- focus champ = `border-color brand-600` + `box-shadow 0 0 0 1px brand-600` + `outline: none` → **un seul liseré ~2px émeraude**, identique clair + sombre, **zéro double/triple cadre** ;
+- hover isolé conforme ;
+- l'outline détaché global est bien neutralisé sur les champs.
+
+> ⚠️ Les audits `ui-auditor` / `mobile-ios-auditor` ci-dessous ont tourné sur le contrat **v3** (brand-700 + ring-500/50). Le rendu final `b0d74ce` est un liseré `brand-600` **opaque** (pas un ring translucide `/30`–`/50`) → strictement **plus contrasté** que tout contrat à ring translucide précédemment audité. La preuve a11y du rendu final est le **live-test runtime @cowork** ci-dessus. Contraste `brand-600` dark ≈ 3.79:1 (cf. [THI-304](https://linear.app/thierryvm/issue/THI-304) Lot C), liseré doublé ~2px par le `box-shadow` assorti.
+
+Carve-out `aria-invalid` (ring danger préservé au focus) + non-régression des non-champs (globale `*:focus-visible` `globals.css:394-398` **inchangée**, mécanisme additif) : vérifiés en **code** par @cowork, structurellement sûrs (couverts par tests pour `aria-invalid`).
+
+### QA agents
+
+| Agent                | Verdict                  | Contrat audité | Note                                                                                                                                     |
+| -------------------- | ------------------------ | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `plan-reviewer`      | ✅ APPROVED WITH CHANGES | v5 (`b0d74ce`) | 3 hard gates traités : `.drw-input` hors scope tracé (THI-304 Lot D), carve-out `aria-invalid`, contraste admin = même token             |
+| `ui-auditor`         | ✅ PASS                  | v3             | Audité sur brand-700 + ring/50. Rendu final = liseré brand-600 opaque, plus contrasté → conformité confirmée par live-test runtime       |
+| `mobile-ios-auditor` | ✅ PASS_WITH_NOTES       | v3             | BLOCK levé : dépendance `:focus-visible` au tap iOS = dette **pré-existante** (THI-304 Lot B), non régressée. iOS 16px / F3 / F4 intacts |
 
 ### Tests
 
 - `vitest` ciblé `input.test.tsx` + `select.test.tsx` : **15/15** pass.
-- `vitest` dossier `src/components/ui/__tests__/` : **72/72** pass.
 - `npm run typecheck` : 0 erreur.
-- `npm run lint` : 0 erreur (6 warnings pré-existants hors scope).
-
-### Live-test @cowork (critère bloquant)
-
-✅ **PASS** — focus input validé en live sur `/login`, **clair ET sombre** : bordure brand-700 + halo doux = un seul signal, visible et conforme 2.4.11, **zéro double cadre**. Pas de bascule sur la variante de repli (bordure seule). SelectTrigger partage le contrat 1:1 (non vu live mais couvert par QA agents + tests). `aria-invalid` couvert par les tests.
+- `npm run lint` : 0 erreur.
+- `npm run build` : OK (CSS central compile, règle `globals.css:421` présente).
 
 ---
 
 ## 5. Hors scope (tracé)
 
-**Le « double cadre au repos »** (bordure de la card du formulaire + bordure du champ, même token `--color-border`) est un sujet **layout/card**, pas primitive champ. À traiter côté card en PR-UI-3a — ne pas compenser via une bordure de champ plus fine (mauvais levier + risque dark).
+**Le « double cadre au repos »** (bordure card du formulaire + bordure du champ, même token `--color-border`) est un sujet **layout/card**, pas primitive champ. À traiter côté card en PR-UI-3a.
 
 **Dette a11y focus transverse → [THI-304](https://linear.app/thierryvm/issue/THI-304)** :
 
-- Lot A : ring `brand-500/30` seul sous WCAG 2.4.11 sur `button.tsx`, `dialog.tsx` (close), `ExpenseEditDrawer.tsx` — à corriger ensemble.
+- Lot A : ring `brand-500/30` seul sous WCAG 2.4.11 sur `button.tsx`, `dialog.tsx` (close), `ExpenseEditDrawer.tsx`.
 - Lot B : fallback `:focus` (en plus de `:focus-visible`) pour iOS WebKit au tap — dette pré-existante.
-- Lot C : note contraste dark `border-brand-700` (2.97:1 bordure seule) + doc `token-usage.md`.
+- Lot C : note contraste dark `border-brand-700` + doc `token-usage.md`.
+- **Lot D : `.drw-input` (Drawer atom, `atoms.css:351`) hors périmètre du fix central** — primitive de champ parallèle qui ne porte pas `.ankora-form-control-16` ; son `:focus` utilise `brand-500` + ring `/0.22`, à aligner sur le contrat champ canonique. Déjà iOS-safe (`:focus`).
 
 ---
 
 ## 6. Suite du lot UI
 
-THI-298 (PR-UI-1) ✅ → THI-299 → THI-300 → THI-201 (UI-3b) → THI-301 (DateField : jour 1-31 + clamp dernier jour du mois). Une PR à la fois.
+THI-298 (PR-UI-1) ✅ → THI-299 → THI-300 → THI-201 (UI-3b) → THI-301 (DateField). Une PR à la fois.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -397,6 +397,35 @@ body > main {
   border-radius: 2px;
 }
 
+/* PR-UI-1 (THI-298) — form-field focus exception to the global outline above.
+   The global `*:focus-visible` outline is the right affordance for controls
+   WITHOUT their own border (buttons, links, tabs, checkboxes) — it stays.
+   But text fields (Input + Select trigger) already own a border, so a detached
+   2px outline stacked on top rendered as a "double border" (@thierry, live
+   2026-05-31). It could NOT be cancelled from the component: the primitives'
+   `focus-visible:outline-none` is a Tailwind utility (in `@layer utilities`),
+   and a NON-layered rule like the global one above always wins over layered
+   ones regardless of specificity — so the cancel must also be non-layered.
+   This companion is non-layered AND more specific, so it wins cleanly:
+     1. kill the detached outline on fields;
+     2. turn the field's own 1px border emerald + add a 1px same-colour
+        box-shadow → a single ~2px emerald edge, NO layout shift (border width
+        is unchanged → no reflow), following the field's `rounded-lg` radius.
+   `.ankora-form-control-16` is carried ONLY by the two field primitives
+   (Input + SelectTrigger), never by checkboxes/buttons — non-field controls
+   keep the global outline. The `:not([aria-invalid='true'])` carve-out leaves
+   the emerald signal OFF invalid fields, so their Tailwind danger border +
+   ring (`aria-invalid:focus-visible:*`) remain the sole, loud signal. Uses
+   `var(--color-brand-600)` exactly like the global rule, so the admin brass
+   accent remap (`[data-accent='admin']`) is honoured with no extra work. */
+.ankora-form-control-16:focus-visible {
+  outline: none;
+}
+.ankora-form-control-16:focus-visible:not([aria-invalid='true']) {
+  border-color: var(--color-brand-600);
+  box-shadow: 0 0 0 1px var(--color-brand-600);
+}
+
 /* PR-D5 mobile-iOS anti-Safari-auto-zoom — declared OUTSIDE `@layer` and
    without `var()` indirection so the rule survives every cascade quirk we
    observed:

--- a/src/components/ui/__tests__/input.test.tsx
+++ b/src/components/ui/__tests__/input.test.tsx
@@ -42,23 +42,23 @@ describe('<Input />', () => {
     expect(input.value).toBe('hello');
   });
 
-  // PR-UI-1 (THI-298) — focus is one coherent emerald signal: a conformant
-  // `border-brand-700` (WCAG 2.4.11) + an assorted soft `ring-brand-500/50`
-  // halo, no offset. NOT the old disparate `border-brand-500` + ring that read
-  // as a "double border", and NOT the rejected interim "ring alone" at /30
-  // (sole indicator below the 3:1 focus-appearance threshold).
-  it('uses the conformant focus border + assorted soft ring (brand-700 + brand-500/50, no offset)', () => {
+  // PR-UI-1 (THI-298) — focus is a single thin `border-brand-600` (WCAG 2.4.11
+  // conformant as the sole indicator), NO ring halo (@thierry: the 2px ring
+  // read as a thick frame). Guards against the previous ring-based contracts.
+  it('uses a thin focus border only (brand-600, no ring)', () => {
     render(<Input placeholder="focus-test" />);
     const input = screen.getByPlaceholderText('focus-test');
-    expect(input.className).toContain('focus-visible:border-brand-700');
-    expect(input.className).toContain('focus-visible:ring-brand-500/50');
-    expect(input.className).toContain('focus-visible:ring-2');
-    expect(input.className).toContain('focus-visible:ring-offset-0');
-    expect(input.className).not.toContain('focus-visible:border-transparent');
-    expect(input.className).not.toContain('focus-visible:ring-brand-500/30');
-    expect(input.className).not.toContain('focus-visible:border-brand-500');
-    expect(input.className).not.toContain('focus-visible:ring-brand-600');
-    expect(input.className).not.toContain('ring-offset-2');
+    // Token-exact check: a ring on a *valid* focus would be the bare
+    // `focus-visible:ring-2` token. The danger ring is `aria-invalid:focus-...`
+    // so a substring check would false-positive — split into exact classes.
+    const classes = input.className.split(/\s+/);
+    expect(classes).toContain('focus-visible:border-brand-600');
+    expect(classes).toContain('focus-visible:outline-none');
+    expect(classes).not.toContain('focus-visible:ring-2');
+    expect(classes).not.toContain('focus-visible:ring-brand-500/50');
+    expect(classes).not.toContain('focus-visible:ring-brand-500/30');
+    expect(classes).not.toContain('focus-visible:border-brand-700');
+    expect(classes).not.toContain('focus-visible:border-transparent');
   });
 
   // PR-UI-1 (THI-298) — at rest the field keeps a full border (affordance),

--- a/src/components/ui/__tests__/input.test.tsx
+++ b/src/components/ui/__tests__/input.test.tsx
@@ -45,13 +45,42 @@ describe('<Input />', () => {
   // PR-UI-2 — focus ring should be subtle (brand-500 at 30%, no offset)
   // instead of the full-opacity ring-brand-600 + ring-offset-2 that read as
   // a thick white halo on dark theme.
-  it('uses the soft focus ring (brand-500/30, no offset)', () => {
+  // PR-UI-1 (THI-298) — focus is now the RING ALONE: transparent border +
+  // ring-offset-0. One signal, not two (the previous border-brand-500 stacked
+  // on the ring read as a "double border").
+  it('uses the soft focus ring alone (brand-500/30, transparent border, no offset)', () => {
     render(<Input placeholder="focus-test" />);
     const input = screen.getByPlaceholderText('focus-test');
     expect(input.className).toContain('focus-visible:ring-brand-500/30');
     expect(input.className).toContain('focus-visible:ring-2');
+    expect(input.className).toContain('focus-visible:border-transparent');
+    expect(input.className).toContain('focus-visible:ring-offset-0');
+    expect(input.className).not.toContain('focus-visible:border-brand-500');
     expect(input.className).not.toContain('focus-visible:ring-brand-600');
     expect(input.className).not.toContain('ring-offset-2');
+  });
+
+  // PR-UI-1 (THI-298) — at rest the field keeps a full border (affordance),
+  // with a subtle brand hint on hover. Thinning the rest border was rejected
+  // (broke affordance on the dark shell).
+  it('keeps a full rest border with a subtle brand hover hint', () => {
+    render(<Input placeholder="rest-test" />);
+    const input = screen.getByPlaceholderText('rest-test');
+    expect(input.className).toContain('border-border');
+    expect(input.className).toContain('hover:border-brand-500/40');
+  });
+
+  // PR-UI-1 (THI-298) — the invalid state must survive the focus contract:
+  // `border-transparent` on focus must NOT erase the danger border. We assert
+  // the presence of all three invalid classes (anti-accidental-removal). The
+  // real cascade override is proven by the live-test, not jsdom (which does
+  // not compute source-order CSS specificity).
+  it('preserves the aria-invalid danger border/ring across rest and focus', () => {
+    render(<Input aria-invalid placeholder="invalid-test" />);
+    const input = screen.getByPlaceholderText('invalid-test');
+    expect(input.className).toContain('aria-invalid:border-danger');
+    expect(input.className).toContain('aria-invalid:focus-visible:border-danger');
+    expect(input.className).toContain('aria-invalid:focus-visible:ring-danger');
   });
 
   // PR-UI-2 — type="number" must hide the webkit spin buttons AND force

--- a/src/components/ui/__tests__/input.test.tsx
+++ b/src/components/ui/__tests__/input.test.tsx
@@ -42,19 +42,20 @@ describe('<Input />', () => {
     expect(input.value).toBe('hello');
   });
 
-  // PR-UI-2 — focus ring should be subtle (brand-500 at 30%, no offset)
-  // instead of the full-opacity ring-brand-600 + ring-offset-2 that read as
-  // a thick white halo on dark theme.
-  // PR-UI-1 (THI-298) — focus is now the RING ALONE: transparent border +
-  // ring-offset-0. One signal, not two (the previous border-brand-500 stacked
-  // on the ring read as a "double border").
-  it('uses the soft focus ring alone (brand-500/30, transparent border, no offset)', () => {
+  // PR-UI-1 (THI-298) — focus is one coherent emerald signal: a conformant
+  // `border-brand-700` (WCAG 2.4.11) + an assorted soft `ring-brand-500/50`
+  // halo, no offset. NOT the old disparate `border-brand-500` + ring that read
+  // as a "double border", and NOT the rejected interim "ring alone" at /30
+  // (sole indicator below the 3:1 focus-appearance threshold).
+  it('uses the conformant focus border + assorted soft ring (brand-700 + brand-500/50, no offset)', () => {
     render(<Input placeholder="focus-test" />);
     const input = screen.getByPlaceholderText('focus-test');
-    expect(input.className).toContain('focus-visible:ring-brand-500/30');
+    expect(input.className).toContain('focus-visible:border-brand-700');
+    expect(input.className).toContain('focus-visible:ring-brand-500/50');
     expect(input.className).toContain('focus-visible:ring-2');
-    expect(input.className).toContain('focus-visible:border-transparent');
     expect(input.className).toContain('focus-visible:ring-offset-0');
+    expect(input.className).not.toContain('focus-visible:border-transparent');
+    expect(input.className).not.toContain('focus-visible:ring-brand-500/30');
     expect(input.className).not.toContain('focus-visible:border-brand-500');
     expect(input.className).not.toContain('focus-visible:ring-brand-600');
     expect(input.className).not.toContain('ring-offset-2');

--- a/src/components/ui/__tests__/input.test.tsx
+++ b/src/components/ui/__tests__/input.test.tsx
@@ -78,6 +78,9 @@ describe('<Input />', () => {
   it('preserves the aria-invalid danger border/ring across rest and focus', () => {
     render(<Input aria-invalid placeholder="invalid-test" />);
     const input = screen.getByPlaceholderText('invalid-test');
+    // The Tailwind variants only fire when aria-invalid is actually on the
+    // node — assert the attribute first so the test covers the state end-to-end.
+    expect(input).toHaveAttribute('aria-invalid', 'true');
     expect(input.className).toContain('aria-invalid:border-danger');
     expect(input.className).toContain('aria-invalid:focus-visible:border-danger');
     expect(input.className).toContain('aria-invalid:focus-visible:ring-danger');

--- a/src/components/ui/__tests__/select.test.tsx
+++ b/src/components/ui/__tests__/select.test.tsx
@@ -89,4 +89,26 @@ describe('<Select /> composition', () => {
     expect(trigger.className).toContain('aria-invalid:focus-visible:border-danger');
     expect(trigger.className).toContain('aria-invalid:focus-visible:ring-danger');
   });
+
+  // PR-UI-1 (THI-298) — mirror the Input end-to-end invalid test: the Tailwind
+  // `aria-invalid:*` variants only fire when the attribute reaches the DOM.
+  // `aria-invalid` goes on the SelectTrigger (which spreads props onto the
+  // underlying button), NOT on the Radix `Select` Root (not a DOM node).
+  it('forwards aria-invalid to the trigger and keeps the danger contract', () => {
+    render(
+      <Select>
+        <SelectTrigger aria-label="Invalid select" aria-invalid>
+          <SelectValue placeholder="x" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="x">x</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+    const trigger = screen.getByLabelText('Invalid select');
+    expect(trigger).toHaveAttribute('aria-invalid', 'true');
+    expect(trigger.className).toContain('aria-invalid:border-danger');
+    expect(trigger.className).toContain('aria-invalid:focus-visible:border-danger');
+    expect(trigger.className).toContain('aria-invalid:focus-visible:ring-danger');
+  });
 });

--- a/src/components/ui/__tests__/select.test.tsx
+++ b/src/components/ui/__tests__/select.test.tsx
@@ -60,9 +60,10 @@ describe('<Select /> composition', () => {
 
   // PR-UI-1 (THI-298) — the trigger mirrors Input.tsx 1:1 on the "one signal
   // not two" field contract: full rest border + subtle brand hover, focus as
-  // the ring alone (transparent border + ring-offset-0), and a preserved
-  // aria-invalid danger border on focus. jsdom asserts class presence only;
-  // the cascade override is proven by the live-test.
+  // one coherent emerald signal (conformant `border-brand-700` + assorted soft
+  // `ring-brand-500/50`, no offset), and a preserved aria-invalid danger border
+  // on focus. jsdom asserts class presence only; the cascade override is proven
+  // by the live-test.
   it('mirrors the Input field contract on focus/hover/invalid', () => {
     render(
       <Select>
@@ -79,10 +80,12 @@ describe('<Select /> composition', () => {
     expect(trigger.className).toContain('border-border');
     expect(trigger.className).toContain('hover:border-brand-500/40');
     expect(trigger.className).toContain('transition-colors');
-    // focus = ring alone
-    expect(trigger.className).toContain('focus-visible:border-transparent');
+    // focus = conformant border + assorted soft ring
+    expect(trigger.className).toContain('focus-visible:border-brand-700');
+    expect(trigger.className).toContain('focus-visible:ring-brand-500/50');
     expect(trigger.className).toContain('focus-visible:ring-offset-0');
-    expect(trigger.className).toContain('focus-visible:ring-brand-500/30');
+    expect(trigger.className).not.toContain('focus-visible:border-transparent');
+    expect(trigger.className).not.toContain('focus-visible:ring-brand-500/30');
     expect(trigger.className).not.toContain('focus-visible:border-brand-500');
     // invalid preserved across focus
     expect(trigger.className).toContain('aria-invalid:border-danger');

--- a/src/components/ui/__tests__/select.test.tsx
+++ b/src/components/ui/__tests__/select.test.tsx
@@ -57,4 +57,36 @@ describe('<Select /> composition', () => {
     const trigger = screen.getByLabelText('Disabled select');
     expect(trigger).toBeDisabled();
   });
+
+  // PR-UI-1 (THI-298) — the trigger mirrors Input.tsx 1:1 on the "one signal
+  // not two" field contract: full rest border + subtle brand hover, focus as
+  // the ring alone (transparent border + ring-offset-0), and a preserved
+  // aria-invalid danger border on focus. jsdom asserts class presence only;
+  // the cascade override is proven by the live-test.
+  it('mirrors the Input field contract on focus/hover/invalid', () => {
+    render(
+      <Select>
+        <SelectTrigger aria-label="Contract">
+          <SelectValue placeholder="x" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="x">x</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+    const trigger = screen.getByLabelText('Contract');
+    // rest + hover
+    expect(trigger.className).toContain('border-border');
+    expect(trigger.className).toContain('hover:border-brand-500/40');
+    expect(trigger.className).toContain('transition-colors');
+    // focus = ring alone
+    expect(trigger.className).toContain('focus-visible:border-transparent');
+    expect(trigger.className).toContain('focus-visible:ring-offset-0');
+    expect(trigger.className).toContain('focus-visible:ring-brand-500/30');
+    expect(trigger.className).not.toContain('focus-visible:border-brand-500');
+    // invalid preserved across focus
+    expect(trigger.className).toContain('aria-invalid:border-danger');
+    expect(trigger.className).toContain('aria-invalid:focus-visible:border-danger');
+    expect(trigger.className).toContain('aria-invalid:focus-visible:ring-danger');
+  });
 });

--- a/src/components/ui/__tests__/select.test.tsx
+++ b/src/components/ui/__tests__/select.test.tsx
@@ -58,12 +58,10 @@ describe('<Select /> composition', () => {
     expect(trigger).toBeDisabled();
   });
 
-  // PR-UI-1 (THI-298) — the trigger mirrors Input.tsx 1:1 on the "one signal
-  // not two" field contract: full rest border + subtle brand hover, focus as
-  // one coherent emerald signal (conformant `border-brand-700` + assorted soft
-  // `ring-brand-500/50`, no offset), and a preserved aria-invalid danger border
-  // on focus. jsdom asserts class presence only; the cascade override is proven
-  // by the live-test.
+  // PR-UI-1 (THI-298) — the trigger mirrors Input.tsx 1:1: full rest border +
+  // subtle brand hover, focus = a single thin `border-brand-600` (no ring), and
+  // a loud aria-invalid danger border + ring on invalid+focus. jsdom asserts
+  // class presence only; the cascade override is proven by the live-test.
   it('mirrors the Input field contract on focus/hover/invalid', () => {
     render(
       <Select>
@@ -76,21 +74,24 @@ describe('<Select /> composition', () => {
       </Select>,
     );
     const trigger = screen.getByLabelText('Contract');
+    const classes = trigger.className.split(/\s+/);
     // rest + hover
-    expect(trigger.className).toContain('border-border');
-    expect(trigger.className).toContain('hover:border-brand-500/40');
-    expect(trigger.className).toContain('transition-colors');
-    // focus = conformant border + assorted soft ring
-    expect(trigger.className).toContain('focus-visible:border-brand-700');
-    expect(trigger.className).toContain('focus-visible:ring-brand-500/50');
-    expect(trigger.className).toContain('focus-visible:ring-offset-0');
-    expect(trigger.className).not.toContain('focus-visible:border-transparent');
-    expect(trigger.className).not.toContain('focus-visible:ring-brand-500/30');
-    expect(trigger.className).not.toContain('focus-visible:border-brand-500');
-    // invalid preserved across focus
-    expect(trigger.className).toContain('aria-invalid:border-danger');
-    expect(trigger.className).toContain('aria-invalid:focus-visible:border-danger');
-    expect(trigger.className).toContain('aria-invalid:focus-visible:ring-danger');
+    expect(classes).toContain('border-border');
+    expect(classes).toContain('hover:border-brand-500/40');
+    expect(classes).toContain('transition-colors');
+    // focus = thin border only, no ring (token-exact: the danger ring shares
+    // the `focus-visible:ring-2` suffix, so check exact tokens not substrings)
+    expect(classes).toContain('focus-visible:border-brand-600');
+    expect(classes).toContain('focus-visible:outline-none');
+    expect(classes).not.toContain('focus-visible:ring-2');
+    expect(classes).not.toContain('focus-visible:ring-brand-500/50');
+    expect(classes).not.toContain('focus-visible:border-brand-700');
+    expect(classes).not.toContain('focus-visible:border-transparent');
+    // invalid stays loud: danger border + re-anchored danger ring on focus
+    expect(classes).toContain('aria-invalid:border-danger');
+    expect(classes).toContain('aria-invalid:focus-visible:border-danger');
+    expect(classes).toContain('aria-invalid:focus-visible:ring-2');
+    expect(classes).toContain('aria-invalid:focus-visible:ring-danger');
   });
 
   // PR-UI-1 (THI-298) — mirror the Input end-to-end invalid test: the Tailwind

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -20,26 +20,24 @@ import { cn } from '@/lib/utils';
  *   black-on-black on the `[data-theme="dark"]` shell. `dark:[color-scheme:dark]`
  *   propagates the right scheme so the icon is rendered with light pixels.
  *
- * PR-UI-1 (THI-298, 2026-05-31) — "un signal pas deux". The old focus stacked
- * TWO *disparate* signals: a `border-brand-500` AND a `ring-2`, read by
- * @thierry as a "double border". The fix is a single *coherent* signal: at
- * focus the border turns `brand-700` and the ring is `brand-500/50` of the
- * SAME teal family — one emerald affordance in two assorted layers, not two
- * mismatched outlines.
+ * PR-UI-1 (THI-298, 2026-05-31) — "un signal pas deux". The focus signal is a
+ * single thin coloured border, no ring halo. Earlier iterations stacked a
+ * coloured border AND a 2px ring (read by @thierry as a thick "double border"
+ * frame); the ring was dropped. At focus the border simply turns `brand-600`
+ * (#0d9488) — an affirmed cousin of the hover hint, one clean line.
  *
- * Note — an interim "ring alone" variant (`border-transparent` + ring `/30`)
- * was rejected before merge: with the border transparent the ring became the
- * sole focus indicator, and `brand-500/30` falls below the WCAG 2.4.11 (Focus
- * Appearance, AA 2.2) 3:1 threshold (~1.3:1 light, ~1.8:1 dark). `brand-700`
- * (#0f766e) as the focus border is ≈5:1 on card in both themes → conformant.
+ * Colour rationale: with no ring, the border is the SOLE focus indicator, so it
+ * must clear WCAG 2.4.11 (Focus Appearance, AA 2.2) 3:1 on its own. `brand-600`
+ * is ≥3:1 on card in BOTH themes (light ~3.9:1, dark ~3.8:1) — unlike
+ * `brand-700` which dips to ~2.97:1 on the dark card.
  *
  * The rest border stays `border-border` (full) — thinning it broke field
  * affordance on the dark shell (border `#1e293b` vs card `#111a2e` is already
  * low-contrast). A subtle `hover:border-brand-500/40` hints interactivity
- * before focus. The `aria-invalid` state is preserved across all three states:
- * `border-danger` at rest AND on focus (`aria-invalid:focus-visible:border-danger`
- * re-asserts the danger border so `border-brand-700` cannot mask the error),
- * plus `ring-danger`. Select (`select.tsx`) mirrors this contract 1:1.
+ * before focus. The `aria-invalid` state stays loud: `border-danger` at rest
+ * AND on focus, plus a danger `ring-2` re-anchored on invalid+focus only (the
+ * one place a ring remains) so an erroring field is unmistakable when active.
+ * Select (`select.tsx`) mirrors this contract 1:1.
  */
 const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
   ({ className, type, ...props }, ref) => (
@@ -56,18 +54,20 @@ const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLI
         'placeholder:text-muted',
         // PR-UI-1 — subtle brand hint on hover, before focus engages.
         'hover:border-brand-500/40',
-        // PR-UI-1 — focus = one coherent emerald signal: a conformant
-        // `border-brand-700` (#0f766e, ≈5:1, WCAG 2.4.11) plus a soft assorted
-        // `ring-brand-500/50` halo, no offset. Same teal family, not two
-        // mismatched outlines.
-        'focus-visible:border-brand-700 focus-visible:ring-brand-500/50 focus-visible:ring-2 focus-visible:ring-offset-0 focus-visible:outline-none',
+        // PR-UI-1 — focus = a single thin coloured border, no ring halo. The
+        // border turns `brand-600` (#0d9488, ≥3:1 on card in BOTH themes →
+        // WCAG 2.4.11 conformant as the sole indicator). A ring was dropped
+        // (@thierry: the 2px halo read as a thick frame); the border alone is
+        // the affordance, an affirmed cousin of the hover hint.
+        'focus-visible:border-brand-600 focus-visible:outline-none',
         'disabled:cursor-not-allowed disabled:opacity-50',
-        // PR-UI-1 — preserve the invalid state across all three states. The
-        // `aria-invalid:focus-visible:*` rules MUST come after the plain
-        // `focus-visible:*` ones so source-order wins: otherwise
-        // `border-brand-700` would mask the danger border on a focused invalid
-        // field. Same mechanism as the existing ring-danger override.
-        'aria-invalid:border-danger aria-invalid:focus-visible:border-danger aria-invalid:focus-visible:ring-danger',
+        // PR-UI-1 — invalid stays loud: `border-danger` at rest AND on focus
+        // (`aria-invalid:focus-visible:border-danger` comes after the plain
+        // focus border so source-order wins). Since valid focus no longer
+        // carries a ring, the danger ring is re-anchored HERE (with its own
+        // `ring-2` width) so an invalid + focused field still gets an
+        // unmistakable focus halo — the one place a ring remains.
+        'aria-invalid:border-danger aria-invalid:focus-visible:border-danger aria-invalid:focus-visible:ring-danger aria-invalid:focus-visible:ring-2',
         // F4 — let native `<input type="date">` (and friends) pick the right
         // colour scheme so the calendar icon stays visible on dark theme.
         'dark:scheme-dark',

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -20,18 +20,26 @@ import { cn } from '@/lib/utils';
  *   black-on-black on the `[data-theme="dark"]` shell. `dark:[color-scheme:dark]`
  *   propagates the right scheme so the icon is rendered with light pixels.
  *
- * PR-UI-1 (THI-298, 2026-05-31) — "un signal pas deux". At rest the field
- * kept `border-border`, but on focus it stacked TWO signals: a coloured
- * `border-brand-500` AND a `ring-2`. @thierry read this as a "double border".
- * Fix: focus is now the RING ALONE — `border-transparent` + `ring-offset-0`,
- * so a single emerald halo signals focus. A subtle `hover:border-brand-500/40`
- * hints interactivity before focus. The rest border stays `border-border`
- * (full) — thinning it broke field affordance on the dark shell (border
- * `#1e293b` vs card `#111a2e` is already low-contrast). The `aria-invalid`
- * state is preserved across all three states: `border-danger` at rest AND on
- * focus (`aria-invalid:focus-visible:border-danger` re-asserts the danger
- * border so `border-transparent` cannot erase the error), plus `ring-danger`.
- * Select (`select.tsx`) mirrors this contract 1:1.
+ * PR-UI-1 (THI-298, 2026-05-31) — "un signal pas deux". The old focus stacked
+ * TWO *disparate* signals: a `border-brand-500` AND a `ring-2`, read by
+ * @thierry as a "double border". The fix is a single *coherent* signal: at
+ * focus the border turns `brand-700` and the ring is `brand-500/50` of the
+ * SAME teal family — one emerald affordance in two assorted layers, not two
+ * mismatched outlines.
+ *
+ * Note — an interim "ring alone" variant (`border-transparent` + ring `/30`)
+ * was rejected before merge: with the border transparent the ring became the
+ * sole focus indicator, and `brand-500/30` falls below the WCAG 2.4.11 (Focus
+ * Appearance, AA 2.2) 3:1 threshold (~1.3:1 light, ~1.8:1 dark). `brand-700`
+ * (#0f766e) as the focus border is ≈5:1 on card in both themes → conformant.
+ *
+ * The rest border stays `border-border` (full) — thinning it broke field
+ * affordance on the dark shell (border `#1e293b` vs card `#111a2e` is already
+ * low-contrast). A subtle `hover:border-brand-500/40` hints interactivity
+ * before focus. The `aria-invalid` state is preserved across all three states:
+ * `border-danger` at rest AND on focus (`aria-invalid:focus-visible:border-danger`
+ * re-asserts the danger border so `border-brand-700` cannot mask the error),
+ * plus `ring-danger`. Select (`select.tsx`) mirrors this contract 1:1.
  */
 const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
   ({ className, type, ...props }, ref) => (
@@ -48,15 +56,17 @@ const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLI
         'placeholder:text-muted',
         // PR-UI-1 — subtle brand hint on hover, before focus engages.
         'hover:border-brand-500/40',
-        // PR-UI-1 — focus is the RING ALONE: transparent border + F2 soft ring
-        // (brand-500 at 30%, no offset). One signal, not two.
-        'focus-visible:ring-brand-500/30 focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-offset-0 focus-visible:outline-none',
+        // PR-UI-1 — focus = one coherent emerald signal: a conformant
+        // `border-brand-700` (#0f766e, ≈5:1, WCAG 2.4.11) plus a soft assorted
+        // `ring-brand-500/50` halo, no offset. Same teal family, not two
+        // mismatched outlines.
+        'focus-visible:border-brand-700 focus-visible:ring-brand-500/50 focus-visible:ring-2 focus-visible:ring-offset-0 focus-visible:outline-none',
         'disabled:cursor-not-allowed disabled:opacity-50',
         // PR-UI-1 — preserve the invalid state across all three states. The
         // `aria-invalid:focus-visible:*` rules MUST come after the plain
         // `focus-visible:*` ones so source-order wins: otherwise
-        // `border-transparent` would erase the danger border on a focused
-        // invalid field. Same mechanism as the existing ring-danger override.
+        // `border-brand-700` would mask the danger border on a focused invalid
+        // field. Same mechanism as the existing ring-danger override.
         'aria-invalid:border-danger aria-invalid:focus-visible:border-danger aria-invalid:focus-visible:ring-danger',
         // F4 — let native `<input type="date">` (and friends) pick the right
         // colour scheme so the calendar icon stays visible on dark theme.

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -54,11 +54,14 @@ const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLI
         'placeholder:text-muted',
         // PR-UI-1 — subtle brand hint on hover, before focus engages.
         'hover:border-brand-500/40',
-        // PR-UI-1 — focus = a single thin coloured border, no ring halo. The
-        // border turns `brand-600` (#0d9488, ≥3:1 on card in BOTH themes →
-        // WCAG 2.4.11 conformant as the sole indicator). A ring was dropped
-        // (@thierry: the 2px halo read as a thick frame); the border alone is
-        // the affordance, an affirmed cousin of the hover hint.
+        // PR-UI-1 — focus = a single thin emerald edge, no detached outline,
+        // no ring halo (@thierry: the 2px halo/outline read as a thick frame).
+        // The ~2px thickness + the outline cancellation are applied CENTRALLY,
+        // non-layered, in `globals.css` (`.ankora-form-control-16:focus-visible`)
+        // because the global `*:focus-visible` outline is itself non-layered and
+        // cannot be cancelled from a Tailwind utility. These two classes set the
+        // border colour (cosmetic, matches the central rule) and are otherwise
+        // superseded there — see globals.css for the full mechanism.
         'focus-visible:border-brand-600 focus-visible:outline-none',
         'disabled:cursor-not-allowed disabled:opacity-50',
         // PR-UI-1 — invalid stays loud: `border-danger` at rest AND on focus

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -19,6 +19,19 @@ import { cn } from '@/lib/utils';
  *   defaults to `color-scheme: light` and renders the calendar SVG in
  *   black-on-black on the `[data-theme="dark"]` shell. `dark:[color-scheme:dark]`
  *   propagates the right scheme so the icon is rendered with light pixels.
+ *
+ * PR-UI-1 (THI-298, 2026-05-31) — "un signal pas deux". At rest the field
+ * kept `border-border`, but on focus it stacked TWO signals: a coloured
+ * `border-brand-500` AND a `ring-2`. @thierry read this as a "double border".
+ * Fix: focus is now the RING ALONE — `border-transparent` + `ring-offset-0`,
+ * so a single emerald halo signals focus. A subtle `hover:border-brand-500/40`
+ * hints interactivity before focus. The rest border stays `border-border`
+ * (full) — thinning it broke field affordance on the dark shell (border
+ * `#1e293b` vs card `#111a2e` is already low-contrast). The `aria-invalid`
+ * state is preserved across all three states: `border-danger` at rest AND on
+ * focus (`aria-invalid:focus-visible:border-danger` re-asserts the danger
+ * border so `border-transparent` cannot erase the error), plus `ring-danger`.
+ * Select (`select.tsx`) mirrors this contract 1:1.
  */
 const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
   ({ className, type, ...props }, ref) => (
@@ -33,10 +46,18 @@ const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLI
         'ankora-form-control-16 border-border bg-card text-foreground flex h-10 w-full rounded-lg border px-3 py-2 shadow-sm transition-colors',
         'file:text-foreground file:border-0 file:bg-transparent file:text-sm file:font-medium',
         'placeholder:text-muted',
-        // F2 — softer focus ring (no offset, brand-500 at 30% opacity)
-        'focus-visible:border-brand-500 focus-visible:ring-brand-500/30 focus-visible:ring-2 focus-visible:outline-none',
+        // PR-UI-1 — subtle brand hint on hover, before focus engages.
+        'hover:border-brand-500/40',
+        // PR-UI-1 — focus is the RING ALONE: transparent border + F2 soft ring
+        // (brand-500 at 30%, no offset). One signal, not two.
+        'focus-visible:ring-brand-500/30 focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-offset-0 focus-visible:outline-none',
         'disabled:cursor-not-allowed disabled:opacity-50',
-        'aria-invalid:border-danger aria-invalid:focus-visible:ring-danger',
+        // PR-UI-1 — preserve the invalid state across all three states. The
+        // `aria-invalid:focus-visible:*` rules MUST come after the plain
+        // `focus-visible:*` ones so source-order wins: otherwise
+        // `border-transparent` would erase the danger border on a focused
+        // invalid field. Same mechanism as the existing ring-danger override.
+        'aria-invalid:border-danger aria-invalid:focus-visible:border-danger aria-invalid:focus-visible:ring-danger',
         // F4 — let native `<input type="date">` (and friends) pick the right
         // colour scheme so the calendar icon stays visible on dark theme.
         'dark:scheme-dark',

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -19,16 +19,21 @@ const SelectTrigger = React.forwardRef<
     className={cn(
       // PR-D5 mobile-iOS: `ankora-form-control-16` enforces 16px font-size.
       // See `Input.tsx` + `globals.css` for the full triage.
-      'ankora-form-control-16 border-border bg-card flex h-10 w-full items-center justify-between gap-2 rounded-lg border px-3 py-2 shadow-sm',
-      // PR-BETA-CLEANUP-3 (2026-05-27) — aligned on the Input.tsx F2 contract:
-      // `ring-2 ring-offset-2 ring-brand-600` rendered as a thick white halo
-      // on dark theme (the offset uses `--color-background`, which inverts
-      // brand-600 into a hard outline). Softer ring + no offset matches the
-      // F2 fix shipped on Input on 2026-05-07. Same rule, same look.
-      'focus-visible:border-brand-500 focus-visible:ring-brand-500/30 focus-visible:ring-2 focus-visible:outline-none',
+      // PR-UI-1 (THI-298) — `transition-colors` added for parity with Input so
+      // the border/ring change animates smoothly on hover/focus.
+      'ankora-form-control-16 border-border bg-card flex h-10 w-full items-center justify-between gap-2 rounded-lg border px-3 py-2 shadow-sm transition-colors',
+      // PR-UI-1 — subtle brand hint on hover, before focus engages.
+      'hover:border-brand-500/40',
+      // PR-UI-1 (THI-298) — mirrors Input.tsx 1:1: focus is the RING ALONE
+      // (`border-transparent` + `ring-offset-0`), one signal not two. Keeps the
+      // F2 soft ring (brand-500 at 30%, no offset) shipped on 2026-05-07.
+      'focus-visible:ring-brand-500/30 focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-offset-0 focus-visible:outline-none',
       'disabled:cursor-not-allowed disabled:opacity-50',
       'data-placeholder:text-muted',
-      'aria-invalid:border-danger aria-invalid:focus-visible:ring-danger',
+      // PR-UI-1 — preserve invalid across all states (see Input.tsx). The
+      // `aria-invalid:focus-visible:*` rules come after the plain ones so
+      // source-order keeps the danger border/ring on a focused invalid field.
+      'aria-invalid:border-danger aria-invalid:focus-visible:border-danger aria-invalid:focus-visible:ring-danger',
       className,
     )}
     {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -24,10 +24,11 @@ const SelectTrigger = React.forwardRef<
       'ankora-form-control-16 border-border bg-card flex h-10 w-full items-center justify-between gap-2 rounded-lg border px-3 py-2 shadow-sm transition-colors',
       // PR-UI-1 — subtle brand hint on hover, before focus engages.
       'hover:border-brand-500/40',
-      // PR-UI-1 (THI-298) — mirrors Input.tsx 1:1: focus is the RING ALONE
-      // (`border-transparent` + `ring-offset-0`), one signal not two. Keeps the
-      // F2 soft ring (brand-500 at 30%, no offset) shipped on 2026-05-07.
-      'focus-visible:ring-brand-500/30 focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-offset-0 focus-visible:outline-none',
+      // PR-UI-1 (THI-298) — mirrors Input.tsx 1:1: focus = one coherent emerald
+      // signal, a conformant `border-brand-700` (#0f766e, ≈5:1, WCAG 2.4.11)
+      // plus an assorted soft `ring-brand-500/50` halo, no offset. (An interim
+      // "ring alone" variant at /30 was rejected — sole indicator below 3:1.)
+      'focus-visible:border-brand-700 focus-visible:ring-brand-500/50 focus-visible:ring-2 focus-visible:ring-offset-0 focus-visible:outline-none',
       'disabled:cursor-not-allowed disabled:opacity-50',
       'data-placeholder:text-muted',
       // PR-UI-1 — preserve invalid across all states (see Input.tsx). The

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -24,9 +24,11 @@ const SelectTrigger = React.forwardRef<
       'ankora-form-control-16 border-border bg-card flex h-10 w-full items-center justify-between gap-2 rounded-lg border px-3 py-2 shadow-sm transition-colors',
       // PR-UI-1 — subtle brand hint on hover, before focus engages.
       'hover:border-brand-500/40',
-      // PR-UI-1 (THI-298) — mirrors Input.tsx 1:1: focus = a single thin
-      // `border-brand-600` (#0d9488, ≥3:1 both themes, WCAG 2.4.11), no ring
-      // halo (@thierry: the 2px ring read as a thick frame).
+      // PR-UI-1 (THI-298) — mirrors Input.tsx 1:1: focus = a single thin emerald
+      // edge, no detached outline, no ring halo. The ~2px thickness + outline
+      // cancellation live CENTRALLY (non-layered) in `globals.css`
+      // (`.ankora-form-control-16:focus-visible`); these two classes are
+      // cosmetic colour and are superseded there — see globals.css.
       'focus-visible:border-brand-600 focus-visible:outline-none',
       'disabled:cursor-not-allowed disabled:opacity-50',
       'data-placeholder:text-muted',

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -24,17 +24,16 @@ const SelectTrigger = React.forwardRef<
       'ankora-form-control-16 border-border bg-card flex h-10 w-full items-center justify-between gap-2 rounded-lg border px-3 py-2 shadow-sm transition-colors',
       // PR-UI-1 — subtle brand hint on hover, before focus engages.
       'hover:border-brand-500/40',
-      // PR-UI-1 (THI-298) — mirrors Input.tsx 1:1: focus = one coherent emerald
-      // signal, a conformant `border-brand-700` (#0f766e, ≈5:1, WCAG 2.4.11)
-      // plus an assorted soft `ring-brand-500/50` halo, no offset. (An interim
-      // "ring alone" variant at /30 was rejected — sole indicator below 3:1.)
-      'focus-visible:border-brand-700 focus-visible:ring-brand-500/50 focus-visible:ring-2 focus-visible:ring-offset-0 focus-visible:outline-none',
+      // PR-UI-1 (THI-298) — mirrors Input.tsx 1:1: focus = a single thin
+      // `border-brand-600` (#0d9488, ≥3:1 both themes, WCAG 2.4.11), no ring
+      // halo (@thierry: the 2px ring read as a thick frame).
+      'focus-visible:border-brand-600 focus-visible:outline-none',
       'disabled:cursor-not-allowed disabled:opacity-50',
       'data-placeholder:text-muted',
-      // PR-UI-1 — preserve invalid across all states (see Input.tsx). The
-      // `aria-invalid:focus-visible:*` rules come after the plain ones so
-      // source-order keeps the danger border/ring on a focused invalid field.
-      'aria-invalid:border-danger aria-invalid:focus-visible:border-danger aria-invalid:focus-visible:ring-danger',
+      // PR-UI-1 — invalid stays loud (see Input.tsx): the danger ring is
+      // re-anchored here (own `ring-2`) so an invalid + focused trigger keeps
+      // an unmistakable halo — the one place a ring remains.
+      'aria-invalid:border-danger aria-invalid:focus-visible:border-danger aria-invalid:focus-visible:ring-danger aria-invalid:focus-visible:ring-2',
       className,
     )}
     {...props}


### PR DESCRIPTION
## PR-UI-1 — Champs : focus/bordure « un signal pas deux » (THI-298)

> Contrat documenté = commit livré **`b0d74ce`**. Les itérations v1→v4 sont superseded (cf. section Itérations).

### Motivation
Au focus, le contrat de champ partagé (`Input` + `SelectTrigger`) empilait plusieurs signaux : une bordure colorée **et** un `ring-2`, **et** un outline détaché de 2px venant de la règle globale `*:focus-visible` (`globals.css:394`). @thierry l'a lu comme une « double/triple bordure ». Cette PR fait du focus **un seul liseré émeraude ~2px**, sans ring, sans outline détaché.

### Changements (Input ET SelectTrigger, symétriques 1:1)
| État | Après (`b0d74ce`) |
|------|-------------------|
| Repos | `border-border` (inchangé — affordance, `/60` rejeté en dark) |
| Hover | `hover:border-brand-500/40` (indice subtil) |
| Focus (valide) | **Composant** : `focus-visible:border-brand-600 focus-visible:outline-none`. **Central** (`globals.css:421`) : `border-color brand-600` + `box-shadow 0 0 0 1px brand-600` + `outline:none` → liseré ~2px opaque, no-reflow, **sans ring** |
| Invalide | `aria-invalid:border-danger` + `aria-invalid:focus-visible:ring-danger ring-2` — bordure + ring danger survivent au focus (carve-out central `:not([aria-invalid])`). Le ring n'existe QUE pour l'invalide |

### Mécanisme central (pourquoi `globals.css`)
La globale `*:focus-visible { outline: 2px }` est **non-layered**. Le `focus-visible:outline-none` du composant est une utility Tailwind (**layered**) → non-layered gagne toujours, l'outline détaché s'appliquait en plus de la bordure. La neutralisation doit donc être non-layered : exception compagne `.ankora-form-control-16:focus-visible` (`globals.css:421`), plus spécifique et non-layered. `.ankora-form-control-16` n'est porté QUE par `Input` + `SelectTrigger` → boutons/liens/tabs/checkboxes gardent la globale intacte (**anti-régression WCAG 2.4.7**). Réutilise `var(--color-brand-600)` → remap brass admin honoré.

### Itérations (traçabilité)
1. v1 repos `/60` → rejeté (a11y dark). 2. v2 `border-transparent` + ring `/30` → rejeté (ring seul sous 2.4.11). 3. v3 `brand-700` + ring `/50` → rejeté @thierry (halo lu comme cadre épais). 4. v4 (`c0adaa6`) bordure fine seule → l'outline global détaché subsistait. 5. **v5 livré (`b0d74ce`)** neutralisation centrale non-layered + liseré ~2px no-reflow + carve-out aria-invalid.

### Fichiers
`src/app/globals.css` (mécanisme central) · `src/components/ui/input.tsx` · `src/components/ui/select.tsx` · tests `input.test.tsx` + `select.test.tsx`.

### Evidence
- **Live-test @cowork sur `b0d74ce`** ✅ PASS — runtime, **clair ET sombre** : liseré brand-600 + box-shadow 1px + outline neutralisé = un seul signal, zéro double cadre. Re-vérifié après stabilisation `transition-colors`.
- `plan-reviewer` ✅ APPROVED WITH CHANGES (3 hard gates : `.drw-input` hors scope tracé THI-304 Lot D, carve-out aria-invalid, contraste admin = même token).
- `ui-auditor` / `mobile-ios-auditor` ✅ PASS — audités sur le contrat v3 (brand-700 + ring/50) ; le rendu final est un liseré brand-600 **opaque** (plus contrasté qu'un ring translucide) → preuve a11y du rendu final = live-test runtime @cowork ci-dessus.
- `typecheck` ✅ · `lint` ✅ · `vitest` 15/15 ciblé ✅ · `build` ✅.

### Hors scope (tracé)
Double cadre au repos (card vs champ) → PR-UI-3a. Dette focus transverse → THI-304 (Lot A ring `/30`, Lot B fallback `:focus` iOS, Lot C contraste dark, **Lot D `.drw-input` drawer atom**).

Closes THI-298.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
