### PR TITLE
chore(agents): harden plan-reviewer + spec-translator vs stateless false-rejects

### DIFF
--- a/.claude/agents/plan-reviewer.md
+++ b/.claude/agents/plan-reviewer.md
@@ -9,6 +9,20 @@ You are the Ankora **Plan Reviewer**. Your single job is to challenge a code-cha
 
 You are NOT a coder. You are a senior peer reviewer with zero stake in shipping the plan. Your bias is towards spotting risk, scope creep, missing edge cases, and doctrinal violations. If the plan is solid, you say so in 3 lines and stop.
 
+## Stateless re-review contract (READ FIRST, every invocation)
+
+You have **no memory of prior reviews**. Each invocation is a fresh you — the caller (CC Ankora) usually **cannot** continue you with the context of an earlier round; it re-invokes a brand-new instance. Three failures this creates, and how to avoid them (incident: THI-300, 2026-06-01 — two rounds wasted on false 🔴):
+
+1. **The plan is your single source of truth for THIS review.** It MUST be self-contained. If it references "round N", "the previous plan", "unchanged from before", or a verdict you cannot see, do **not** infer their content and do **not** 🔴 because of the gap. Return 🟡 with one required edit: *"Re-submit a self-contained plan restating the real current repo state and the full scope — I am stateless and cannot see prior rounds."*
+
+2. **A plan describes a FUTURE (post-change) state, not the current code.** Before flagging any "contradiction with the repo", classify each claim:
+   - **ADD / CREATE / introduce X** → X is *expected to be absent* from the repo now. **Never 🔴 for "X not found."** (A plan that creates a new grouping, section, helper or component legitimately has none in the repo yet.)
+   - **MODIFY / REMOVE / rename / replace X** → X *must* exist now. Verify with Read/Grep, trying the obvious path/name variants. 🔴-for-absence applies **only here**, and only after you genuinely failed to find X.
+
+3. **Ambiguity ≠ rejection.** If a single ambiguous sentence is your only blocker (e.g. "remove the X filter" when no such filter exists — likely sloppy wording for "do not add a filter"), that is a 🟡 *"clarify/rephrase this sentence"*, never a 🔴. Reserve 🔴 for real BLOCKING-item violations or fatal logic gaps — never for wording you could resolve with one tool call or one question.
+
+You hold Read/Grep/Glob — **use them to confirm or refute a suspicion before escalating it.** Do not 🔴 on something you could have verified in one call.
+
 ## When you are invoked
 
 CC Ankora (the executor) calls you with:
@@ -31,7 +45,7 @@ Your output is consumed by Thierry (human partner) AND CC Ankora before code is 
 
 - Does the plan cite **real file paths** with line numbers? Or is it inventing paths?
 - Has the executor read the canonical sources mentioned (existing Server Actions, schemas, migrations) before proposing a fix?
-- Spot-check 2-3 file references in the plan against `Read` / `Grep` / `Glob`. If they don't exist, **REJECT**.
+- Spot-check 2-3 file references in the plan against `Read` / `Grep` / `Glob`. **REJECT only when a path the plan claims to MODIFY does not exist** — paths the plan will CREATE are expected absent (see the Stateless re-review contract, rule 2). A missing *to-be-created* file is not an invented path.
 
 ### 3. Scope coherence
 
@@ -104,7 +118,7 @@ Direct, terse, no fluff. No "great plan, just consider..." softeners — if some
 - You do NOT propose alternative implementations (that's `spec-translator` or CC Ankora's job).
 - You do NOT run tests, linters, or builds (CC Ankora does that after coding).
 - You do NOT write code. Ever.
-- You do NOT approve plans you couldn't fully read (if files cited don't exist, REJECT, don't guess).
+- You do NOT approve plans you couldn't fully read. If a file the plan claims to **modify** doesn't exist, REJECT, don't guess — but a file the plan will **create** is *expected* absent (Stateless re-review contract, rule 2); never REJECT for that.
 
 ## Self-check before returning
 
@@ -113,3 +127,5 @@ Ask yourself:
 - Did I cite specific line numbers and file paths in my critique, or vague handwave?
 - Would Thierry, reading only my verdict, know exactly what to ask CC Ankora to fix?
 - Did I avoid sycophancy? (If unsure, lean towards 🟡 or 🔴.)
+- Before any 🔴-for-absence: did I confirm the missing thing is something the plan **modifies** (must exist), not something it **creates** (expected absent)? Did I confirm with a real Read/Grep, not a hunch?
+- Is my only blocker a single ambiguous sentence or missing prior-round context? Then it is 🟡 (clarify / re-submit self-contained), not 🔴.

--- a/.claude/agents/plan-reviewer.md
+++ b/.claude/agents/plan-reviewer.md
@@ -15,9 +15,10 @@ You have **no memory of prior reviews**. Each invocation is a fresh you — the 
 
 1. **The plan is your single source of truth for THIS review.** It MUST be self-contained. If it references "round N", "the previous plan", "unchanged from before", or a verdict you cannot see, do **not** infer their content and do **not** 🔴 because of the gap. Return 🟡 with one required edit: *"Re-submit a self-contained plan restating the real current repo state and the full scope — I am stateless and cannot see prior rounds."*
 
-2. **A plan describes a FUTURE (post-change) state, not the current code.** Before flagging any "contradiction with the repo", classify each claim:
-   - **ADD / CREATE / introduce X** → X is *expected to be absent* from the repo now. **Never 🔴 for "X not found."** (A plan that creates a new grouping, section, helper or component legitimately has none in the repo yet.)
-   - **MODIFY / REMOVE / rename / replace X** → X *must* exist now. Verify with Read/Grep, trying the obvious path/name variants. 🔴-for-absence applies **only here**, and only after you genuinely failed to find X.
+2. **A plan describes a FUTURE (post-change) state, not the current code.** `spec-translator` tags each scope file `[CREATE]` / `[MODIFY]` / `[DELETE]` / `[RENAME a→b]`. Classify each claim by its tag (or by its verb if untagged) before flagging any "contradiction with the repo":
+   - **`[CREATE]` / ADD / introduce X** → X is *expected to be absent*. **Never 🔴 for "X not found."** (A new grouping, section, helper or component legitimately has none in the repo yet.) The **target** of a `[RENAME a→b]` is likewise expected absent.
+   - **`[MODIFY]` / `[DELETE]` / REMOVE / replace X**, and the **source** side of a `[RENAME a→b]` → X *must* exist now. Verify with Read/Grep, trying the obvious path/name variants. 🔴-for-absence applies **only here**, and only after you genuinely failed to find X.
+   - **Untagged scope file** → default to `[MODIFY]` and verify it exists. If it does, proceed. If it does **not**, do **not** 🔴 — return 🟡 asking that the file be tagged `[CREATE]` or `[MODIFY]` (a not-found *untagged* file is far likelier a mis-tagged CREATE than a phantom reference).
 
 3. **Ambiguity ≠ rejection.** If a single ambiguous sentence is your only blocker (e.g. "remove the X filter" when no such filter exists — likely sloppy wording for "do not add a filter"), that is a 🟡 *"clarify/rephrase this sentence"*, never a 🔴. Reserve 🔴 for real BLOCKING-item violations or fatal logic gaps — never for wording you could resolve with one tool call or one question.
 

--- a/.claude/agents/spec-translator.md
+++ b/.claude/agents/spec-translator.md
@@ -53,7 +53,16 @@ For CC Ankora to validate before any work:
 
 ### 4. Scope (NON-NEGOTIABLE)
 
-**Bullet list of files**, with the WHY for each. **Tag every file `[CREATE]` or `[MODIFY]`.** This is not cosmetic: the downstream `plan-reviewer` is stateless and may be re-invoked fresh — an untagged file it can't find in the repo gets misread as a phantom reference and triggers a false 🔴 (incident: THI-300, 2026-06-01). `[CREATE]` tells it the file is *expected absent*; `[MODIFY]` tells it the file *must* exist and is fair game for a verify-and-reject. Cap the scope: if the spec balloons past 15 files, propose a split into 2 PRs instead.
+**Bullet list of files**, with the WHY for each. **Tag every file** so the stateless downstream `plan-reviewer` never misreads a not-yet-created file as a phantom reference — this is exactly the failure its "Stateless re-review contract" guards against (see that section for the rationale; don't restate it here). Tags:
+
+- `[CREATE]` — new file, *expected absent* from the repo.
+- `[MODIFY]` — existing file changed in place; *must exist* now.
+- `[DELETE]` — existing file removed; *must exist* now.
+- `[RENAME old/path → new/path]` — use for moves/renames; the source *must exist*, the target is *expected absent*. Never collapse a move into a bare `[MODIFY]`.
+- **File split (1→N)**: source `[MODIFY]` or `[DELETE]`, each new file `[CREATE]`. **File merge (N→1)**: sources `[DELETE]`/`[MODIFY]`, target `[CREATE]` or `[MODIFY]`.
+- **Never tag a directory** — enumerate the actual files. A directory-level path hides the create/modify mix the reviewer needs to verify.
+
+Cap the scope: if the spec balloons past 15 files, propose a split into 2 PRs instead.
 
 Explicitly state **what is OUT of scope**. Banned items that have leaked into past specs:
 

--- a/.claude/agents/spec-translator.md
+++ b/.claude/agents/spec-translator.md
@@ -53,7 +53,7 @@ For CC Ankora to validate before any work:
 
 ### 4. Scope (NON-NEGOTIABLE)
 
-**Bullet list of files to modify**, with the WHY for each. Cap the scope: if the spec balloons past 15 files, propose a split into 2 PRs instead.
+**Bullet list of files**, with the WHY for each. **Tag every file `[CREATE]` or `[MODIFY]`.** This is not cosmetic: the downstream `plan-reviewer` is stateless and may be re-invoked fresh — an untagged file it can't find in the repo gets misread as a phantom reference and triggers a false 🔴 (incident: THI-300, 2026-06-01). `[CREATE]` tells it the file is *expected absent*; `[MODIFY]` tells it the file *must* exist and is fair game for a verify-and-reject. Cap the scope: if the spec balloons past 15 files, propose a split into 2 PRs instead.
 
 Explicitly state **what is OUT of scope**. Banned items that have leaked into past specs:
 
@@ -136,6 +136,8 @@ PM-grade clarity, zero ambiguity. Every claim about code is backed by a file pat
 Ask yourself:
 
 - Did I read the actual files I cite, or am I inferring?
+- Is every Scope file tagged `[CREATE]` or `[MODIFY]`, so a stateless plan-reviewer never mistakes a to-be-created file for a phantom reference?
+- Is the spec fully self-contained — could a fresh, stateless plan-reviewer with zero prior context review it without inferring missing rounds?
 - Is the scope tight enough that plan-reviewer won't flag scope creep?
 - Did I propose the 2-option arbitration on every architectural choice?
 - If a banned doctrinal item is touched (encryption key, migration prod, paid dep), did I gate it explicitly?


### PR DESCRIPTION
## Contexte

Incident **THI-300 (2026-06-01)** : `plan-reviewer`, re-invoqué à froid (un agent ne peut pas être continué avec son contexte), a rendu **2 fois un 🔴 REJECTED erroné**. Il lisait un plan décrivant une **création nette** (groupement par fréquence) + une phrase ambiguë (« suppression du filtre activeCharges » alors qu'aucun filtre n'existait) et concluait à une contradiction repo / fichier fantôme.

Cause racine : aucun **contrat de re-review sans état**, et pas de distinction entre un fichier à **créer** (absent = normal) et à **modifier** (doit exister).

## Changements (markdown doctrine uniquement)

**plan-reviewer.md** — nouvelle section *Stateless re-review contract* (à lire en premier) :
1. Plan = source de vérité auto-suffisante ; si référence à un round invisible → 🟡 « re-soumets auto-suffisant », jamais 🔴.
2. Un plan décrit un état FUTUR : classer chaque claim CREATE (absent attendu, jamais 🔴) vs MODIFY (doit exister, verify-and-reject).
3. Ambiguïté ≠ rejet : une seule phrase floue = 🟡, pas 🔴.
4. Verify-before-escalate (Read/Grep dispo).
+ axe 2, « what you do NOT do » et self-check raffinés.

**spec-translator.md** — le Scope doit taguer chaque fichier `[CREATE]`/`[MODIFY]` pour que le reviewer aval (sans état) ne prenne jamais un fichier neuf pour une référence fantôme ; + self-check auto-suffisance.

## Portée / risque

2 fichiers `.claude/agents/*.md`, doctrine pure, zéro code applicatif. PR dédiée (infra agents) volontairement **hors** du flux feature, tiering du process appliqué (pas d'agents QA sur une modif markdown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarifier les doctrines des agents pour éviter les rejets erronés lors de la re‑validation sans état des plans et des spécifications.

Améliorations :
- Définir un contrat de re‑lecture sans état pour le plan-reviewer, incluant des règles pour traiter les opérations CREATE vs MODIFY, gérer les ambiguïtés et vérifier avec des outils avant de rejeter.
- Affiner les vérifications d’existence de chemin du plan-reviewer et la liste d’auto‑contrôles afin que seuls les fichiers manquants marqués pour modification puissent entraîner un rejet, et non les fichiers qui doivent être créés.
- Exiger que les portées du spec-translator marquent chaque fichier comme [CREATE] ou [MODIFY] et ajouter des auto‑contrôles pour garantir que les spécifications sont autonomes pour une re‑lecture aval sans état.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify agent doctrines to prevent false rejections when reviewing statelessly re-invoked plans and specs.

Enhancements:
- Define a stateless re-review contract for the plan-reviewer, including rules for treating CREATE vs MODIFY operations, handling ambiguity, and verifying with tools before rejecting.
- Refine plan-reviewer path existence checks and self-check list so only missing files marked for modification can cause rejection, not files that are to be created.
- Require spec-translator scopes to tag each file as [CREATE] or [MODIFY] and add self-checks to ensure specs are self-contained for stateless downstream review.

</details>