### PR TITLE
fix(sw): locale-aware bypass — stop caching /en/app + close /admin & /login leak (THI-324)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -5,12 +5,14 @@
  * RLS and session freshness.
  */
 
-// Bumped 2026-05-19 (PR P0-V2) to purge caches poisoned with the HTML 404 that
-// /fonts/*.ttf used to return before PR #169 fixed the middleware matcher. The
-// `activate` handler below deletes any cache whose key doesn't start with the
-// current `CACHE_VERSION`, so bumping this constant is the canonical way to
-// force a clean slate across all returning visitors on first SW activation.
-const CACHE_VERSION = 'ankora-v2-20260519';
+// Bumped 2026-06-02 (THI-324) to purge caches poisoned with authenticated,
+// locale-prefixed pages (`/en/app/*`, `/admin`, `/login`, …) that the old
+// locale-blind `isBypass` let through — see the `isBypass` note below. The
+// `activate` handler deletes any cache whose key doesn't start with the current
+// `CACHE_VERSION`, so bumping this constant is the canonical way to force a
+// clean slate across all returning visitors on first SW activation.
+// (Previous bump 2026-05-19 / PR P0-V2 purged the /fonts/*.ttf HTML-404 poison.)
+const CACHE_VERSION = 'ankora-v3-20260602';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 
 const PRECACHE_URLS = [
@@ -42,13 +44,33 @@ self.addEventListener('activate', (event) => {
   );
 });
 
+// Authenticated / credential-bearing page surfaces, matched WITH OR WITHOUT a
+// leading next-intl locale segment (`en`, `fr-BE`, `nl-BE`, `de-DE`, `es-ES`).
+//
+// THI-324: the previous `startsWith('/app')` was locale-BLIND. The default
+// locale (`fr-BE`) is unprefixed, so `/app` matched — but `/en/app`, `/nl-BE/app`
+// etc. did NOT, slipped past the bypass, and got network-first-CACHED, poisoning
+// authenticated non-default-locale pages (the FR→EN revert on navigation). The
+// same blind spot left `/admin` (requireAdmin) and the `(auth)` group pages
+// (`/login`, `/signup`, `/forgot-password`, `/reset-password`) cacheable too —
+// a pre-existing leak this regex also closes.
+//
+// Slugs are the REAL resolved paths: the `(auth)` route group adds no URL
+// segment, so the auth pages are `/login` … not `/auth/*`. The only `/auth/*`
+// path is the non-localized OAuth callback (`src/app/auth/callback`), kept via a
+// plain `startsWith('/auth')` below. Over-bypassing (network-first) is the SAFE
+// direction; under-bypassing (caching auth) is the dangerous one.
+const PROTECTED_LOCALED =
+  /^\/(?:[a-z]{2}(?:-[A-Z]{2})?\/)?(?:app|admin|onboarding|login|signup|forgot-password|reset-password)(?:\/|$)/;
+
 function isBypass(url) {
   return (
-    url.pathname.startsWith('/app') ||
-    url.pathname.startsWith('/auth') ||
+    // Locale-prefixable authenticated page surfaces (with or without locale).
+    PROTECTED_LOCALED.test(url.pathname) ||
+    // Non-localized surfaces — never carry a locale prefix.
+    url.pathname.startsWith('/auth') || // OAuth callback (route handler)
     url.pathname.startsWith('/api') ||
     url.pathname.startsWith('/_next/data') ||
-    url.pathname.startsWith('/onboarding') ||
     // Self-hosted variable fonts. The browser HTTP cache + Vercel
     // Cache-Control already handle them efficiently; routing them through the
     // SW cache risked serving a stale HTML 404 from before PR #169 (when the

--- a/src/lib/sw/__tests__/is-bypass.test.ts
+++ b/src/lib/sw/__tests__/is-bypass.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * THI-324 — `public/sw.js` is a CLASSIC service worker (uses `self`,
+ * `addEventListener`), so it cannot be imported as an ESM module.
+ *
+ * To keep ONE source of truth and zero drift, we read the shipped file and
+ * extract the `PROTECTED_LOCALED` regex literal verbatim, rebuilding it with
+ * `new RegExp` (a regex — NOT `eval`/`new Function`, so no code-execution
+ * surface; a malformed pattern would simply throw here). The locale-aware regex
+ * is the THI-324 fix and the security-critical part, so it is tested exhaustively
+ * against the bypass truth-table.
+ *
+ * The non-localized prefixes (`/auth`, `/api`, `/_next/data`, `/fonts/`) are
+ * plain `startsWith` checks in `isBypass`; we guard them against silent removal
+ * by asserting their presence in the shipped source (anti-drift), which avoids
+ * having to eval the whole function.
+ */
+const swSource = readFileSync(path.join(process.cwd(), 'public', 'sw.js'), 'utf8');
+
+function extractProtectedLocaled(): RegExp {
+  const match = swSource.match(/const PROTECTED_LOCALED\s*=\s*\/([\s\S]*?)\/;/);
+  if (!match) {
+    throw new Error('sw.js: PROTECTED_LOCALED literal not found — update the extractor');
+  }
+  return new RegExp(match[1]!);
+}
+
+const PROTECTED_LOCALED = extractProtectedLocaled();
+const matches = (pathname: string) => PROTECTED_LOCALED.test(pathname);
+
+describe('sw.js PROTECTED_LOCALED — authenticated page surfaces, locale-aware (THI-324)', () => {
+  it.each([
+    // Default locale (unprefixed) — already matched before THI-324.
+    '/app',
+    '/app/charges',
+    '/admin',
+    '/login',
+    '/signup',
+    '/signup/check-email',
+    '/forgot-password',
+    '/reset-password',
+    '/onboarding',
+    // Locale-prefixed — the THI-324 regression (were CACHED before the fix).
+    '/en/app',
+    '/fr-BE/app/charges',
+    '/nl-BE/app',
+    '/en/admin',
+    '/es-ES/login',
+    '/de-DE/onboarding',
+    '/de-DE/reset-password',
+  ])('matches (→ bypassed, never cached): %s', (pathname) => {
+    expect(matches(pathname)).toBe(true);
+  });
+
+  it.each([
+    // Public marketing / shell — SAFE to cache, must NOT be matched.
+    '/',
+    '/en',
+    '/pricing',
+    '/en/faq',
+    '/offline',
+    '/manifest.webmanifest',
+    // Boundary checks vs the old loose `startsWith('/app')`.
+    '/applications',
+    '/app-store',
+    '/en/applications',
+  ])('does NOT match (cacheable public surface): %s', (pathname) => {
+    expect(matches(pathname)).toBe(false);
+  });
+});
+
+describe('sw.js — non-localized bypass prefixes stay present (anti-drift guard)', () => {
+  // These are plain `startsWith` in `isBypass`; a silent removal would re-open a
+  // cache path for an infra/auth surface.
+  it.each([
+    "startsWith('/auth')",
+    "startsWith('/api')",
+    "startsWith('/_next/data')",
+    "startsWith('/fonts/')",
+  ])('isBypass still contains %s', (snippet) => {
+    expect(swSource).toContain(snippet);
+  });
+});
+
+describe('sw.js — security-critical slugs stay covered (anti-drift guard)', () => {
+  it.each(['app', 'admin', 'login', 'signup', 'forgot-password', 'reset-password', 'onboarding'])(
+    'PROTECTED_LOCALED still covers the auth-sensitive slug: %s',
+    (slug) => {
+      // A silent removal of any of these would re-open a cache leak for that
+      // surface (unprefixed AND locale-prefixed) — fail loudly.
+      expect(matches(`/${slug}`)).toBe(true);
+      expect(matches(`/en/${slug}`)).toBe(true);
+    },
+  );
+});


### PR DESCRIPTION
## Bug (THI-324)
`public/sw.js` `isBypass()` était **locale-aveugle** : `startsWith('/app')` matchait la locale par défaut (non préfixée) mais **pas** `/en/app`, `/nl-BE/app`… → ces pages authentifiées tombaient dans la branche network-first-AVEC-CACHE → pages non-default-locale empoisonnées → **revert FR→EN** à la navigation (nav `<Link>` locale-aware figée par un render EN caché).

**Fuite pré-existante fermée au passage** : le même angle mort laissait `/admin` (`requireAdmin`) et le groupe `(auth)` (`/login`, `/signup`, `/forgot-password`, `/reset-password`) **cachables**.

## Fix (public/sw.js uniquement)
- `PROTECTED_LOCALED` : segment locale next-intl optionnel + slugs réels résolus (`app|admin|onboarding|login|signup|forgot-password|reset-password`). Plus strict que l'ancien `startsWith` (`/applications` ne matche plus).
- `/auth` (callback OAuth non-localisé), `/api`, `/_next/data`, `/fonts/` restent en `startsWith`.
- Bump `CACHE_VERSION` v2→v3 → le handler `activate` purge les entrées déjà empoisonnées chez les visiteurs de retour.

## Tests
- Vitest lit `sw.js`, extrait la regex (`new RegExp`, **pas d'eval**) et asserte la matrice complète + garde-fous anti-drift : **36 cas** verts (`/en/app` bypassé, `/admin`/`/login`/`/reset-password` bypassés avec & sans locale, `/applications`/`/pricing` cachables).

## Gouvernance
- `plan-reviewer` (Opus) : APPROVE conditionnel — il a détecté la fuite `/admin` + `(auth)` que ma 1re regex ratait ; conditions appliquées verbatim (admin + 4 slugs auth + matrice).
- typecheck ✅ · lint ✅ · 36 tests ✅.

## Vérif finale @thierry
Sur le preview : passe en EN, navigue entre pages `/en/app/*` → la locale ne doit plus reverter vers FR au clic. (Le SW se met à jour à la prochaine visite ; une page déjà affichée depuis l'ancien cache se rafraîchit à la navigation suivante.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Faire en sorte que le service worker contourne le cache pour toutes les pages authentifiées de manière sensible à la locale et purger les caches précédemment corrompus.

Corrections de bugs :
- S’assurer que les routes authentifiées préfixées par une locale (par ex. `/en/app`, `/nl-BE/app`) sont contournées par le service worker et ne sont jamais mises en cache.
- Empêcher les pages d’administration et liées à l’authentification (par ex. `/admin`, `/login`, `/signup`, les flux de réinitialisation de mot de passe) d’être mises en cache par le service worker.

Améliorations :
- Introduire une regex centralisée pour les routes protégées, avec locale optionnelle, dans le service worker afin de renforcer la logique de contournement et d’éviter des vérifications `startsWith` trop larges.

Tests :
- Ajouter une couverture Vitest qui lit le `sw.js` construit, valide la regex des routes protégées contre une matrice de chemins, et protège contre les dérives dans les préfixes et slugs critiques de contournement.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the service worker bypass cache for all authenticated pages in a locale-aware way and purge previously poisoned caches.

Bug Fixes:
- Ensure locale-prefixed authenticated routes (e.g. /en/app, /nl-BE/app) are bypassed by the service worker and never cached.
- Prevent admin and auth-related pages (e.g. /admin, /login, /signup, password reset flows) from being cached by the service worker.

Enhancements:
- Introduce a centralized regex for protected, locale-optional routes in the service worker to tighten bypass matching and avoid overbroad startsWith checks.

Tests:
- Add Vitest coverage that reads the built sw.js, validates the protected-routes regex against a matrix of paths, and guards against drift in critical bypass prefixes and slugs.

</details>