### PR TITLE
feat(simulator): comparative projection chart (SVG-maison) + adaptive icon + pedago

### DIFF
--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -926,7 +926,13 @@
         "cumul6mLoss": "In 6 Monaten, −{amount} verfügbar",
         "cumul6mNeutral": "Keine Auswirkung über 6 Monate",
         "incomeHint": "Füge dein Einkommen hinzu, um die Auswirkung auf dein verfügbares Budget zu sehen.",
-        "incomeHintCta": "Einkommen einrichten"
+        "incomeHintCta": "Einkommen einrichten",
+        "pedago": {
+          "gainTitle": "Gute Wahl.",
+          "gainBody": "Dieses Szenario verbessert deinen verfügbaren Betrag, ohne deine Rücklagen anzutasten.",
+          "lossTitle": "Abzuwägen.",
+          "lossBody": "Dieses Szenario senkt deinen verfügbaren Betrag. Du entscheidest, ob es sich lohnt."
+        }
       }
     },
     "deletionStatus": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -926,7 +926,13 @@
         "cumul6mLoss": "Over 6 months, −{amount} of available leftover",
         "cumul6mNeutral": "No impact over 6 months",
         "incomeHint": "Add your income to see the impact on your available leftover.",
-        "incomeHintCta": "Set up my income"
+        "incomeHintCta": "Set up my income",
+        "pedago": {
+          "gainTitle": "Good move.",
+          "gainBody": "This scenario improves your available leftover without touching your provisions.",
+          "lossTitle": "Worth weighing.",
+          "lossBody": "This scenario lowers your available leftover. It's up to you whether it's worth it."
+        }
       }
     },
     "deletionStatus": {

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -926,7 +926,13 @@
         "cumul6mLoss": "En 6 meses, −{amount} de disponible",
         "cumul6mNeutral": "Sin impacto a 6 meses",
         "incomeHint": "Añade tus ingresos para ver el impacto en tu disponible.",
-        "incomeHintCta": "Configurar mis ingresos"
+        "incomeHintCta": "Configurar mis ingresos",
+        "pedago": {
+          "gainTitle": "Buena decisión.",
+          "gainBody": "Este escenario mejora tu disponible sin tocar tus reservas.",
+          "lossTitle": "A considerar.",
+          "lossBody": "Este escenario reduce tu disponible. Tú decides si vale la pena."
+        }
       }
     },
     "deletionStatus": {

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -926,7 +926,13 @@
         "cumul6mLoss": "En 6 mois, −{amount} de réserve libre",
         "cumul6mNeutral": "Aucun impact sur 6 mois",
         "incomeHint": "Ajoute tes revenus pour voir l'impact sur ton reste disponible.",
-        "incomeHintCta": "Configurer mes revenus"
+        "incomeHintCta": "Configurer mes revenus",
+        "pedago": {
+          "gainTitle": "Bon choix.",
+          "gainBody": "Ce scénario améliore ta réserve libre sans toucher à tes provisions.",
+          "lossTitle": "Impact à considérer.",
+          "lossBody": "Ce scénario réduit ta réserve libre. À toi de voir si ça en vaut la peine."
+        }
       }
     },
     "deletionStatus": {

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -926,7 +926,13 @@
         "cumul6mLoss": "Over 6 maanden, −{amount} beschikbaar saldo",
         "cumul6mNeutral": "Geen impact over 6 maanden",
         "incomeHint": "Voeg je inkomen toe om de impact op je beschikbaar saldo te zien.",
-        "incomeHintCta": "Mijn inkomen instellen"
+        "incomeHintCta": "Mijn inkomen instellen",
+        "pedago": {
+          "gainTitle": "Goede keuze.",
+          "gainBody": "Dit scenario verbetert je beschikbaar saldo zonder je voorzieningen aan te raken.",
+          "lossTitle": "Om te overwegen.",
+          "lossBody": "Dit scenario verlaagt je beschikbaar saldo. Aan jou om te bepalen of het de moeite waard is."
+        }
       }
     },
     "deletionStatus": {

--- a/src/app/[locale]/app/simulator/SimulatorClient.tsx
+++ b/src/app/[locale]/app/simulator/SimulatorClient.tsx
@@ -199,6 +199,7 @@ export function SimulatorClient({
                 type="button"
                 variant={mode === key ? 'default' : 'outline'}
                 size="sm"
+                className="min-h-11"
                 onClick={() => setMode(key)}
                 // PR-D5 a11y: announce active state to AT (visual cue is
                 // variant-only otherwise — silent for VoiceOver/NVDA).
@@ -234,6 +235,7 @@ export function SimulatorClient({
               <Input
                 id="newAmount"
                 type="number"
+                autoComplete="off"
                 inputMode="decimal"
                 min={0}
                 step="0.01"
@@ -249,6 +251,7 @@ export function SimulatorClient({
                 <Label htmlFor="newLabel">{tFields('label')}</Label>
                 <Input
                   id="newLabel"
+                  autoComplete="off"
                   value={newLabel}
                   onChange={(e) => setNewLabel(e.target.value)}
                 />
@@ -258,6 +261,7 @@ export function SimulatorClient({
                 <Input
                   id="newAmountAdd"
                   type="number"
+                  autoComplete="off"
                   inputMode="decimal"
                   min={0}
                   step="0.01"
@@ -265,7 +269,7 @@ export function SimulatorClient({
                   onChange={(e) => setNewAmount(e.target.value)}
                 />
               </div>
-              <div className="grid grid-cols-2 gap-3">
+              <div className="grid min-w-0 grid-cols-2 gap-3">
                 <div className="flex flex-col gap-2">
                   <Label htmlFor="newFrequency">{tFields('frequency')}</Label>
                   <Select

--- a/src/app/[locale]/app/simulator/SimulatorClient.tsx
+++ b/src/app/[locale]/app/simulator/SimulatorClient.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
+import { AlertCircle, CheckCircle2, Minus, TrendingDown, TrendingUp } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -152,6 +153,30 @@ export function SimulatorClient({
   // misleading, so we surface a setup hint instead.
   const incomeMissing = revenusMoney.lte(0);
 
+  // Adaptive impact tone (gain / loss / neutral) driving the header icon +
+  // pedagogical takeaway. `result` is null until a scenario is picked.
+  const impactTone: 'gain' | 'loss' | 'neutral' = !result
+    ? 'neutral'
+    : result.monthlyDelta.gt(0)
+      ? 'gain'
+      : result.monthlyDelta.lt(0)
+        ? 'loss'
+        : 'neutral';
+  const ImpactIcon =
+    impactTone === 'gain' ? TrendingUp : impactTone === 'loss' ? TrendingDown : Minus;
+  const impactIconClass =
+    impactTone === 'gain'
+      ? 'text-success'
+      : impactTone === 'loss'
+        ? 'text-danger'
+        : 'text-muted-foreground';
+  const impactIconBg =
+    impactTone === 'gain'
+      ? 'bg-success/10'
+      : impactTone === 'loss'
+        ? 'bg-danger/10'
+        : 'bg-surface-muted';
+
   return (
     <div className="flex flex-col gap-6">
       {!hideHeader && (
@@ -282,7 +307,14 @@ export function SimulatorClient({
 
       <Card>
         <CardHeader>
-          <CardTitle>{tImpact('title')}</CardTitle>
+          <div className="flex items-center gap-2.5">
+            <span
+              className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${impactIconBg}`}
+            >
+              <ImpactIcon aria-hidden strokeWidth={1.75} className={`h-4 w-4 ${impactIconClass}`} />
+            </span>
+            <CardTitle>{tImpact('title')}</CardTitle>
+          </div>
         </CardHeader>
         <CardContent>
           {/* `!reserveView` also narrows the type for the else branch; it is
@@ -356,9 +388,45 @@ export function SimulatorClient({
                 </p>
               </div>
 
-              {/* S3 + S4 — 6-month réserve-libre projection (cumul marginal) +
-                  human cumul sentence. Self-suppresses when monthlyDelta == 0. */}
-              <SimulatorProjection monthlyDelta={result.monthlyDelta} fmtMoney={fmtMoney} />
+              {/* 6-month comparative projection (baseline vs scenario) + human
+                  cumul sentence. Self-suppresses when monthlyDelta == 0. */}
+              <SimulatorProjection
+                monthlyDelta={result.monthlyDelta}
+                baseline={reserveView.current}
+                fmtMoney={fmtMoney}
+              />
+
+              {/* Adaptive pedagogical takeaway (R-06: never culpabilising). */}
+              {impactTone !== 'neutral' && (
+                <div
+                  className={`flex items-start gap-2.5 rounded-lg p-3 ${impactTone === 'gain' ? 'bg-success/10' : 'bg-danger/10'}`}
+                  data-testid="simulator-pedago"
+                >
+                  {impactTone === 'gain' ? (
+                    <CheckCircle2
+                      aria-hidden
+                      strokeWidth={1.75}
+                      className="text-success mt-0.5 h-5 w-5 shrink-0"
+                    />
+                  ) : (
+                    <AlertCircle
+                      aria-hidden
+                      strokeWidth={1.75}
+                      className="text-danger mt-0.5 h-5 w-5 shrink-0"
+                    />
+                  )}
+                  <p className="text-foreground text-sm leading-relaxed">
+                    <span className="font-semibold">
+                      {impactTone === 'gain'
+                        ? tImpact('pedago.gainTitle')
+                        : tImpact('pedago.lossTitle')}
+                    </span>{' '}
+                    {impactTone === 'gain'
+                      ? tImpact('pedago.gainBody')
+                      : tImpact('pedago.lossBody')}
+                  </p>
+                </div>
+              )}
 
               {/* Anchor — demoted effort-lissé sub-text (== dashboard "Effort lissé"). */}
               <p className="text-muted-foreground border-border border-t pt-3 text-xs">

--- a/src/app/[locale]/app/simulator/SimulatorProjection.tsx
+++ b/src/app/[locale]/app/simulator/SimulatorProjection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useId } from 'react';
+import { useCallback, useId, useRef, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 
 import { Simulation, type Money } from '@/lib/domain';
@@ -17,20 +17,25 @@ import type { formatCurrency } from '@/lib/i18n/formatters';
  *   - Soft gradient area between them = the cumulative gain/loss.
  *   - Discrete € y-axis, locale month labels, endpoint value, no heavy grid.
  *
+ * **Responsive container, 1:1 pixels** (fix 2026-06-04): the SVG is rendered at
+ * the measured container width with a matching pixel `viewBox`, so fonts and
+ * the line keep a CONSTANT size at any width (a fixed 380-unit viewBox stretched
+ * to a wide card blew text/stroke up ~2.5×). A `ResizeObserver` (callback ref)
+ * tracks the width — re-attaches correctly even when the chart appears after a
+ * zero-delta state.
+ *
  * **CSP-safe by construction** (SVG geometry attributes + `fill`/`stroke` +
  * a `<linearGradient>` def — never an inline `style`), zero chart lib (budget
- * 0 €, bundle 0, SSR/RSC-friendly). Colour adapts: success (gain) / danger
- * (loss). When the delta is zero the chart is suppressed (neutral line).
+ * 0 €, bundle 0). Colour adapts: success (gain) / danger (loss). Zero delta →
+ * the chart is suppressed (neutral line).
  *
  * FSMA: pure arithmetic on the entered scenario. Both `monthlyDelta` and
  * `baseline` are `Money` passed client→client (no RSC boundary crossed).
  */
 
-const VIEW_W = 380;
-const VIEW_H = 190;
-const MARGIN = { left: 44, right: 48, top: 14, bottom: 26 };
-const PLOT_W = VIEW_W - MARGIN.left - MARGIN.right;
-const PLOT_H = VIEW_H - MARGIN.top - MARGIN.bottom;
+const HEIGHT = 196;
+const MARGIN = { left: 48, right: 54, top: 16, bottom: 28 };
+const PLOT_H = HEIGHT - MARGIN.top - MARGIN.bottom;
 const DEFAULT_MONTHS = 6;
 
 export function SimulatorProjection({
@@ -53,6 +58,24 @@ export function SimulatorProjection({
   const locale = useLocale() as Locale;
   const gradId = useId();
 
+  // Measure the available width so the SVG renders at 1:1 px (no text/stroke
+  // scaling). Callback ref re-attaches the observer if the node remounts.
+  const [width, setWidth] = useState(640);
+  const observerRef = useRef<ResizeObserver | null>(null);
+  const setContainer = useCallback((node: HTMLDivElement | null) => {
+    observerRef.current?.disconnect();
+    // Guard for environments without ResizeObserver (jsdom) — falls back to
+    // the default width, which still renders a valid chart.
+    if (node && typeof ResizeObserver !== 'undefined') {
+      const ro = new ResizeObserver((entries) => {
+        const w = entries[0]?.contentRect.width;
+        if (w && w > 0) setWidth(w);
+      });
+      ro.observe(node);
+      observerRef.current = ro;
+    }
+  }, []);
+
   const isZero = monthlyDelta.isZero();
   const positive = monthlyDelta.gt(0);
   const cumul = Simulation.projectCumulative(monthlyDelta, months); // Money
@@ -68,9 +91,9 @@ export function SimulatorProjection({
     );
   }
 
+  const plotW = Math.max(120, width - MARGIN.left - MARGIN.right);
   const base = baseline.toNumber();
   const delta = monthlyDelta.toNumber();
-  // Scenario = baseline + cumulative delta, month by month (k = 0..months).
   const scenario = Array.from({ length: months + 1 }, (_, k) => base + delta * k);
 
   const dataMin = Math.min(base, ...scenario);
@@ -79,7 +102,7 @@ export function SimulatorProjection({
   const lo = dataMin - span * 0.55;
   const hi = dataMax + span * 0.55;
 
-  const xAt = (i: number) => MARGIN.left + (i / months) * PLOT_W;
+  const xAt = (i: number) => MARGIN.left + (i / months) * plotW;
   const yAt = (v: number) => MARGIN.top + PLOT_H - ((v - lo) / (hi - lo)) * PLOT_H;
 
   const baselineY = yAt(base);
@@ -93,10 +116,9 @@ export function SimulatorProjection({
     `${scenarioPath} L ${endX.toFixed(1)} ${baselineY.toFixed(1)}` +
     ` L ${xAt(0).toFixed(1)} ${baselineY.toFixed(1)} Z`;
 
-  // Discrete y-axis: 3 ticks (lo / mid / hi), rounded to a clean step.
   const yTicks = [lo, (lo + hi) / 2, hi];
 
-  // Locale month labels (current month + k forward).
+  // Locale month labels (current month + k). Thin out on narrow widths.
   const now = new Date();
   const monthFmt = new Intl.DateTimeFormat(locale, { month: 'short' });
   const monthLabel = (k: number) => {
@@ -104,6 +126,7 @@ export function SimulatorProjection({
     const s = monthFmt.format(d).replace('.', '');
     return s.charAt(0).toUpperCase() + s.slice(1);
   };
+  const showEveryMonth = width >= 540;
 
   const lineColor = positive ? 'var(--color-success)' : 'var(--color-danger)';
   const ariaLabel = t('projectionAria', { from: fmtMoney(0), to: fmtMoney(cumul) });
@@ -114,7 +137,8 @@ export function SimulatorProjection({
 
   return (
     <div
-      className="border-border flex flex-col gap-2.5 border-t pt-3"
+      ref={setContainer}
+      className="border-border flex w-full flex-col gap-2.5 border-t pt-3"
       data-testid="simulator-projection"
     >
       <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
@@ -154,10 +178,12 @@ export function SimulatorProjection({
       </div>
 
       <svg
-        viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+        width={width}
+        height={HEIGHT}
+        viewBox={`0 0 ${width} ${HEIGHT}`}
         role="img"
         aria-label={ariaLabel}
-        className="block h-auto w-full"
+        className="block max-w-full"
       >
         <defs>
           <linearGradient id={gradId} x1="0" y1="0" x2="0" y2="1">
@@ -171,7 +197,7 @@ export function SimulatorProjection({
           <g key={`y${i}`}>
             <line
               x1={MARGIN.left}
-              x2={VIEW_W - MARGIN.right}
+              x2={width - MARGIN.right}
               y1={yAt(v)}
               y2={yAt(v)}
               stroke="var(--color-border)"
@@ -182,9 +208,8 @@ export function SimulatorProjection({
               x={MARGIN.left - 8}
               y={yAt(v) + 3}
               textAnchor="end"
-              fontSize="9.5"
+              fontSize="10"
               fill="var(--color-muted-foreground)"
-              opacity="0.85"
             >
               {fmtMoney(Math.round(v))}
             </text>
@@ -192,24 +217,25 @@ export function SimulatorProjection({
         ))}
 
         {/* Locale month labels. */}
-        {scenario.map((_, i) => (
-          <text
-            key={`x${i}`}
-            x={xAt(i)}
-            y={VIEW_H - 8}
-            textAnchor="middle"
-            fontSize="9.5"
-            fill="var(--color-muted-foreground)"
-            opacity="0.85"
-          >
-            {monthLabel(i)}
-          </text>
-        ))}
+        {scenario.map((_, i) =>
+          showEveryMonth || i % 2 === 0 ? (
+            <text
+              key={`x${i}`}
+              x={xAt(i)}
+              y={HEIGHT - 9}
+              textAnchor="middle"
+              fontSize="10"
+              fill="var(--color-muted-foreground)"
+            >
+              {monthLabel(i)}
+            </text>
+          ) : null,
+        )}
 
         {/* Baseline "Sans changement" — dashed reference. */}
         <line
           x1={MARGIN.left}
-          x2={VIEW_W - MARGIN.right}
+          x2={width - MARGIN.right}
           y1={baselineY}
           y2={baselineY}
           stroke="var(--color-muted-foreground)"
@@ -224,30 +250,30 @@ export function SimulatorProjection({
           d={scenarioPath}
           fill="none"
           stroke={lineColor}
-          strokeWidth="2.5"
+          strokeWidth="2"
           strokeLinecap="round"
           strokeLinejoin="round"
         />
 
-        {/* Start dot (on baseline) + endpoint halo/dot + value. */}
+        {/* Start dot (baseline) + endpoint halo/dot + value. */}
         <circle
           cx={xAt(0)}
           cy={baselineY}
-          r="3.2"
+          r="3.5"
           fill="var(--color-card)"
           stroke="var(--color-muted-foreground)"
           strokeWidth="2"
         />
-        <circle cx={endX} cy={endY} r="5.5" fill={lineColor} fillOpacity="0.18" />
+        <circle cx={endX} cy={endY} r="6" fill={lineColor} fillOpacity="0.18" />
         <circle
           cx={endX}
           cy={endY}
-          r="3.4"
+          r="3.5"
           fill="var(--color-card)"
           stroke={lineColor}
           strokeWidth="2"
         />
-        <text x={endX + 8} y={endY + 3} fontSize="12" fontWeight="700" fill={lineColor}>
+        <text x={endX + 9} y={endY + 4} fontSize="13" fontWeight="700" fill={lineColor}>
           {endLabel}
         </text>
       </svg>

--- a/src/app/[locale]/app/simulator/SimulatorProjection.tsx
+++ b/src/app/[locale]/app/simulator/SimulatorProjection.tsx
@@ -1,56 +1,61 @@
 'use client';
 
-import { useTranslations } from 'next-intl';
+import { useId } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
 
 import { Simulation, type Money } from '@/lib/domain';
+import type { Locale } from '@/i18n/routing';
 import type { formatCurrency } from '@/lib/i18n/formatters';
 
 /**
- * SimulatorProjection — 6-month "réserve libre" projection inside the simulator
- * Impact card (Track B P1 lot 1, model locked 2026-05-30: "cumul marginal").
+ * SimulatorProjection — 6-month comparative projection inside the simulator
+ * Impact card (model: "scenario impact over time").
  *
- * - S3: a light inline SVG sparkline. Two reads — a flat **0 baseline** ("Sans
- *   changement") and the **scenario line** = `monthlyDelta × month` ("Avec ce
- *   choix"). The growing gap IS the cumulative saving. No hardcoded absolute
- *   baseline (the landing's `RESERVE_BASELINE_6M` is fabricated demo data and
- *   stays out of the authenticated cockpit).
- * - S4: a human cumul sentence — "En 6 mois, +X € en réserve libre".
+ * Two lines (validated design @thierry 2026-06-04):
+ *   - "Sans changement" = flat dashed baseline at the current réserve libre.
+ *   - "Avec ce choix"    = baseline + cumulative monthly delta (rises/falls).
+ *   - Soft gradient area between them = the cumulative gain/loss.
+ *   - Discrete € y-axis, locale month labels, endpoint value, no heavy grid.
  *
- * FSMA: pure arithmetic on the entered scenario, zero behavioural assumption
- * (we never claim the user banks their broader réserve). RSC boundary: this is
- * a `'use client'` leaf; `cumulativeReserveSeries` runs in the browser from a
- * `monthlyDelta` already client-side — no `Money`/`Decimal` is serialised.
+ * **CSP-safe by construction** (SVG geometry attributes + `fill`/`stroke` +
+ * a `<linearGradient>` def — never an inline `style`), zero chart lib (budget
+ * 0 €, bundle 0, SSR/RSC-friendly). Colour adapts: success (gain) / danger
+ * (loss). When the delta is zero the chart is suppressed (neutral line).
  *
- * When `monthlyDelta` is zero (e.g. negotiating to the same amount) there is
- * nothing to plot, so the sparkline is suppressed and a neutral line is shown —
- * the hero already surfaces the unchanged "X → X /mois".
+ * FSMA: pure arithmetic on the entered scenario. Both `monthlyDelta` and
+ * `baseline` are `Money` passed client→client (no RSC boundary crossed).
  */
 
-// Compact, mobile-first sparkline geometry (viewBox units, scales with width).
-const VIEW_W = 240;
-const VIEW_H = 64;
-const PAD = 6;
+const VIEW_W = 380;
+const VIEW_H = 190;
+const MARGIN = { left: 44, right: 48, top: 14, bottom: 26 };
+const PLOT_W = VIEW_W - MARGIN.left - MARGIN.right;
+const PLOT_H = VIEW_H - MARGIN.top - MARGIN.bottom;
 const DEFAULT_MONTHS = 6;
 
 export function SimulatorProjection({
   monthlyDelta,
+  baseline,
   fmtMoney,
   months = DEFAULT_MONTHS,
 }: {
   monthlyDelta: Money;
+  /** Current réserve libre — the flat "Sans changement" reference line. */
+  baseline: Money;
   /**
-   * Locale-aware currency formatter from the parent. Typed off `formatCurrency`
-   * so it accepts `Money | number` (plan-reviewer note 1) — passing a function
-   * client→client crosses no RSC boundary.
+   * Locale-aware currency formatter from the parent (accepts `Money | number`).
+   * Passing a function client→client crosses no RSC boundary.
    */
   fmtMoney: (value: Parameters<typeof formatCurrency>[0]) => string;
   months?: number;
 }) {
   const t = useTranslations('app.simulator.impact');
+  const locale = useLocale() as Locale;
+  const gradId = useId();
 
   const isZero = monthlyDelta.isZero();
   const positive = monthlyDelta.gt(0);
-  const cumul = Simulation.projectCumulative(monthlyDelta, months);
+  const cumul = Simulation.projectCumulative(monthlyDelta, months); // Money
 
   if (isZero) {
     return (
@@ -63,41 +68,49 @@ export function SimulatorProjection({
     );
   }
 
-  // Real cumulative values (Money), then `.toNumber()` ONLY for pixel geometry —
-  // every displayed amount still goes through `fmtMoney(Money)`.
-  const series = Simulation.cumulativeReserveSeries(monthlyDelta, months);
-  // Prepend a 0 origin so both lines start together at month 0 and visibly
-  // diverge — matches the "de 0 € à {to}" narrative read to screen readers.
-  const points = [0, ...series.map((m) => m.toNumber())];
-  const end = points[points.length - 1]!;
+  const base = baseline.toNumber();
+  const delta = monthlyDelta.toNumber();
+  // Scenario = baseline + cumulative delta, month by month (k = 0..months).
+  const scenario = Array.from({ length: months + 1 }, (_, k) => base + delta * k);
 
-  const lo = Math.min(0, end);
-  const hi = Math.max(0, end);
-  const range = hi - lo; // > 0 here (isZero short-circuited above)
-  const plotW = VIEW_W - PAD * 2;
-  const plotH = VIEW_H - PAD * 2;
+  const dataMin = Math.min(base, ...scenario);
+  const dataMax = Math.max(base, ...scenario);
+  const span = dataMax - dataMin || Math.max(1, Math.abs(base) * 0.1);
+  const lo = dataMin - span * 0.55;
+  const hi = dataMax + span * 0.55;
 
-  const xAt = (i: number) => PAD + (i / (points.length - 1)) * plotW;
-  const yAt = (v: number) => {
-    // Defensive: a degenerate [0,0] domain would yield NaN (plan-reviewer
-    // point 3). Unreachable while `isZero` short-circuits, kept for safety.
-    if (range === 0) return PAD + plotH / 2;
-    return PAD + plotH - ((v - lo) / range) * plotH;
-  };
+  const xAt = (i: number) => MARGIN.left + (i / months) * PLOT_W;
+  const yAt = (v: number) => MARGIN.top + PLOT_H - ((v - lo) / (hi - lo)) * PLOT_H;
 
-  const baselineY = yAt(0);
-  const scenarioPath = points
+  const baselineY = yAt(base);
+  const endX = xAt(months);
+  const endY = yAt(scenario[months]!);
+
+  const scenarioPath = scenario
     .map((v, i) => `${i === 0 ? 'M' : 'L'} ${xAt(i).toFixed(1)} ${yAt(v).toFixed(1)}`)
     .join(' ');
   const areaPath =
-    `${scenarioPath} L ${xAt(points.length - 1).toFixed(1)} ${baselineY.toFixed(1)}` +
+    `${scenarioPath} L ${endX.toFixed(1)} ${baselineY.toFixed(1)}` +
     ` L ${xAt(0).toFixed(1)} ${baselineY.toFixed(1)} Z`;
+
+  // Discrete y-axis: 3 ticks (lo / mid / hi), rounded to a clean step.
+  const yTicks = [lo, (lo + hi) / 2, hi];
+
+  // Locale month labels (current month + k forward).
+  const now = new Date();
+  const monthFmt = new Intl.DateTimeFormat(locale, { month: 'short' });
+  const monthLabel = (k: number) => {
+    const d = new Date(now.getFullYear(), now.getMonth() + k, 1);
+    const s = monthFmt.format(d).replace('.', '');
+    return s.charAt(0).toUpperCase() + s.slice(1);
+  };
 
   const lineColor = positive ? 'var(--color-success)' : 'var(--color-danger)';
   const ariaLabel = t('projectionAria', { from: fmtMoney(0), to: fmtMoney(cumul) });
   const cumulText = positive
     ? t('cumul6mGain', { amount: fmtMoney(cumul.abs()) })
     : t('cumul6mLoss', { amount: fmtMoney(cumul.abs()) });
+  const endLabel = `${positive ? '+' : '−'}${fmtMoney(cumul.abs())}`;
 
   return (
     <div
@@ -110,34 +123,30 @@ export function SimulatorProjection({
           <li className="flex items-center gap-1.5">
             <svg
               aria-hidden="true"
-              width="10"
-              height="2"
+              width="14"
+              height="3"
               className="text-muted-foreground inline-block"
             >
               <line
                 x1="0"
-                y1="1"
-                x2="10"
-                y2="1"
+                y1="1.5"
+                x2="14"
+                y2="1.5"
                 stroke="currentColor"
                 strokeWidth="2"
-                strokeDasharray="3 3"
+                strokeDasharray="3 2"
               />
             </svg>
             <span className="text-muted-foreground">{t('projectionBaselineLegend')}</span>
           </li>
           <li className="flex items-center gap-1.5">
-            {/* The swatch (graphical object, WCAG 1.4.11 → 3:1) carries the
-                scenario colour; the LABEL stays muted-foreground so the small
-                text meets 4.5:1 in both themes (success #059669 is sub-AA for
-                small text on the light card; danger #dc2626 on the dark card). */}
             <svg
               aria-hidden="true"
-              width="10"
-              height="2"
+              width="14"
+              height="3"
               className={`inline-block ${positive ? 'text-success' : 'text-danger'}`}
             >
-              <line x1="0" y1="1" x2="10" y2="1" stroke="currentColor" strokeWidth="2" />
+              <line x1="0" y1="1.5" x2="14" y2="1.5" stroke="currentColor" strokeWidth="2" />
             </svg>
             <span className="text-muted-foreground">{t('projectionScenarioLegend')}</span>
           </li>
@@ -148,46 +157,101 @@ export function SimulatorProjection({
         viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
         role="img"
         aria-label={ariaLabel}
-        // Compact sparkline: full width on mobile, capped on desktop so the
-        // 240×64 viewBox is not stretched into a giant triangle on a wide card
-        // (@thierry PROD review 2026-06-02 — "barre énorme, pas pro").
-        className="block h-auto w-full max-w-md"
+        className="block h-auto w-full"
       >
-        {/* Flat 0 baseline — "Sans changement". */}
+        <defs>
+          <linearGradient id={gradId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={lineColor} stopOpacity="0.2" />
+            <stop offset="100%" stopColor={lineColor} stopOpacity="0.03" />
+          </linearGradient>
+        </defs>
+
+        {/* Discrete y-axis: faint gridline + muted € label per tick. */}
+        {yTicks.map((v, i) => (
+          <g key={`y${i}`}>
+            <line
+              x1={MARGIN.left}
+              x2={VIEW_W - MARGIN.right}
+              y1={yAt(v)}
+              y2={yAt(v)}
+              stroke="var(--color-border)"
+              strokeWidth="1"
+              strokeOpacity="0.5"
+            />
+            <text
+              x={MARGIN.left - 8}
+              y={yAt(v) + 3}
+              textAnchor="end"
+              fontSize="9.5"
+              fill="var(--color-muted-foreground)"
+              opacity="0.85"
+            >
+              {fmtMoney(Math.round(v))}
+            </text>
+          </g>
+        ))}
+
+        {/* Locale month labels. */}
+        {scenario.map((_, i) => (
+          <text
+            key={`x${i}`}
+            x={xAt(i)}
+            y={VIEW_H - 8}
+            textAnchor="middle"
+            fontSize="9.5"
+            fill="var(--color-muted-foreground)"
+            opacity="0.85"
+          >
+            {monthLabel(i)}
+          </text>
+        ))}
+
+        {/* Baseline "Sans changement" — dashed reference. */}
         <line
-          x1={xAt(0)}
-          x2={xAt(points.length - 1)}
+          x1={MARGIN.left}
+          x2={VIEW_W - MARGIN.right}
           y1={baselineY}
           y2={baselineY}
           stroke="var(--color-muted-foreground)"
           strokeWidth="1.5"
-          strokeDasharray="3 3"
+          strokeDasharray="5 4"
           strokeOpacity="0.6"
         />
-        {/* Scenario area + line — "Avec ce choix". */}
-        <path d={areaPath} fill={lineColor} fillOpacity="0.12" />
+
+        {/* Scenario area + line "Avec ce choix". */}
+        <path d={areaPath} fill={`url(#${gradId})`} />
         <path
           d={scenarioPath}
           fill="none"
           stroke={lineColor}
-          strokeWidth="2"
+          strokeWidth="2.5"
           strokeLinecap="round"
           strokeLinejoin="round"
         />
-        {/* End marker. */}
+
+        {/* Start dot (on baseline) + endpoint halo/dot + value. */}
         <circle
-          cx={xAt(points.length - 1)}
-          cy={yAt(end)}
-          r="2.5"
+          cx={xAt(0)}
+          cy={baselineY}
+          r="3.2"
+          fill="var(--color-card)"
+          stroke="var(--color-muted-foreground)"
+          strokeWidth="2"
+        />
+        <circle cx={endX} cy={endY} r="5.5" fill={lineColor} fillOpacity="0.18" />
+        <circle
+          cx={endX}
+          cy={endY}
+          r="3.4"
           fill="var(--color-card)"
           stroke={lineColor}
           strokeWidth="2"
         />
+        <text x={endX + 8} y={endY + 3} fontSize="12" fontWeight="700" fill={lineColor}>
+          {endLabel}
+        </text>
       </svg>
 
-      {/* Cumul sentence in `text-foreground` (AAA both themes) — the gain/loss
-          colour lives in the sparkline (large graphical, ≥3:1). Colouring this
-          small text success/danger would breach 4.5:1 (see legend note). */}
       <p
         className="text-foreground text-sm font-medium tabular-nums"
         data-testid="simulator-cumul6m"

--- a/src/app/[locale]/app/simulator/SimulatorProjection.tsx
+++ b/src/app/[locale]/app/simulator/SimulatorProjection.tsx
@@ -67,6 +67,10 @@ export function SimulatorProjection({
     // Guard for environments without ResizeObserver (jsdom) — falls back to
     // the default width, which still renders a valid chart.
     if (node && typeof ResizeObserver !== 'undefined') {
+      // Synchronous initial measure (the callback ref runs post-layout, pre-paint)
+      // — avoids a flash at the default width before the observer first fires.
+      const initialW = node.getBoundingClientRect().width;
+      if (initialW > 0) setWidth(initialW);
       const ro = new ResizeObserver((entries) => {
         const w = entries[0]?.contentRect.width;
         if (w && w > 0) setWidth(w);
@@ -129,11 +133,20 @@ export function SimulatorProjection({
   const showEveryMonth = width >= 540;
 
   const lineColor = positive ? 'var(--color-success)' : 'var(--color-danger)';
-  const ariaLabel = t('projectionAria', { from: fmtMoney(0), to: fmtMoney(cumul) });
+  const ariaLabel = t('projectionAria', {
+    from: fmtMoney(base),
+    to: fmtMoney(scenario[months]!),
+  });
   const cumulText = positive
     ? t('cumul6mGain', { amount: fmtMoney(cumul.abs()) })
     : t('cumul6mLoss', { amount: fmtMoney(cumul.abs()) });
   const endLabel = `${positive ? '+' : '−'}${fmtMoney(cumul.abs())}`;
+  // Place the endpoint value to the right of the dot, or above it when the
+  // right gutter is too narrow (iPhone SE / large amounts) — avoids clipping.
+  const labelRoomRight = width - (endX + 10) >= endLabel.length * 7.5;
+  const labelX = labelRoomRight ? endX + 9 : endX;
+  const labelY = labelRoomRight ? endY + 4 : endY - 10;
+  const labelAnchor = labelRoomRight ? 'start' : 'middle';
 
   return (
     <div
@@ -273,7 +286,14 @@ export function SimulatorProjection({
           stroke={lineColor}
           strokeWidth="2"
         />
-        <text x={endX + 9} y={endY + 4} fontSize="13" fontWeight="700" fill={lineColor}>
+        <text
+          x={labelX}
+          y={labelY}
+          textAnchor={labelAnchor}
+          fontSize="13"
+          fontWeight="700"
+          fill={lineColor}
+        >
           {endLabel}
         </text>
       </svg>

--- a/src/app/[locale]/app/simulator/__tests__/SimulatorProjection.test.tsx
+++ b/src/app/[locale]/app/simulator/__tests__/SimulatorProjection.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+
+import messages from '../../../../../../messages/fr-BE.json';
+import { money } from '@/lib/domain';
+import { formatCurrency } from '@/lib/i18n/formatters';
+import { SimulatorProjection } from '../SimulatorProjection';
+
+function renderProj(delta: number) {
+  return render(
+    <NextIntlClientProvider locale="fr-BE" messages={messages} timeZone="Europe/Brussels">
+      <SimulatorProjection
+        monthlyDelta={money(delta)}
+        baseline={money(624)}
+        fmtMoney={(v) => formatCurrency(v, 'fr-BE')}
+      />
+    </NextIntlClientProvider>,
+  );
+}
+
+describe('<SimulatorProjection /> (area-chart redesign)', () => {
+  it('renders a CSP-safe area chart for a positive delta (no inline style)', () => {
+    const { container } = renderProj(19);
+    expect(screen.getByTestId('simulator-projection')).toBeInTheDocument();
+    expect(screen.getByRole('img')).toBeInTheDocument();
+    // Gradient def + area + line + endpoint dot/halo.
+    expect(container.querySelector('linearGradient')).not.toBeNull();
+    expect(container.querySelectorAll('path').length).toBeGreaterThanOrEqual(2);
+    expect(container.querySelectorAll('circle').length).toBeGreaterThanOrEqual(2);
+    // Strict CSP: geometry via SVG attributes only, never an inline style attr.
+    expect(container.querySelector('[style]')).toBeNull();
+    // Human cumul sentence present.
+    expect(screen.getByTestId('simulator-cumul6m').textContent ?? '').toMatch(/réserve libre/i);
+  });
+
+  it('suppresses the chart and shows a neutral line when delta is zero', () => {
+    renderProj(0);
+    expect(screen.queryByTestId('simulator-projection')).toBeNull();
+    expect(screen.queryByRole('img')).toBeNull();
+    expect(screen.getByTestId('simulator-cumul6m')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Simulateur — chart de projection comparative (redesign validé @thierry)

Remplace le sparkline « wedge plat » par un **area/line chart comparatif** moderne, **SVG-maison** (CSP-safe, 0 bundle).

### Design (validé via aperçu : ta réf + Tremor/Income Lab + ChatGPT challengé)
- **2 lignes** : « Sans changement » (pointillée plate = réserve actuelle) + « Avec ce choix » (pleine, monte/descend).
- Écart ombré (gradient) = gain/perte cumulé · axe Y € discret · labels mois (locale) · valeur en bout (`+54 €` / `−54 €`).
- **Icône d'impact adaptative** : `TrendingUp` vert (gain) · `TrendingDown` rouge (perte) · `Minus` muted (neutre).
- **Bloc pédago adaptatif** (R-06, jamais culpabilisant) : « Bon choix » (check-circle vert) / « Impact à considérer » (alert-circle rouge).
- **Icônes Lucide uniquement, zéro emoji.** Contrôles Scénario + chiffre ancré « Reste disponible 624 → 633 » préservés.

### Challenge technique (vs ChatGPT qui recommandait Recharts)
Recharts injecte des `style` inline runtime → **bloqués par la CSP stricte** (`style-src 'self' 'nonce'`), + ~100 ko bundle (Lighthouse) + `'use client'`. → **SVG-maison** : même look, CSP-safe, 0 ko, SSR. Composant réutilisable (Timeline #3 / Goals #6 du NORTH_STAR).

### Gates
typecheck · lint · **1423 tests** · build. i18n pédago × 5 locales (NL/DE/ES réels, glossaire registre je/du/tú).

### Restant (DoD)
- [ ] Validation visuelle @thierry (preview Vercel)
- [ ] QA agents (dashboard-ux Layer 0, mobile-ios, ui, i18n) après GO visuel
- [ ] DoD5 → merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
