### PR TITLE
feat(charges): badge fréquence sobre, visible et distinct (THI-299)

### DIFF
--- a/docs/i18n-glossary.md
+++ b/docs/i18n-glossary.md
@@ -141,6 +141,23 @@ Runtime formatter uses `Intl.NumberFormat(locale, { style: 'currency', currency:
 | Semestriel  | Halfjaarlijks   | Semi-annual | Halbjährlich    | Semestral  |
 | Annuel      | Jaarlijks       | Annual      | Jährlich        | Anual      |
 
+### Frequency abbreviations (`common.frequencyAbbr`)
+
+Compact labels for the charges-list frequency tag (THI-299). The full word above stays the accessible name (screen-reader `sr-only` + hover `title`); these are the visible shorthand only. Added 2026-06-01.
+
+| Enum         | fr-BE | nl-BE  | en    | de-DE   | es-ES |
+| ------------ | ----- | ------ | ----- | ------- | ----- |
+| `monthly`    | Mens. | Mnd.   | Mo.   | Mtl.    | Mens. |
+| `quarterly`  | Trim. | Kwart. | Qtr.  | Quartl. | Trim. |
+| `semiannual` | Sem.  | Halfj. | Semi. | Halbj.  | Sem.  |
+| `annual`     | Ann.  | Jaarl. | Ann.  | Jährl.  | Anual |
+
+**Decisions (i18n-auditor 2026-06-01):**
+
+- `Sem.` (fr-BE/es-ES) is mildly ambiguous (semestriel/semestral vs semaine/semana), accepted because the enum has only 4 values, all shown together, and the full word is always available. Not used for any weekly frequency (none exists).
+- de-DE `quarterly` = **`Quartl.`** (not `Vj.`): `Vj.` reads as _Vorjahr_ (prior year) in a financial context — replaced to remove the collision.
+- es-ES `annual` = `Anual` keeps no trailing dot: it is the full short word, not a truncation, so a period would be grammatically wrong.
+
 ---
 
 ## 5. Tone rules
@@ -178,9 +195,10 @@ Runtime formatter uses `Intl.NumberFormat(locale, { style: 'currency', currency:
 
 ## 7. Versioning
 
-| Version | Date       | Change                                                                                                     |
-| ------- | ---------- | ---------------------------------------------------------------------------------------------------------- |
-| 1.0     | 2026-04-20 | Initial glossary — Wave 1.5 "Opération Babel" translation.                                                 |
-| 1.1     | 2026-04-20 | Destructive confirmations switch to email-as-keyword pattern (§6). Drop SUPPRIMER/DELETE/LÖSCHEN/ELIMINAR. |
+| Version | Date       | Change                                                                                                            |
+| ------- | ---------- | ----------------------------------------------------------------------------------------------------------------- |
+| 1.0     | 2026-04-20 | Initial glossary — Wave 1.5 "Opération Babel" translation.                                                        |
+| 1.1     | 2026-04-20 | Destructive confirmations switch to email-as-keyword pattern (§6). Drop SUPPRIMER/DELETE/LÖSCHEN/ELIMINAR.        |
+| 1.2     | 2026-06-01 | Add `common.frequencyAbbr` abbreviation table (§4, THI-299). de-DE quarterly `Vj.`→`Quartl.` (Vorjahr collision). |
 
 Any new term, any register change, any account-name update **must** be logged here before landing in messages/\*.json.

--- a/docs/prs/PR-UI-2-report.md
+++ b/docs/prs/PR-UI-2-report.md
@@ -1,0 +1,97 @@
+# PR-UI-2 — Badge fréquence charges : sobre + visible + distinct (THI-299)
+
+> **Branche** : `feat/thi-299-charges-frequency-badge` · **Ticket** : THI-299
+> **Auteur** : @cc-ankora (orchestrateur, @cowork en debrief) · **Date** : 2026-06-01
+
+---
+
+## 1. Objectif
+
+Le badge fréquence de la liste charges (`ChargesClient.tsx`) était **invisible et indistinct** :
+
+- `bg-surface-muted` sur `bg-card` ≈ 1.05:1 → pilule invisible.
+- texte `text-muted-foreground` = identique au `charges-row-next-due` → indistinct.
+- rendait le **mot entier** (`tFreq(c.frequency)`, namespace `common.frequency`).
+
+Décision @thierry verrouillée : **PAS de color-coding** (la couleur reste réservée au `color_token` catégorie). Différencier par **abréviation + icône neutre**, WCAG ≥ 4.5:1, tokens sémantiques, zéro hex.
+
+## 2. Solution livrée
+
+Tag **borderless** : icône de récurrence neutre + abréviation locale en `text-foreground`. La visibilité + la distinction reposent sur **trois signaux opaques, 100% tokens** (au lieu d'un conteneur invisible) :
+
+1. l'icône `<Repeat>` (lucide, `text-muted-foreground`, `size-3`, décorative) ;
+2. la couleur `text-foreground` (vs `text-muted-foreground` du next-due — AAA sur card) ;
+3. la forme **abrégée** (Mens./Trim./Sem./Ann.).
+
+```tsx
+<span data-testid="charges-row-frequency"
+  className="text-foreground inline-flex w-fit shrink-0 items-center gap-1 text-xs font-medium md:order-3">
+  <Repeat aria-hidden="true" className="text-muted-foreground size-3" />
+  <abbr title={tFreq(...)} aria-hidden="true" className="no-underline">{tFreqAbbr(...)}</abbr>
+  <span className="sr-only">{tFreq(...)}</span>
+</span>
+```
+
+### Pourquoi borderless (et pas le chip outlined initialement prévu)
+
+Le plan initial utilisait `border-border-strong`. Les audits `ui-auditor` + `mobile-ios-auditor` ont révélé que **`--color-border-strong` est un token fantôme** : référencé dans `token-usage.md` §3 + `claude-design-brief.md` mais **jamais défini dans `globals.css`**. Un chip outlined aurait eu une bordure invisible (~1.16:1) — soit exactement le bug du ticket. Plutôt que de définir le token (décision de **valeur** de design = arbitrage @thierry/@cowork, interdit en même session que l'implémentation, doctrine banned-list #2), le badge est passé en borderless. Le token fantôme est tracé séparément en **THI-314**.
+
+### a11y
+
+- Icône décorative : `aria-hidden="true"`.
+- L'abréviation visible est `aria-hidden` ; le **mot complet** est exposé aux lecteurs d'écran via `sr-only` (robuste : VoiceOver iOS n'annonce pas fiablement `<abbr title>`).
+- Les voyants gardent le mot complet au survol via `title`.
+
+## 3. Clés i18n — nouveau namespace `common.frequencyAbbr` (5 locales)
+
+`common.frequency` (mots complets) **inchangé** — consommé par 4 surfaces (selects ChargesClient + ChargeEditDrawer + OnboardingWizard + SimulatorClient). Les abréviations sont des **nouvelles** clés.
+
+| Enum       | fr-BE | nl-BE  | en    | de-DE   | es-ES |
+| ---------- | ----- | ------ | ----- | ------- | ----- |
+| monthly    | Mens. | Mnd.   | Mo.   | Mtl.    | Mens. |
+| quarterly  | Trim. | Kwart. | Qtr.  | Quartl. | Trim. |
+| semiannual | Sem.  | Halfj. | Semi. | Halbj.  | Sem.  |
+| annual     | Ann.  | Jaarl. | Ann.  | Jährl.  | Anual |
+
+de-DE quarterly = **`Quartl.`** (pas `Vj.` : collision avec _Vorjahr_ en contexte financier, flag i18n-auditor appliqué). Glossaire `docs/i18n-glossary.md` bumpé **v1.2** avec la table + les décisions.
+
+## 4. Fichiers modifiés
+
+- `src/app/[locale]/app/charges/ChargesClient.tsx` — badge + hook `tFreqAbbr` + import `Repeat`.
+- `messages/{fr-BE,en,nl-BE,de-DE,es-ES}.json` — namespace `common.frequencyAbbr`.
+- `src/app/[locale]/app/charges/__tests__/ChargesClient.test.tsx` — asserts abréviation + `title` (matcher `getByTitle`).
+- `docs/i18n-glossary.md` — table abréviations + v1.2.
+
+## 5. QA — agents (DoD)
+
+| Agent                | Verdict                  | Résolution                                                                                                                                 |
+| -------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `plan-reviewer`      | 🟡 APPROVED WITH CHANGES | 4 consommateurs `common.frequency` documentés, matcher `title` corrigé, invariant géométrie e2e noté, DoD ajoutée — tous intégrés          |
+| `i18n-auditor`       | PASS_WITH_NOTES          | `Vj.`→`Quartl.` appliqué ; glossaire v1.2 ; `Sem.`/`Semi.`/`Anual` jugés acceptables (contexte 4 valeurs + mot complet dispo)              |
+| `ui-auditor`         | BLOCK → résolu           | F1/F2/F3 (token fantôme + contraste bordure) éliminés par le borderless ; F5 (abbr VoiceOver) → `sr-only` ; F6 (`aria-hidden`) → `="true"` |
+| `mobile-ios-auditor` | PASS_WITH_NOTES → résolu | token fantôme idem ; pas d'overflow iPhone SE (label `truncate` + chip `shrink-0`) ; `no-underline` OK WebKit                              |
+
+**Note densité (non bloquante, pour live-test @thierry)** : icône `Repeat` ×N lignes — risque de charge visuelle à confirmer en live. L'icône est subordonnée (`text-muted-foreground`) sous le texte (`text-foreground`).
+
+## 6. Tests
+
+- `vitest` `ChargesClient.test.tsx` : **18/18** pass.
+- `npm run typecheck` : 0 erreur.
+- `npm run lint` : 0 erreur. `npm run lint:use-server` : pass.
+- JSON valide ×5 locales.
+- e2e `charges-list-desktop` : invariant préservé (badge garde `shrink-0`, markup identique sur toutes les lignes → spread géométrique = 0).
+
+## 7. Hors scope (tracé)
+
+- **Groupement / total bas** = THI-300 (PR-UI-3a).
+- **Token `--color-border-strong`** = THI-314 (définition + doc, décision valeur @thierry).
+- `common.frequency` mots complets : intouchés.
+
+## 8. Définition de DONE
+
+1. CI verts (Lint, Typecheck, Tests, E2E, Security, Build) : ⏳ à confirmer post-push
+2. Sourcery silencieux sur dernier commit : ⏳
+3. Review humaine : ⏳ @thierry
+4. Pas de conflit main : ⏳
+5. Rapport (ce doc) : ✅
+6. Live-test @thierry clair/sombre (visibilité + distinction + densité icône) : ⏳ **bloquant avant merge**

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -67,6 +67,12 @@
       "quarterly": "Vierteljährlich",
       "semiannual": "Halbjährlich",
       "annual": "Jährlich"
+    },
+    "frequencyAbbr": {
+      "monthly": "Mtl.",
+      "quarterly": "Quartl.",
+      "semiannual": "Halbj.",
+      "annual": "Jährl."
     }
   },
   "layout": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -67,6 +67,12 @@
       "quarterly": "Quarterly",
       "semiannual": "Semi-annual",
       "annual": "Annual"
+    },
+    "frequencyAbbr": {
+      "monthly": "Mo.",
+      "quarterly": "Qtr.",
+      "semiannual": "Semi.",
+      "annual": "Ann."
     }
   },
   "layout": {

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -67,6 +67,12 @@
       "quarterly": "Trimestral",
       "semiannual": "Semestral",
       "annual": "Anual"
+    },
+    "frequencyAbbr": {
+      "monthly": "Mens.",
+      "quarterly": "Trim.",
+      "semiannual": "Sem.",
+      "annual": "Anual"
     }
   },
   "layout": {

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -67,6 +67,12 @@
       "quarterly": "Trimestriel",
       "semiannual": "Semestriel",
       "annual": "Annuel"
+    },
+    "frequencyAbbr": {
+      "monthly": "Mens.",
+      "quarterly": "Trim.",
+      "semiannual": "Sem.",
+      "annual": "Ann."
     }
   },
   "layout": {

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -67,6 +67,12 @@
       "quarterly": "Driemaandelijks",
       "semiannual": "Halfjaarlijks",
       "annual": "Jaarlijks"
+    },
+    "frequencyAbbr": {
+      "monthly": "Mnd.",
+      "quarterly": "Kwart.",
+      "semiannual": "Halfj.",
+      "annual": "Jaarl."
     }
   },
   "layout": {

--- a/src/app/[locale]/app/charges/ChargesClient.tsx
+++ b/src/app/[locale]/app/charges/ChargesClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useState, useTransition } from 'react';
-import { Pencil, Plus, Trash2 } from 'lucide-react';
+import { Pencil, Plus, Repeat, Trash2 } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 
 import { Button } from '@/components/ui/button';
@@ -62,6 +62,7 @@ function todayBrusselsIso(): string {
 export function ChargesClient({ charges }: { charges: RawCharge[] }) {
   const t = useTranslations('app.charges');
   const tFreq = useTranslations('common.frequency');
+  const tFreqAbbr = useTranslations('common.frequencyAbbr');
   const tMonths = useTranslations('common.months');
   const locale = useLocale() as Locale;
   const translateError = useActionErrorTranslator();
@@ -300,11 +301,33 @@ export function ChargesClient({ charges }: { charges: RawCharge[] }) {
                     >
                       {c.label}
                     </span>
+                    {/* Frequency tag (THI-299): a neutral recurrence icon + the locale
+                        abbreviation in `text-foreground`. NOT colour-coded — colour stays
+                        reserved for the category `color_token` (@thierry locked). The
+                        previous pill used `bg-surface-muted` (~1.05:1 on the card →
+                        invisible) AND `text-muted-foreground` (identical to the next-due
+                        label). The fix carries visibility + distinction on three opaque,
+                        token-only signals instead of an invisible container: the icon, the
+                        `text-foreground` colour (vs muted next-due, AAA on card), and the
+                        abbreviated form. No border/fill, so no dependency on the
+                        undefined `--color-border-strong` token. a11y: the icon is
+                        decorative; the visible abbreviation is `aria-hidden` and the full
+                        word is exposed to screen readers via `sr-only` (robust across
+                        VoiceOver, which does not reliably announce `<abbr title>`), while
+                        sighted users still get the full word on hover via `title`. */}
                     <span
                       data-testid="charges-row-frequency"
-                      className="bg-surface-muted text-muted-foreground inline-flex w-fit shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-medium md:order-3"
+                      className="text-foreground inline-flex w-fit shrink-0 items-center gap-1 text-xs font-medium md:order-3"
                     >
-                      {tFreq(c.frequency as Frequency)}
+                      <Repeat aria-hidden="true" className="text-muted-foreground size-3" />
+                      <abbr
+                        title={tFreq(c.frequency as Frequency)}
+                        aria-hidden="true"
+                        className="no-underline"
+                      >
+                        {tFreqAbbr(c.frequency as Frequency)}
+                      </abbr>
+                      <span className="sr-only">{tFreq(c.frequency as Frequency)}</span>
                     </span>
                   </div>
 

--- a/src/app/[locale]/app/charges/__tests__/ChargesClient.test.tsx
+++ b/src/app/[locale]/app/charges/__tests__/ChargesClient.test.tsx
@@ -110,7 +110,10 @@ describe('<ChargesClient /> — PR-BETA-1 visual refactor', () => {
     expect(within(firstRow).getByTestId('charges-row-label')).toHaveTextContent(
       'Loyer appartement',
     );
-    expect(within(firstRow).getByTestId('charges-row-frequency')).toHaveTextContent(/mensuel/i);
+    // THI-299: the badge now shows the locale abbreviation, with the full word
+    // kept accessible via the `<abbr title>`.
+    expect(within(firstRow).getByTestId('charges-row-frequency')).toHaveTextContent(/mens\./i);
+    expect(within(firstRow).getByTitle('Mensuel')).toBeInTheDocument();
     // Tolerate regular space or non-breaking space inserted by Intl.NumberFormat.
     expect(within(firstRow).getByTestId('charges-row-amount')).toHaveTextContent(/1[  ]200/);
 
@@ -119,7 +122,8 @@ describe('<ChargesClient /> — PR-BETA-1 visual refactor', () => {
     const secondRow = screen.getByTestId('charges-row-a2');
     // PR-BETA-CLEANUP-2: next-due asserted below; month-only cell removed.
     expect(within(secondRow).getByTestId('charges-row-label')).toHaveTextContent('Taxe voiture');
-    expect(within(secondRow).getByTestId('charges-row-frequency')).toHaveTextContent(/annuel/i);
+    expect(within(secondRow).getByTestId('charges-row-frequency')).toHaveTextContent(/ann\./i);
+    expect(within(secondRow).getByTitle('Annuel')).toBeInTheDocument();
     expect(within(secondRow).getByTestId('charges-row-amount')).toHaveTextContent(/300/);
   });
 


### PR DESCRIPTION
## PR-UI-2 — Badge fréquence charges : sobre + visible + distinct (THI-299)

### Problème
Le badge fréquence (`ChargesClient.tsx`) était **invisible** (`bg-surface-muted` sur card ≈ 1.05:1) et **indistinct** du next-due (même `text-muted-foreground`).

### Solution — tag borderless (zéro couleur, décision @thierry verrouillée)
Icône de récurrence neutre + abréviation locale en `text-foreground`. Visibilité + distinction portées par **3 signaux opaques 100% tokens** : icône `<Repeat>` (décorative) + `text-foreground` (vs muted next-due, AAA) + forme abrégée.

```tsx
<span data-testid="charges-row-frequency"
  className="text-foreground inline-flex w-fit shrink-0 items-center gap-1 text-xs font-medium md:order-3">
  <Repeat aria-hidden="true" className="text-muted-foreground size-3" />
  <abbr title={tFreq(...)} aria-hidden="true" className="no-underline">{tFreqAbbr(...)}</abbr>
  <span className="sr-only">{tFreq(...)}</span>
</span>
```

### Catch QA majeur
Le plan initial utilisait `border-border-strong`. `ui-auditor` + `mobile-ios-auditor` ont révélé que **`--color-border-strong` est un token fantôme** (référencé dans les docs, jamais défini dans `globals.css`) → bordure invisible = le bug même du ticket. Badge passé borderless ; token tracé en **THI-314** (la définition de sa valeur est un arbitrage design @thierry, hors session d'implémentation).

### i18n — nouveau namespace `common.frequencyAbbr` (5 locales)
`common.frequency` (mots complets) **inchangé** (4 consommateurs : selects + onboarding + simulator). de-DE quarterly = `Quartl.` (pas `Vj.`, collision _Vorjahr_, flag i18n-auditor). Glossaire bumpé **v1.2**.

| Enum | fr-BE | nl-BE | en | de-DE | es-ES |
|---|---|---|---|---|---|
| monthly | Mens. | Mnd. | Mo. | Mtl. | Mens. |
| quarterly | Trim. | Kwart. | Qtr. | Quartl. | Trim. |
| semiannual | Sem. | Halfj. | Semi. | Halbj. | Sem. |
| annual | Ann. | Jaarl. | Ann. | Jährl. | Anual |

### a11y
Icône `aria-hidden` ; abréviation `aria-hidden` + mot complet en `sr-only` (VoiceOver iOS n'annonce pas fiablement `<abbr title>`) ; `title` pour le survol voyant.

### QA (DoD)
- `plan-reviewer` 🟡 APPROVED WITH CHANGES (intégré : 4 consommateurs, matcher `title`, invariant géométrie e2e, DoD).
- `i18n-auditor` PASS_WITH_NOTES (`Vj.`→`Quartl.`, glossaire v1.2).
- `ui-auditor` BLOCK → **résolu** (token fantôme éliminé par borderless ; `sr-only` ; `aria-hidden="true"`).
- `mobile-ios-auditor` PASS_WITH_NOTES → résolu (pas d'overflow iPhone SE, `no-underline` OK WebKit).
- typecheck 0 · lint 0 · lint:use-server OK · vitest charges 18/18 · JSON ×5 valide.

### Hors scope (tracé)
Groupement/total = **THI-300** · token strong = **THI-314** · `common.frequency` intouché.

### ⚠️ Live-test @thierry requis avant merge (clair/sombre)
Visibilité + distinction du next-due + **densité de l'icône `Repeat` sur N lignes** (note ui-auditor, non bloquante mais à valider en live).

Rapport complet : `docs/prs/PR-UI-2-report.md`. Closes THI-299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
