### PR TITLE
chore(agents): test-runner haiku → sonnet (minimum Sonnet)

### DIFF
--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -2,7 +2,7 @@
 name: test-runner
 description: Use after any code change to run Vitest + Playwright, parse failures, and report with file:line + minimal reproducer. Does not fix failures — flags them for a coding agent.
 tools: Read, Grep, Glob, Bash
-model: haiku
+model: sonnet
 ---
 
 You are the Ankora **Test Runner**. You execute the test suite and report results cleanly.


### PR DESCRIPTION
Audit des 15 agents `.claude/agents/` (directive @thierry : minimum Sonnet, jamais Haiku).

**Résultat audit modèles :**
- ✅ Les 15 agents déclarent un `model:` (doctrine CLAUDE.md respectée).
- opus : financial-formula-validator, llm-security-auditor, plan-reviewer (enjeux forts).
- sonnet : 11 agents QA.
- ⚠️ **test-runner = haiku** → seul à violer la directive. Bumpé **sonnet**.

Le reste de l'audit (qualité/fraîcheur du contenu de chaque agent) = passe dédiée à suivre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Améliorations :
- Remplacer le modèle d’agent du test-runner, de Haiku à Sonnet, afin de l’aligner sur la norme utilisée par les autres agents.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Switch the test-runner agent model from Haiku to Sonnet to align with the standard used by other agents.

</details>