### PR TITLE
fix(ui): tidy charges row alignment + cap simulator sparkline width

### DIFF
--- a/src/app/[locale]/app/charges/ChargesClient.tsx
+++ b/src/app/[locale]/app/charges/ChargesClient.tsx
@@ -209,7 +209,7 @@ export function ChargesClient({
         // absolute edit/delete buttons (top-2 + size-11 = 52px) now that the
         // card padding (`p-4`) is gone — prevents the tap targets overflowing
         // onto the next row on very short content (mobile-ios-auditor F3).
-        className="md:hover:bg-surface-muted relative min-h-13 py-3 pr-24 transition-colors md:grid md:min-h-0 md:grid-cols-[minmax(8rem,10rem)_minmax(0,1fr)_auto_auto_auto_auto] md:items-baseline md:gap-4 md:px-2 md:py-3 md:pr-2"
+        className="md:hover:bg-surface-muted relative min-h-13 py-3 pr-24 transition-colors md:grid md:min-h-0 md:grid-cols-[minmax(8rem,10rem)_minmax(0,1fr)_4.5rem_7rem_auto_auto] md:items-baseline md:gap-4 md:px-2 md:py-3 md:pr-2"
       >
         {/* Mobile: header row (next-due + amount on a single line).
             Desktop: contents — projects next-due + amount as grid cells 1 / 4. */}

--- a/src/app/[locale]/app/simulator/SimulatorProjection.tsx
+++ b/src/app/[locale]/app/simulator/SimulatorProjection.tsx
@@ -148,7 +148,10 @@ export function SimulatorProjection({
         viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
         role="img"
         aria-label={ariaLabel}
-        className="block h-auto w-full"
+        // Compact sparkline: full width on mobile, capped on desktop so the
+        // 240×64 viewBox is not stretched into a giant triangle on a wide card
+        // (@thierry PROD review 2026-06-02 — "barre énorme, pas pro").
+        className="block h-auto w-full max-w-md"
       >
         {/* Flat 0 baseline — "Sans changement". */}
         <line


### PR DESCRIPTION
## Contexte
Retour empirique @thierry sur PROD (2026-06-02), 2 polish UI ciblés (voie légère, className-only).

## A — Alignement liste charges
La grille desktop mettait la puce fréquence ET le montant en colonnes `auto` (largeur variable) → bord droit en dents de scie (« brouillon »). Colonnes passées en largeur fixe (`4.5rem` / `7rem`) → montants alignés à droite proprement.

## D — Chart simulateur
La sparkline `viewBox 240×64` était en `w-full` → étirée en triangle géant (~290px) sur un card desktop large (« barre énorme, pas pro »). Bornée à `max-w-md` → reste compacte sur desktop, pleine largeur sur mobile.

## Hors scope (tracés séparément)
- Statut « payé » des charges → **THI-329**
- Switch FR→EN navigation → **THI-324** (à traiter ensuite)

## Vérif
- typecheck ✅ · lint ✅ (0 err) · tests charges (24) + simulateur/projection (13) ✅
- className-only, zéro logique touchée
- ⚠️ **Rendu à valider par @thierry sur le preview Vercel** (pages `/app/*` auth-gated, non visibles en Chrome frais) : alignement charges desktop + taille chart simulateur, clair + sombre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Peaufiner l’interface utilisateur pour la liste des frais et la courbe de projection du simulateur en fonction des retours de production.

Améliorations :
- Aligner les colonnes de la liste des frais sur desktop avec des largeurs fixes afin que les montants monétaires soient systématiquement alignés.
- Limiter la courbe de projection du simulateur à une largeur maximale afin qu’elle reste visuellement compacte sur les cartes desktop larges.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Polish the UI for the charges list and simulator projection sparkline based on production feedback.

Enhancements:
- Align charges list desktop columns with fixed widths so monetary amounts line up consistently.
- Constrain the simulator sparkline to a maximum width so it remains visually compact on wide desktop cards.

</details>