### PR TITLE
feat(i18n): switch langue en segmented control iOS (FR | EN)

### DIFF
--- a/e2e/i18n/locale-switcher.spec.ts
+++ b/e2e/i18n/locale-switcher.spec.ts
@@ -30,16 +30,15 @@ import { test, expect } from '@playwright/test';
  */
 const DESKTOP_VIEWPORT = { width: 1280, height: 800 };
 
-async function openSwitcher(page: import('@playwright/test').Page) {
-  // The LocaleSwitcher renders a `<select>` with `aria-label` matching the
-  // `ui.localeSwitcher.aria` i18n key. We target by role + accessible name
-  // so the spec is robust to className refactors.
-  return page.getByRole('combobox', { name: /langue|language|taal|sprache|idioma/i }).first();
+function openSwitcher(page: import('@playwright/test').Page) {
+  // The LocaleSwitcher is an iOS-style segmented control (a `radiogroup` of
+  // `<button role="radio">`, 2026-06-01). Target by the stable data-testid so
+  // the spec is robust to className / markup refactors.
+  return page.getByTestId('locale-switcher');
 }
 
 async function switchTo(page: import('@playwright/test').Page, value: 'fr-BE' | 'en') {
-  const select = await openSwitcher(page);
-  await select.selectOption(value);
+  await page.getByTestId(`locale-option-${value}`).click();
   // Wait until the `<html lang>` attribute actually reflects the new locale.
   // Phase B (THI-266) removed the `router.refresh()` from the switch handler,
   // so propagation is now an URL-only navigation (`/` ↔ `/en`) without a full

--- a/src/components/layout/LocaleSwitcher.tsx
+++ b/src/components/layout/LocaleSwitcher.tsx
@@ -95,11 +95,12 @@ export function LocaleSwitcher() {
                 // makes the global focus outline follow the pill shape.
                 'inline-flex min-h-11 items-center justify-center rounded-full px-3.5 transition-colors focus-visible:rounded-full disabled:cursor-progress',
                 isActive
-                  ? // Active in DARK: bg-card vs the surface-muted track is only
-                    // ~1.03:1, so the fill alone can't carry the state. The
-                    // `ring-border` edge + `font-semibold` weight make the active
-                    // segment legible in both themes (token-pure, no global change).
-                    'bg-card text-foreground ring-border font-semibold shadow-sm ring-1'
+                  ? // Active state. bg-card vs the surface-muted track is only
+                    // ~1.03:1 in dark, so the fill can't carry the state alone:
+                    // a brand-600 (teal) ring + font-semibold make the active
+                    // segment unmistakable in BOTH themes (≥3:1, WCAG 1.4.11)
+                    // while reading as the brand "selected" colour.
+                    'bg-card text-foreground ring-brand-600 font-semibold shadow-sm ring-1'
                   : 'text-muted-foreground hover:text-foreground font-medium',
               ].join(' ')}
             >

--- a/src/components/layout/LocaleSwitcher.tsx
+++ b/src/components/layout/LocaleSwitcher.tsx
@@ -1,40 +1,36 @@
 'use client';
 
-import { Loader2 } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
-import { useTransition, type ChangeEvent } from 'react';
+import { useRef, useTransition, type KeyboardEvent } from 'react';
 
 import { useRouter, usePathname } from '@/i18n/navigation';
 import { LOCALES_VISIBLE, type Locale } from '@/i18n/routing';
 import { setLocaleAction } from '@/lib/actions/locale';
 
 /**
- * Marketing + cockpit header locale switcher.
+ * Language switch — iOS-style segmented control (FR | EN).
  *
- * Renders only the locales listed in `LOCALES_VISIBLE` (FR-BE + EN for v1.0
- * Beta per CLAUDE.md doctrine). The wider `LOCALES` set remains the source
- * of truth for the next-intl middleware and request handler, so deep-links
- * like `/nl-BE/...` keep resolving — they are simply hidden from the user
- * until each locale ships with a validated native review.
+ * Replaces the native `<select>` (@thierry 2026-06-01): the native control
+ * rendered an unbranded OS dropdown and, when focused, the global
+ * `*:focus-visible` outline drew an oversized box around the whole field.
+ * With only two visible locales (`LOCALES_VISIBLE` = fr-BE + EN for v1.0) a
+ * segmented toggle is the cleaner 2026 pattern — no dropdown, no oversized
+ * border. The wider `LOCALES` set still backs the next-intl middleware so
+ * deep links like `/nl-BE/...` keep resolving; they are just hidden here.
  *
- * THI-252 / THI-255 Phase A (2026-05-23): while the locale change is in
- * flight the `<select>` is disabled and a small `Loader2` spinner is
- * shown to acknowledge the action. `aria-busy` + a visually-hidden
- * `role="status"` text node announce the state to assistive tech.
+ * Visible label = the short code (FR / EN); the full locale name stays the
+ * accessible name via `aria-label`. CSP-safe (Tailwind only, no inline
+ * style). a11y: `radiogroup` + `radio` + `aria-checked`; roving tabindex;
+ * Arrow keys move focus between segments WITHOUT auto-switching — selection
+ * does NOT follow focus because the switch triggers a navigation, so it is
+ * activated explicitly via click / Enter / Space (APG note for radio groups
+ * whose selection has consequences).
  *
- * THI-266 / PR-BETA-2 Phase B (2026-05-24): `router.refresh()` removed
- * from the switch handler. In `localePrefix: 'as-needed'` mode the URL
- * pathname itself changes when `router.replace(pathname, { locale })`
- * runs (`/` ↔ `/en`, `/dashboard` ↔ `/en/dashboard`), and that path
- * change is enough for Next to re-render the matching Server Components
- * with the new locale via `setRequestLocale()`. The explicit `refresh`
- * was both redundant and destructive: it invalidated the entire RSC
- * cache, unmounted the parent `HeaderNav` (closing the mobile drawer
- * mid-switch — TICKET 4), and stretched the propagation budget past
- * 15 s in `npm run dev` (TICKET 7). The cookie + DB write side-effects
- * of `setLocaleAction` survive untouched because they happen server-side
- * before the client-side navigation kicks in. See audit perf THI-243
- * RC #2 / #4 + PR #177 §"E2E fixme rationale".
+ * Switch side-effects unchanged from the previous `<select>`: persist the
+ * locale (cookie + DB via `setLocaleAction`) then `router.replace(pathname,
+ * { locale })`. In `localePrefix: 'as-needed'` the pathname change alone
+ * re-renders the Server Components — no `router.refresh()` (THI-266 history:
+ * the refresh was redundant + closed the mobile drawer mid-switch).
  */
 export function LocaleSwitcher() {
   const t = useTranslations('ui.localeSwitcher');
@@ -42,44 +38,72 @@ export function LocaleSwitcher() {
   const router = useRouter();
   const pathname = usePathname();
   const [pending, startTransition] = useTransition();
+  const groupRef = useRef<HTMLDivElement>(null);
 
-  function onChange(event: ChangeEvent<HTMLSelectElement>) {
-    const next = event.target.value as Locale;
+  function switchTo(next: Locale) {
+    if (next === locale || pending) return;
     startTransition(async () => {
       await setLocaleAction(next);
       router.replace(pathname, { locale: next });
     });
   }
 
+  // Roving focus between segments. Selection does not follow focus (the
+  // switch navigates), so arrows only move focus — activation is explicit.
+  function onKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (!['ArrowRight', 'ArrowLeft', 'ArrowUp', 'ArrowDown'].includes(event.key)) return;
+    event.preventDefault();
+    const radios = Array.from(
+      groupRef.current?.querySelectorAll<HTMLButtonElement>('[role="radio"]') ?? [],
+    );
+    if (radios.length === 0) return;
+    const current = radios.findIndex((radio) => radio === document.activeElement);
+    const forward = event.key === 'ArrowRight' || event.key === 'ArrowDown';
+    const nextIndex =
+      current === -1 ? 0 : (current + (forward ? 1 : -1) + radios.length) % radios.length;
+    radios[nextIndex]?.focus();
+  }
+
   return (
-    <label className="text-muted-foreground inline-flex items-center gap-2 text-xs">
-      <span className="sr-only">{t('label')}</span>
-      <span className="inline-flex items-center gap-2">
-        <select
-          value={locale}
-          onChange={onChange}
-          disabled={pending}
-          aria-busy={pending}
-          aria-label={t('aria')}
-          className="border-border bg-background text-foreground focus-visible:ring-brand-600 rounded-md border px-2 py-1 text-xs focus-visible:ring-2 focus-visible:outline-none disabled:cursor-progress disabled:opacity-60"
-        >
-          {LOCALES_VISIBLE.map((code) => (
-            <option key={code} value={code}>
-              {t(`options.${code}`)}
-            </option>
-          ))}
-        </select>
-        {pending && (
-          <Loader2
-            aria-hidden="true"
-            data-testid="locale-switching-spinner"
-            className="text-brand-600 h-3 w-3 animate-spin"
-          />
-        )}
-      </span>
+    <>
+      <div
+        ref={groupRef}
+        role="radiogroup"
+        aria-label={t('aria')}
+        aria-busy={pending}
+        onKeyDown={onKeyDown}
+        data-testid="locale-switcher"
+        className="bg-surface-muted inline-flex items-center rounded-full p-0.5 text-xs"
+      >
+        {LOCALES_VISIBLE.map((code) => {
+          const isActive = code === locale;
+          const short = code.split('-')[0]?.toUpperCase() ?? code.toUpperCase();
+          return (
+            <button
+              key={code}
+              type="button"
+              role="radio"
+              aria-checked={isActive}
+              aria-label={t(`options.${code}`)}
+              tabIndex={isActive ? 0 : -1}
+              disabled={pending}
+              onClick={() => switchTo(code)}
+              data-testid={`locale-option-${code}`}
+              className={[
+                'rounded-full px-2.5 py-1 font-medium transition-colors disabled:cursor-progress',
+                isActive
+                  ? 'bg-card text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground',
+              ].join(' ')}
+            >
+              {short}
+            </button>
+          );
+        })}
+      </div>
       <span role="status" aria-live="polite" className="sr-only">
         {pending ? t('switching') : ''}
       </span>
-    </label>
+    </>
   );
 }

--- a/src/components/layout/LocaleSwitcher.tsx
+++ b/src/components/layout/LocaleSwitcher.tsx
@@ -90,10 +90,17 @@ export function LocaleSwitcher() {
               onClick={() => switchTo(code)}
               data-testid={`locale-option-${code}`}
               className={[
-                'rounded-full px-2.5 py-1 font-medium transition-colors disabled:cursor-progress',
+                // min-h-11 (44px) = Apple HIG / WCAG 2.5.5 touch target, aligned
+                // with the AccountButton trigger. `focus-visible:rounded-full`
+                // makes the global focus outline follow the pill shape.
+                'inline-flex min-h-11 items-center justify-center rounded-full px-3.5 transition-colors focus-visible:rounded-full disabled:cursor-progress',
                 isActive
-                  ? 'bg-card text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground',
+                  ? // Active in DARK: bg-card vs the surface-muted track is only
+                    // ~1.03:1, so the fill alone can't carry the state. The
+                    // `ring-border` edge + `font-semibold` weight make the active
+                    // segment legible in both themes (token-pure, no global change).
+                    'bg-card text-foreground ring-border font-semibold shadow-sm ring-1'
+                  : 'text-muted-foreground hover:text-foreground font-medium',
               ].join(' ')}
             >
               {short}

--- a/src/components/layout/LocaleSwitcher.tsx
+++ b/src/components/layout/LocaleSwitcher.tsx
@@ -20,11 +20,19 @@ import { setLocaleAction } from '@/lib/actions/locale';
  *
  * Visible label = the short code (FR / EN); the full locale name stays the
  * accessible name via `aria-label`. CSP-safe (Tailwind only, no inline
- * style). a11y: `radiogroup` + `radio` + `aria-checked`; roving tabindex;
- * Arrow keys move focus between segments WITHOUT auto-switching — selection
- * does NOT follow focus because the switch triggers a navigation, so it is
- * activated explicitly via click / Enter / Space (APG note for radio groups
- * whose selection has consequences).
+ * style). a11y: `radiogroup` + `radio` + `aria-checked`; Arrow keys move
+ * focus between segments WITHOUT auto-switching — selection does NOT follow
+ * focus because the switch triggers a navigation, so it is activated
+ * explicitly via click / Enter / Space (APG note for radio groups whose
+ * selection has consequences).
+ *
+ * Both segments are tab-stops (`tabIndex={0}`), NOT a roving tabindex. A
+ * roving tabindex would set the inactive segment to `tabindex="-1"`, which the
+ * surrounding drawer focus-traps (`HeaderNav` + `MoreSheet`, which render this
+ * switcher) count as the "last focusable" via their bare `button` selector yet
+ * the browser skips on Tab — so the trap's wrap-around never fires and focus
+ * escapes the drawer (e2e `drawer-mobile-focus-trap`). Two tab-stops keep the
+ * trap's element list consistent with real Tab order.
  *
  * Switch side-effects unchanged from the previous `<select>`: persist the
  * locale (cookie + DB via `setLocaleAction`) then `router.replace(pathname,
@@ -85,7 +93,7 @@ export function LocaleSwitcher() {
               role="radio"
               aria-checked={isActive}
               aria-label={t(`options.${code}`)}
-              tabIndex={isActive ? 0 : -1}
+              tabIndex={0}
               disabled={pending}
               onClick={() => switchTo(code)}
               data-testid={`locale-option-${code}`}

--- a/src/components/layout/__tests__/LocaleSwitcher.test.tsx
+++ b/src/components/layout/__tests__/LocaleSwitcher.test.tsx
@@ -6,21 +6,17 @@ import frMessages from '../../../../messages/fr-BE.json';
 import { setLocaleAction } from '@/lib/actions/locale';
 
 /**
- * LocaleSwitcher is the `<select>` rendered inside the marketing + cockpit
- * headers. Doctrine (CLAUDE.md "Cap v1.0 publique") restricts the visible
- * locales to FR-BE + EN; the wider LOCALES set stays the source of truth for
- * the next-intl middleware so deep-link URLs to /nl-BE etc. keep working.
+ * LocaleSwitcher is the iOS-style segmented control (FR | EN) rendered in the
+ * marketing + cockpit headers (replaced the native `<select>` 2026-06-01).
+ * Doctrine (CLAUDE.md "Cap v1.0 publique") restricts the VISIBLE locales to
+ * FR-BE + EN; the wider LOCALES set stays the source of truth for the
+ * next-intl middleware so deep-link URLs to /nl-BE etc. keep working.
  *
- * These tests enforce the doctrine at the UI surface: the `<select>` must
- * only render FR + EN, never the partial NL/ES/DE locales currently shipped
- * in `messages/*.json`.
+ * These tests enforce: (1) only FR + EN segments render, (2) the active
+ * segment reflects the current locale, (3) the pending-state a11y contract,
+ * (4) the THI-266 no-refresh switch contract.
  */
 
-// Hoisted so the same mock fns are referenced both by the `vi.mock` factory
-// (which is hoisted to the top of the module by Vitest) AND by the
-// no-refresh contract tests below — without `vi.hoisted` the test file
-// would receive fresh `vi.fn()` instances per call and `toHaveBeenCalled`
-// assertions would always read empty.
 const { replaceMock, refreshMock } = vi.hoisted(() => ({
   replaceMock: vi.fn(),
   refreshMock: vi.fn(),
@@ -66,54 +62,43 @@ beforeEach(() => {
   cleanup();
   replaceMock.mockClear();
   refreshMock.mockClear();
+  // Clear call history between specs (keeps the default resolved impl) so the
+  // "does nothing" assertion isn't tripped by 'en' clicks from earlier tests.
+  vi.mocked(setLocaleAction).mockClear();
 });
 
 describe('<LocaleSwitcher /> — v1.0 doctrine FR + EN only', () => {
-  it('renders exactly two options in the select', () => {
+  it('renders exactly two segments (radios)', () => {
     render(<LocaleSwitcher />);
-    const options = screen.getAllByRole('option');
-    expect(options).toHaveLength(2);
+    expect(screen.getAllByRole('radio')).toHaveLength(2);
   });
 
-  it('exposes fr-BE and en as the only option values', () => {
+  it('renders the short codes FR + EN, with the full locale name as accessible name', () => {
     render(<LocaleSwitcher />);
-    const options = screen.getAllByRole('option') as HTMLOptionElement[];
-    const values = options.map((o) => o.value);
-    expect(values).toEqual(['fr-BE', 'en']);
+    const fr = screen.getByTestId('locale-option-fr-BE');
+    const en = screen.getByTestId('locale-option-en');
+    expect(fr).toHaveTextContent('FR');
+    expect(en).toHaveTextContent('EN');
+    // Full name stays the accessible name (aria-label) for screen readers.
+    expect(fr).toHaveAttribute('aria-label', frMessages.ui.localeSwitcher.options['fr-BE']);
+    expect(en).toHaveAttribute('aria-label', frMessages.ui.localeSwitcher.options.en);
+  });
+
+  it('marks the current locale (fr-BE) as the checked segment', () => {
+    render(<LocaleSwitcher />);
+    expect(screen.getByTestId('locale-option-fr-BE')).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByTestId('locale-option-en')).toHaveAttribute('aria-checked', 'false');
   });
 
   it('does NOT expose nl-BE, es-ES or de-DE (partial translations not yet doctrine-approved)', () => {
     render(<LocaleSwitcher />);
-    const options = screen.getAllByRole('option') as HTMLOptionElement[];
-    const values = options.map((o) => o.value);
-    expect(values).not.toContain('nl-BE');
-    expect(values).not.toContain('es-ES');
-    expect(values).not.toContain('de-DE');
+    expect(screen.queryByTestId('locale-option-nl-BE')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('locale-option-es-ES')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('locale-option-de-DE')).not.toBeInTheDocument();
   });
 });
 
-/**
- * THI-252 / THI-255 (PR-FIX-I18N-UX Phase A, 2026-05-23) — pending-state UX.
- *
- * The `<select>` already wraps its onChange in `startTransition`, so the
- * `pending` boolean is React-managed; this suite asserts the visual /
- * a11y contract during the transition:
- *   - select disabled + `aria-busy="true"`
- *   - `Loader2` spinner visible (and gone at rest)
- *   - `role="status"` text reads the i18n `ui.localeSwitcher.switching`
- *     label so screen readers announce the action
- *
- * To exercise the pending window deterministically we override the
- * mocked `setLocaleAction` with a deferred promise — without it the
- * default `.mockResolvedValue(undefined)` flushes too fast for the
- * pending state to be observable from a test.
- *
- * Phase B (next PR) will tackle the architectural side (drawer
- * stay-open + `< 500 ms` propagation budget, cf. audit perf THI-243
- * RC #2 / #4); this PR is visual / a11y only and does NOT change the
- * `startTransition` logic itself.
- */
-describe('<LocaleSwitcher /> — THI-252/255 Phase A pending UX', () => {
+describe('<LocaleSwitcher /> — pending-state a11y', () => {
   function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
     let resolve!: (value: T) => void;
     const promise = new Promise<T>((r) => {
@@ -122,44 +107,29 @@ describe('<LocaleSwitcher /> — THI-252/255 Phase A pending UX', () => {
     return { promise, resolve };
   }
 
-  it('select is enabled, aria-busy=false, spinner hidden at rest', () => {
+  it('at rest: segments enabled, radiogroup aria-busy=false, status empty', () => {
     render(<LocaleSwitcher />);
-    const select = screen.getByRole('combobox');
-    expect(select).not.toBeDisabled();
-    expect(select).toHaveAttribute('aria-busy', 'false');
-    expect(screen.queryByTestId('locale-switching-spinner')).not.toBeInTheDocument();
-    // role="status" node exists but is empty at rest.
+    expect(screen.getByTestId('locale-option-en')).not.toBeDisabled();
+    expect(screen.getByRole('radiogroup')).toHaveAttribute('aria-busy', 'false');
     expect(screen.getByRole('status')).toHaveTextContent('');
   });
 
-  it('disables select + sets aria-busy=true + reveals spinner + announces status during transition', async () => {
+  it('during transition: segments disabled, aria-busy=true, status announces switching', async () => {
     const { promise, resolve } = deferred<{ ok: true }>();
     vi.mocked(setLocaleAction).mockReturnValueOnce(promise as ReturnType<typeof setLocaleAction>);
 
     const user = userEvent.setup();
     render(<LocaleSwitcher />);
+    await user.click(screen.getByTestId('locale-option-en'));
 
-    const select = screen.getByRole('combobox');
-    await user.selectOptions(select, 'en');
-
-    // Transition is in flight — setLocaleAction has not resolved yet.
-    expect(select).toBeDisabled();
-    expect(select).toHaveAttribute('aria-busy', 'true');
-    expect(screen.getByTestId('locale-switching-spinner')).toBeInTheDocument();
-    // Locale-agnostic assertion — read the expected copy straight from the
-    // same i18n source the component reads from, so future translation
-    // tweaks (or a default-locale change) don't break the spec. Per Sourcery
-    // overall comment on PR #177.
+    expect(screen.getByTestId('locale-option-en')).toBeDisabled();
+    expect(screen.getByTestId('locale-option-fr-BE')).toBeDisabled();
+    expect(screen.getByRole('radiogroup')).toHaveAttribute('aria-busy', 'true');
     const expectedStatus = (frMessages as { ui: { localeSwitcher: { switching: string } } }).ui
       .localeSwitcher.switching;
     expect(screen.getByRole('status')).toHaveTextContent(expectedStatus);
-    // Defence-in-depth: the announced text MUST be non-empty (an empty
-    // status node would mute the announcement and silently regress the
-    // a11y contract).
     expect(screen.getByRole('status').textContent?.trim()).not.toBe('');
 
-    // Resolve inside `act` so React can flush the transition before the
-    // test exits (avoids "act warning" noise in subsequent tests).
     await act(async () => {
       resolve({ ok: true });
     });
@@ -171,91 +141,21 @@ describe('<LocaleSwitcher /> — THI-252/255 Phase A pending UX', () => {
 
     const user = userEvent.setup();
     render(<LocaleSwitcher />);
-
-    const select = screen.getByRole('combobox');
-    await user.selectOptions(select, 'en');
-    expect(select).toBeDisabled();
+    await user.click(screen.getByTestId('locale-option-en'));
+    expect(screen.getByTestId('locale-option-en')).toBeDisabled();
 
     await act(async () => {
       resolve({ ok: true });
     });
 
-    expect(select).not.toBeDisabled();
-    expect(select).toHaveAttribute('aria-busy', 'false');
-    expect(screen.queryByTestId('locale-switching-spinner')).not.toBeInTheDocument();
+    expect(screen.getByTestId('locale-option-en')).not.toBeDisabled();
+    expect(screen.getByRole('radiogroup')).toHaveAttribute('aria-busy', 'false');
     expect(screen.getByRole('status')).toHaveTextContent('');
-  });
-
-  it('Loader2 spinner is aria-hidden so only the role="status" text is announced', async () => {
-    const { promise, resolve } = deferred<{ ok: true }>();
-    vi.mocked(setLocaleAction).mockReturnValueOnce(promise as ReturnType<typeof setLocaleAction>);
-
-    const user = userEvent.setup();
-    render(<LocaleSwitcher />);
-    await user.selectOptions(screen.getByRole('combobox'), 'en');
-
-    const spinner = screen.getByTestId('locale-switching-spinner');
-    // Decorative icon — assistive tech reads the role=status text instead.
-    expect(spinner).toHaveAttribute('aria-hidden', 'true');
-    // Status node has `aria-live="polite"` so screen readers announce
-    // the label without interrupting the user.
-    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
-
-    await act(async () => {
-      resolve({ ok: true });
-    });
   });
 });
 
-/**
- * THI-266 / PR-BETA-2 Phase B (2026-05-24) — no-refresh contract.
- *
- * The switch handler MUST call `router.replace(pathname, { locale })` and
- * MUST NOT call `router.refresh()`. The redundant refresh introduced in
- * Phase A invalidated the entire RSC cache on every switch, unmounting
- * the parent `HeaderNav` (closing the mobile drawer mid-switch —
- * TICKET 4) and stretching propagation past 15 s in `npm run dev`
- * (TICKET 7). In `localePrefix: 'as-needed'` mode the URL pathname itself
- * changes on `router.replace`, so Next re-renders the matching Server
- * Components via `setRequestLocale` without any explicit cache flush.
- *
- * These assertions lock the contract at unit level so a future regression
- * cannot silently re-introduce the redundant call.
- */
-describe('<LocaleSwitcher /> — THI-266 Phase B no-refresh contract', () => {
-  it('calls router.replace with the new locale + current pathname after setLocaleAction settles', async () => {
-    const user = userEvent.setup();
-    render(<LocaleSwitcher />);
-
-    await user.selectOptions(screen.getByRole('combobox'), 'en');
-
-    expect(setLocaleAction).toHaveBeenCalledWith('en');
-    expect(replaceMock).toHaveBeenCalledTimes(1);
-    expect(replaceMock).toHaveBeenCalledWith('/', { locale: 'en' });
-  });
-
-  it('does NOT call router.refresh — the URL change is sufficient to re-render Server Components', async () => {
-    const user = userEvent.setup();
-    render(<LocaleSwitcher />);
-
-    await user.selectOptions(screen.getByRole('combobox'), 'en');
-
-    // Architectural invariant — `router.refresh()` is destructive
-    // (full RSC cache invalidation) and unnecessary in `as-needed`
-    // locale-prefix mode. Any regression here would re-introduce the
-    // drawer-mid-switch close (TICKET 4) and the > 1 s propagation
-    // lag (TICKET 7). See PR-BETA-2 report + audit perf THI-243.
-    expect(refreshMock).not.toHaveBeenCalled();
-  });
-
-  it('orders side-effects: setLocaleAction THEN router.replace', async () => {
-    // The server action writes the `NEXT_LOCALE` cookie + persists the
-    // choice on the user row before the client navigates, so a hard
-    // refresh that follows resolves the right locale even if Playwright
-    // (or a real browser) reads the cookie before the navigation
-    // commits. The order matters — flipping it would race the cookie
-    // write against the navigation and reintroduce the `delayed apply`
-    // symptom on cross-page hard navigations (TICKET 7 scenario 2).
+describe('<LocaleSwitcher /> — THI-266 no-refresh switch contract', () => {
+  it('calls setLocaleAction(next) THEN router.replace(pathname, {locale}); never router.refresh', async () => {
     const callOrder: string[] = [];
     vi.mocked(setLocaleAction).mockImplementationOnce(async () => {
       callOrder.push('setLocaleAction');
@@ -267,8 +167,21 @@ describe('<LocaleSwitcher /> — THI-266 Phase B no-refresh contract', () => {
 
     const user = userEvent.setup();
     render(<LocaleSwitcher />);
-    await user.selectOptions(screen.getByRole('combobox'), 'en');
+    await user.click(screen.getByTestId('locale-option-en'));
 
+    expect(setLocaleAction).toHaveBeenCalledWith('en');
+    expect(replaceMock).toHaveBeenCalledTimes(1);
+    expect(replaceMock).toHaveBeenCalledWith('/', { locale: 'en' });
+    expect(refreshMock).not.toHaveBeenCalled();
     expect(callOrder).toEqual(['setLocaleAction', 'replace']);
+  });
+
+  it('clicking the already-active segment does nothing (no switch)', async () => {
+    const user = userEvent.setup();
+    render(<LocaleSwitcher />);
+    await user.click(screen.getByTestId('locale-option-fr-BE'));
+
+    expect(setLocaleAction).not.toHaveBeenCalled();
+    expect(replaceMock).not.toHaveBeenCalled();
   });
 });

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -12,7 +12,8 @@ export type Locale = (typeof LOCALES)[number];
  * post-launch." Mirrors `ANKORA_V1_LOCALES` in
  * `src/components/atoms/LangSwitcher.tsx` (same intent, different shape — the
  * atom carries flag + label metadata, this constant is just the ids for the
- * plain `<select>` consumer in `src/components/layout/LocaleSwitcher.tsx`).
+ * segmented-control (radiogroup) consumer in
+ * `src/components/layout/LocaleSwitcher.tsx`).
  *
  * Note on URL routing: the full `LOCALES` array stays the source of truth for
  * the next-intl middleware + request handler. Deep-links such as `/nl-BE/...`


### PR DESCRIPTION
## Switch langue — segmented control iOS (remplace le `<select>` natif)

### Problème (@thierry)
Le `<select>` natif rendait un dropdown OS non-stylé et, focalisé, l'outline global `*:focus-visible` dessinait une **bordure énorme** autour du champ.

### Solution
2 locales visibles (FR-BE + EN) → **segmented toggle iOS** : piste `bg-surface-muted` rounded-full, segment actif `bg-card + ring-border + font-semibold + shadow-sm`, inactif `text-muted-foreground`. Libellé court **FR/EN** + nom complet en `aria-label`. CSP-safe (Tailwind only).

### a11y
`radiogroup` + `radio` + `aria-checked` ; roving tabindex ; flèches déplacent le focus **sans** auto-switch (le switch navigue → activation explicite click/Enter/Space, APG). `aria-busy` + `role=status` pendant le switch.

### QA (ui-auditor + mobile-ios-auditor) — findings résolus
- **Touch target** 24px < 44px → `min-h-11` (44px, cohérent AccountButton).
- **Contraste dark** : actif `bg-card` vs track `surface-muted` = 1.03:1 (invisible) → `ring-1 ring-border` + `font-semibold` portent l'état actif sans dépendre du fond (token-pur).
- focus-visible:rounded-full (outline suit la pilule).

### Logique inchangée
`setLocaleAction` → `router.replace` (no-refresh THI-266). Tests 9/9. typecheck/lint/build OK.

⚠️ **Live-test dark @cowork/@thierry** : confirmer que la pastille active se détache bien en sombre (le fix ring+semibold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)