### PR TITLE
feat(charges): Factures Phase 2 — Payé toggle + redesign + dashboard trim

### DIFF
--- a/docs/plans/factures-phase2-paid-toggle-design.md
+++ b/docs/plans/factures-phase2-paid-toggle-design.md
@@ -1,0 +1,148 @@
+# Factures Phase 2 — Payé toggle + paid-aware summary + dashboard trim + redesign
+
+> Plan @cc-ankora 2026-06-04. À valider par `plan-reviewer` avant tout code.
+> Demande @thierry (informelle) : « on n'a rien pour valider qu'un paiement a
+> été effectué » + « trop de factures du mois prochain » sur le dashboard +
+> redesign visuel validé. Inspiration : son tableau Coda (Payé / Montant payé /
+> Solde restant) — **sans le copier**.
+
+## Goal
+
+Brancher l'UI manquante sur le backend de paiement **déjà construit + testé**
+(`togglePaymentAction`), refléter l'état payé, trimmer le bucket dashboard
+« Mois prochain », et appliquer le redesign visuel validé visuellement.
+
+## Contexte (code-vérifié, 2026-06-04)
+
+- **Backend EXISTE, aucune UI ne l'appelle** (grep `.tsx` = 0 match) :
+  - `src/lib/actions/charge-payments.ts` → `togglePaymentAction(input)` →
+    `ActionResult<{ paid, paidAmount }>`. Toggle idempotent (INSERT=payé /
+    DELETE=non payé). Authz workspace **avant** write, rate-limit `mutation`,
+    audit `CHARGE_PAYMENT_TOGGLED`, `revalidateDashboard()` + `revalidateAppPath('charges')`.
+  - Schéma `chargePaymentToggleSchema` : `{ chargeId(uuid), periodYear(2000-2100),
+periodMonth(1-12), paidAmount?(optional), note? }`. `paidAmount` omis →
+    défaut `charges.amount` côté action. **Le toggle simple n'envoie que
+    `{chargeId, periodYear, periodMonth}`.**
+  - Domaine `charge-payments/{mark-paid,queries,types}` + tests. Migration
+    `20260503000004_pr_d1_charge_payments.sql` (RLS workspace).
+- **Snapshot** (`workspace-snapshot.ts`) expose `currentMonthPayments:
+Array<{chargeId, periodYear, periodMonth, paidAmount...}>` (mois courant
+  uniquement) + `currentPeriod {year, month}` (TZ Europe/Brussels).
+- **Charges page** (`charges/page.tsx`) passe charges/subtotals/totals —
+  **aucune donnée paiement** aujourd'hui.
+- **Dashboard buckets** (`ProchainesFacturesCard` + `getUpcomingCharges`) :
+  labels `overdue="En retard"`, `j7="Cette semaine"`, `j14="Ce mois-ci"`,
+  `j30="Mois prochain"`. `j30` liste TOUTES les factures dues à 15–30 j
+  (12 chez @thierry) → cause du « trop de factures ».
+
+## Scope (MVP — toggle simple, validé @thierry)
+
+1. **Toggle « Payé / À payer »** sur la page charges, par facture **due ce
+   mois** (`paymentMonths.includes(currentPeriod.month)`). Appelle
+   `togglePaymentAction({chargeId, periodYear: currentPeriod.year,
+periodMonth: currentPeriod.month})`. État optimiste local (seedé depuis
+   `paidChargeIds`), `useTransition`; revert + toast sur erreur. Factures non
+   dues ce mois : pas de toggle (futur).
+2. **Style payé + résumé « ce mois »** : ligne payée = ✓ + montant atténué.
+   Petite ligne de résumé distincte du total lissé : « X/Y factures payées ce
+   mois · reste {montant} » (dérivé des factures dues ce mois). **Ne touche pas**
+   au total « Effort mensuel lissé » / « Équivalent annuel » (métrique
+   différente, lissage ≠ cash du mois).
+3. **Trim dashboard** : `ProchainesFacturesCard` plafonne chaque bucket à
+   `MAX_VISIBLE = 4` lignes + « +N autres » (le lien « Voir toutes » existe
+   déjà dans le header). Corrige le « mois prochain » à 12 lignes.
+4. **Redesign visuel validé** : `<ul>` encadré arrondi par groupe fréquence ;
+   en-tête groupe = icône `Repeat` neutre + fréquence + **compteur** ;
+   **sous-total déplacé en bas** du groupe, **coloré brand**
+   (`text-brand-700` light / token brand dark). Dark mode vérifié. **Conserve
+   tous les testids** (`charges-group-*`, `charges-group-subtotal-*`,
+   `charges-row-*`, `charges-total`), le groupement, le CRUD, le total global.
+
+## Non-goals
+
+- Montant partiel (`paidAmount` override) → Phase 3 si besoin réel.
+- Toggle inline sur la carte dashboard → fast-follow (la page charges est la
+  surface de gestion primaire).
+- Marquer payé pour une période future (mois courant uniquement).
+
+## Fichiers touchés
+
+- `src/app/[locale]/app/charges/page.tsx` — passer `paidChargeIds: string[]`
+  (depuis `snapshot.currentMonthPayments.map(p => p.chargeId)`) + `currentPeriod
+{year, month}` à `ChargesClient`.
+- `src/app/[locale]/app/charges/ChargesClient.tsx` — (a) redesign liste/groupes/
+  sous-totaux ; (b) toggle Payé par ligne due ce mois (état optimiste
+  `useState<Set<string>>` seedé, `useTransition` + `togglePaymentAction`) ;
+  (c) résumé « ce mois » payé/reste. Conserver tous les testids + le
+  `renderChargeRow` responsive existant (adapter, pas réécrire à zéro).
+- `src/components/dashboard/ProchainesFacturesCard.tsx` — `MAX_VISIBLE` slice +
+  « +N autres ».
+- `messages/{fr-BE,en,nl-BE,de-DE,es-ES}.json` — clés :
+  `app.charges.{paidToggleAria, unpaidToggleAria, markedPaidToast,
+markedUnpaidToast, togglePaidFailed, paidSummary, dueThisMonthBadge?}` +
+  `dashboard.upcomingBills.moreCount`. NL/DE/ES traduits (glossaire, registre).
+- Tests : `ChargesClient` (toggle on/off optimiste + erreur revert, style payé,
+  résumé), `ProchainesFacturesCard` (cap + overflow count), wiring action
+  (mock `togglePaymentAction`).
+
+## Logique période
+
+- `currentPeriod` = `snapshot.currentPeriod` (déjà calculé, TZ Brussels).
+- `paidChargeIds` = `new Set(snapshot.currentMonthPayments.map(p => p.chargeId))`
+  (déjà filtré mois courant côté snapshot).
+- Toggle visible ssi `c.paymentMonths.includes(currentPeriod.month)` (RawCharge
+  porte déjà `paymentMonths`).
+- Optimisme : flip local du Set ; si `result.ok === false` → revert + toast
+  `translateError(result.errorCode)`.
+
+## Sécurité / risk tiering
+
+Voie LOURDE-light : appelle une Server Action **existante** (aucune modif de
+l'action / RLS / domaine / migration). `plan-reviewer` (ce doc) + QA ciblés :
+`dashboard-ux-auditor`, `mobile-ios-auditor` (toggle = touch target 44px),
+`i18n-auditor` (nouvelles clés ×5), `security-auditor` (chemin d'appel action :
+pas de `chargeId` trusté côté client au-delà de ce que l'action revérifie ;
+confirmer authz inchangée). `financial-formula-validator` non requis (aucune
+math domaine ; résumé = sommes simples). `rls-flow-tester` non requis (pas de
+migration/RLS touchée).
+
+## DoD
+
+`typecheck` · `lint` · `lint:use-server` · `test` · `build` · QA agents ·
+Sourcery silencieux · DoD5. Validation visuelle @thierry sur preview Vercel
+(desktop + mobile, light + dark).
+
+## Découpage
+
+Un seul PR « feat(charges): Phase 2 — Payé toggle + redesign + dashboard trim »
+si < ~550 lignes. Si dépassement → split : (PR-A) charges page toggle+redesign,
+(PR-B) dashboard trim. Estimation : ~400–500 lignes → un PR.
+
+## Changements plan-reviewer intégrés (🟡 APPROVED WITH CHANGES, 2026-06-04)
+
+- **CR-1 — état optimiste (le + important)** : utiliser **`useOptimistic`**
+  (React 19) et NON un `useState<Set>` seedé une fois. Base = `paidChargeIds`
+  (prop serveur, re-synchronisée à chaque `revalidateAppPath('charges')`). Le
+  reducer flippe un `chargeId` ; après la transition + revalidation, React
+  réconcilie automatiquement vers la vérité serveur (rollback natif sur erreur,
+  puisque la DB n'a pas changé → `paidChargeIds` inchangé). Toast d'erreur si
+  `result.ok === false`. Zéro double-source-of-truth.
+- **CR-2 — limite assumée (ajout Non-goals)** : une facture en retard
+  (`overdue` au dashboard) dont `paymentMonths` n'inclut PAS le mois courant
+  n'aura **pas** de toggle sur la page charges en Phase 2 (toggle = mois
+  courant only). Limite UX assumée, pas un bug.
+- **CR-3 — tests existants à adapter (nommés)** :
+  - `ChargesClient.test.tsx:~121` « exactement 1 listitem par charge » → le
+    toggle vit DANS le `<li>` existant, aucun `<li>`/`role=listitem` parasite.
+  - `e2e/charges/charges-list-desktop.spec.ts:95,121` baseline grid ≤ 6px →
+    re-vérifier si `renderChargeRow` change de colonnes (préférer **ne pas**
+    ajouter de 7e colonne : intégrer le toggle dans une cellule existante / en
+    tête de ligne pour préserver l'alignement baseline 6 colonnes).
+  - `e2e/charges/charges-list-mobile.spec.ts:66-68` (pas de `rounded-lg`/
+    `bg-card`/`p-4` sur la row) → le `rounded` s'applique au `<ul>` du groupe,
+    PAS à la `<li>`.
+  - `ChargesClient.test.tsx:365-407` parité i18n → **étendre** la liste des clés
+    attendues aux nouvelles clés ×5 locales (sinon parité NL/DE/ES non gated).
+- **CR-4 — commits atomiques** (même PR unique) : (1) redesign visuel liste/
+  sous-totaux ; (2) toggle Payé + wiring action + résumé ; (3) trim dashboard.
+  Revert granulaire possible.

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -1100,6 +1100,7 @@
       "dueToday": "Heute",
       "daysUntil": "In {days, plural, =1 {1 Tag} other {# Tagen}}",
       "daysOverdue": "{days, plural, =1 {1 Tag überfällig} other {# Tage überfällig}}",
+      "moreCount": "+ {count, plural, =1 {1 weitere} other {# weitere}}",
       "buckets": {
         "overdue": "Überfällig",
         "j7": "Diese Woche",

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -723,6 +723,11 @@
       "toastCreated": "Fixkosten hinzugefügt",
       "toastUpdated": "Fixkosten aktualisiert",
       "toastDeleted": "Fixkosten gelöscht",
+      "toastMarkedPaid": "Rechnung als bezahlt markiert",
+      "toastMarkedUnpaid": "Rechnung als zu zahlen markiert",
+      "markPaidAria": "{label} als bezahlt markieren",
+      "unmarkPaidAria": "{label} als zu zahlen markieren",
+      "paidSummary": "Diesen Monat bezahlt: {paid}/{total} · noch {remaining}",
       "drawer": {
         "title": "Fixkosten bearbeiten",
         "save": "Speichern",

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -728,6 +728,7 @@
       "markPaidAria": "{label} als bezahlt markieren",
       "unmarkPaidAria": "{label} als zu zahlen markieren",
       "paidSummary": "Diesen Monat bezahlt: {paid}/{total} · noch {remaining}",
+      "paidHint": "Hake die Rechnungen ab, die du diesen Monat schon bezahlt hast.",
       "drawer": {
         "title": "Fixkosten bearbeiten",
         "save": "Speichern",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1100,6 +1100,7 @@
       "dueToday": "Today",
       "daysUntil": "In {days, plural, =1 {1 day} other {# days}}",
       "daysOverdue": "{days, plural, =1 {1 day overdue} other {# days overdue}}",
+      "moreCount": "+ {count, plural, =1 {1 more} other {# more}}",
       "buckets": {
         "overdue": "Overdue",
         "j7": "This week",

--- a/messages/en.json
+++ b/messages/en.json
@@ -728,6 +728,7 @@
       "markPaidAria": "Mark {label} as paid",
       "unmarkPaidAria": "Mark {label} as to pay",
       "paidSummary": "Paid this month: {paid}/{total} · {remaining} left",
+      "paidHint": "Tick the bills you've already paid this month.",
       "drawer": {
         "title": "Edit bill",
         "save": "Save",

--- a/messages/en.json
+++ b/messages/en.json
@@ -723,6 +723,11 @@
       "toastCreated": "Bill added",
       "toastUpdated": "Bill updated",
       "toastDeleted": "Bill deleted",
+      "toastMarkedPaid": "Bill marked as paid",
+      "toastMarkedUnpaid": "Bill marked as to pay",
+      "markPaidAria": "Mark {label} as paid",
+      "unmarkPaidAria": "Mark {label} as to pay",
+      "paidSummary": "Paid this month: {paid}/{total} · {remaining} left",
       "drawer": {
         "title": "Edit bill",
         "save": "Save",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -728,6 +728,7 @@
       "markPaidAria": "Marcar {label} como pagada",
       "unmarkPaidAria": "Marcar {label} como por pagar",
       "paidSummary": "Pagadas este mes: {paid}/{total} · quedan {remaining}",
+      "paidHint": "Marca las facturas que ya has pagado este mes.",
       "drawer": {
         "title": "Modificar gasto fijo",
         "save": "Guardar",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -1100,6 +1100,7 @@
       "dueToday": "Hoy",
       "daysUntil": "En {days, plural, =1 {1 día} other {# días}}",
       "daysOverdue": "{days, plural, =1 {1 día de retraso} other {# días de retraso}}",
+      "moreCount": "+ {count, plural, =1 {1 más} other {# más}}",
       "buckets": {
         "overdue": "Atrasadas",
         "j7": "Esta semana",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -723,6 +723,11 @@
       "toastCreated": "Gasto fijo añadido",
       "toastUpdated": "Gasto fijo actualizado",
       "toastDeleted": "Gasto fijo eliminado",
+      "toastMarkedPaid": "Factura marcada como pagada",
+      "toastMarkedUnpaid": "Factura marcada como por pagar",
+      "markPaidAria": "Marcar {label} como pagada",
+      "unmarkPaidAria": "Marcar {label} como por pagar",
+      "paidSummary": "Pagadas este mes: {paid}/{total} · quedan {remaining}",
       "drawer": {
         "title": "Modificar gasto fijo",
         "save": "Guardar",

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -728,6 +728,7 @@
       "markPaidAria": "Marquer {label} comme payée",
       "unmarkPaidAria": "Marquer {label} comme à payer",
       "paidSummary": "Payées ce mois : {paid}/{total} · reste {remaining}",
+      "paidHint": "Coche les factures que tu as déjà payées ce mois.",
       "drawer": {
         "title": "Modifier la charge",
         "save": "Enregistrer",

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -723,6 +723,11 @@
       "toastCreated": "Charge ajoutée",
       "toastUpdated": "Charge mise à jour",
       "toastDeleted": "Charge supprimée",
+      "toastMarkedPaid": "Facture marquée payée",
+      "toastMarkedUnpaid": "Facture marquée à payer",
+      "markPaidAria": "Marquer {label} comme payée",
+      "unmarkPaidAria": "Marquer {label} comme à payer",
+      "paidSummary": "Payées ce mois : {paid}/{total} · reste {remaining}",
       "drawer": {
         "title": "Modifier la charge",
         "save": "Enregistrer",

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -1100,6 +1100,7 @@
       "dueToday": "Aujourd'hui",
       "daysUntil": "Dans {days, plural, =1 {1 jour} other {# jours}}",
       "daysOverdue": "{days, plural, =1 {1 jour en retard} other {# jours en retard}}",
+      "moreCount": "+ {count, plural, =1 {1 autre} other {# autres}}",
       "buckets": {
         "overdue": "En retard",
         "j7": "Cette semaine",

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -1100,6 +1100,7 @@
       "dueToday": "Vandaag",
       "daysUntil": "Over {days, plural, =1 {1 dag} other {# dagen}}",
       "daysOverdue": "{days, plural, =1 {1 dag te laat} other {# dagen te laat}}",
+      "moreCount": "+ {count, plural, =1 {1 andere} other {# andere}}",
       "buckets": {
         "overdue": "Te laat",
         "j7": "Deze week",

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -723,6 +723,11 @@
       "toastCreated": "Vaste kost toegevoegd",
       "toastUpdated": "Vaste kost bijgewerkt",
       "toastDeleted": "Vaste kost verwijderd",
+      "toastMarkedPaid": "Factuur als betaald gemarkeerd",
+      "toastMarkedUnpaid": "Factuur als te betalen gemarkeerd",
+      "markPaidAria": "{label} als betaald markeren",
+      "unmarkPaidAria": "{label} als te betalen markeren",
+      "paidSummary": "Deze maand betaald: {paid}/{total} · nog {remaining}",
       "drawer": {
         "title": "Vaste kost bewerken",
         "save": "Opslaan",

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -728,6 +728,7 @@
       "markPaidAria": "{label} als betaald markeren",
       "unmarkPaidAria": "{label} als te betalen markeren",
       "paidSummary": "Deze maand betaald: {paid}/{total} · nog {remaining}",
+      "paidHint": "Vink de facturen aan die je deze maand al betaald hebt.",
       "drawer": {
         "title": "Vaste kost bewerken",
         "save": "Opslaan",

--- a/src/app/[locale]/app/charges/ChargesClient.tsx
+++ b/src/app/[locale]/app/charges/ChargesClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useMemo, useState, useTransition } from 'react';
-import { Pencil, Plus, Repeat, Trash2 } from 'lucide-react';
+import { useMemo, useOptimistic, useState, useTransition } from 'react';
+import { Check, Pencil, Plus, Repeat, Trash2 } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 
 import { Button } from '@/components/ui/button';
@@ -18,6 +18,7 @@ import {
 import { toast } from '@/components/ui/toast';
 import type { Locale } from '@/i18n/routing';
 import { createChargeAction, deleteChargeAction } from '@/lib/actions/charges';
+import { togglePaymentAction } from '@/lib/actions/charge-payments';
 import { isNextControlFlowError } from '@/lib/actions/next-control-flow';
 import { nextDueDateForCharge, paymentMonthsFromFrequency } from '@/lib/domain/charges';
 import { formatCurrency, formatDate, formatMonth } from '@/lib/i18n/formatters';
@@ -68,6 +69,10 @@ type ChargesClientProps = {
   monthlyProvisionTotal: number;
   /** Annual equivalent of all active charges. */
   annualTotal: number;
+  /** Charge IDs already settled for `currentPeriod` (seeds the Payé toggle). */
+  paidChargeIds: string[];
+  /** Current period (Europe/Brussels), the toggle's write target. */
+  currentPeriod: { year: number; month: number };
 };
 
 export function ChargesClient({
@@ -75,6 +80,8 @@ export function ChargesClient({
   subtotals,
   monthlyProvisionTotal,
   annualTotal,
+  paidChargeIds,
+  currentPeriod,
 }: ChargesClientProps) {
   const t = useTranslations('app.charges');
   const tFreq = useTranslations('common.frequency');
@@ -105,6 +112,52 @@ export function ChargesClient({
       })).filter((group) => group.rows.length > 0),
     [charges],
   );
+
+  // Optimistic "Payé" state (plan-reviewer CR-1): `useOptimistic` seeds from
+  // the server `paidChargeIds` and reconciles automatically once the action's
+  // `revalidateAppPath('charges')` re-renders the page — no double source of
+  // truth. On a failed toggle the DB is unchanged, so the base stays the same
+  // and the optimistic flip rolls back when the transition settles.
+  const paidBase = useMemo(() => new Set(paidChargeIds), [paidChargeIds]);
+  const [optimisticPaid, applyOptimisticPaid] = useOptimistic(
+    paidBase,
+    (current: ReadonlySet<string>, chargeId: string) => {
+      const next = new Set(current);
+      if (next.has(chargeId)) next.delete(chargeId);
+      else next.add(chargeId);
+      return next;
+    },
+  );
+
+  // Active charges due in the current period — the only ones exposing a toggle
+  // (Phase 2 limit: a charge not due this month has no toggle, cf. plan CR-2).
+  const dueThisMonth = useMemo(
+    () => charges.filter((c) => c.isActive && c.paymentMonths.includes(currentPeriod.month)),
+    [charges, currentPeriod.month],
+  );
+
+  function onTogglePaid(c: RawCharge) {
+    startTransition(async () => {
+      applyOptimisticPaid(c.id);
+      try {
+        const result = await togglePaymentAction({
+          chargeId: c.id,
+          periodYear: currentPeriod.year,
+          periodMonth: currentPeriod.month,
+        });
+        if (result.ok) {
+          toast.success(result.data.paid ? t('toastMarkedPaid') : t('toastMarkedUnpaid'));
+        } else {
+          toast.error(translateError(result.errorCode));
+        }
+      } catch (err) {
+        if (isNextControlFlowError(err)) throw err;
+        // eslint-disable-next-line no-console
+        console.error('togglePaymentAction threw', err);
+        toast.error(translateError('errors.charges.payments.toggleFailed'));
+      }
+    });
+  }
 
   function onCreate(e: React.FormEvent) {
     e.preventDefault();
@@ -201,6 +254,8 @@ export function ChargesClient({
    * (`pr-24` reserves their space) and become inline cells 5/6 on desktop.
    */
   function renderChargeRow(c: RawCharge) {
+    const isDue = c.isActive && c.paymentMonths.includes(currentPeriod.month);
+    const paid = optimisticPaid.has(c.id);
     return (
       <li
         key={c.id}
@@ -209,8 +264,34 @@ export function ChargesClient({
         // absolute edit/delete buttons (top-2 + size-11 = 52px) now that the
         // card padding (`p-4`) is gone — prevents the tap targets overflowing
         // onto the next row on very short content (mobile-ios-auditor F3).
-        className="md:hover:bg-surface-muted relative min-h-13 px-3 py-3 pr-24 transition-colors md:grid md:min-h-0 md:grid-cols-[minmax(8rem,10rem)_minmax(0,1fr)_4.5rem_7rem_auto_auto] md:items-baseline md:gap-4 md:px-4 md:py-3 md:pr-2"
+        // Due-this-month rows reserve left room (`pl-14`/`md:pl-12`) for the
+        // absolutely-positioned Payé toggle — keeps the 6-col desktop grid and
+        // its baseline contract untouched (plan-reviewer CR-3).
+        className={`md:hover:bg-surface-muted relative min-h-13 py-3 pr-24 transition-colors md:grid md:min-h-0 md:grid-cols-[minmax(8rem,10rem)_minmax(0,1fr)_4.5rem_7rem_auto_auto] md:items-baseline md:gap-4 md:py-3 md:pr-2 ${isDue ? 'pl-14 md:pl-12' : 'px-3 md:px-4'}`}
       >
+        {/* Payé toggle — absolute left for due-this-month charges. Lives
+            outside the grid + the mobile flow so it never disturbs the four
+            baseline-measured cells. 44px touch target on mobile. */}
+        {isDue && (
+          <button
+            type="button"
+            onClick={() => onTogglePaid(c)}
+            disabled={isPending}
+            aria-pressed={paid}
+            aria-label={
+              paid ? t('unmarkPaidAria', { label: c.label }) : t('markPaidAria', { label: c.label })
+            }
+            data-testid={`charges-row-paid-${c.id}`}
+            className={`absolute top-2 left-2 flex size-11 items-center justify-center rounded-full border-2 transition-colors md:top-1/2 md:left-3 md:size-7 md:-translate-y-1/2 ${
+              paid
+                ? 'border-brand-600 bg-brand-600 text-white'
+                : 'border-border hover:border-brand-600 text-transparent'
+            }`}
+          >
+            <Check className="h-4 w-4 md:h-3.5 md:w-3.5" strokeWidth={3} aria-hidden />
+          </button>
+        )}
+
         {/* Mobile: header row (next-due + amount on a single line).
             Desktop: contents — projects next-due + amount as grid cells 1 / 4. */}
         <div className="flex items-baseline justify-between gap-3 md:contents">
@@ -222,7 +303,7 @@ export function ChargesClient({
           </span>
           <span
             data-testid="charges-row-amount"
-            className="text-foreground shrink-0 text-base font-semibold tabular-nums md:order-4 md:text-right md:text-sm md:font-medium"
+            className={`shrink-0 text-base font-semibold tabular-nums md:order-4 md:text-right md:text-sm md:font-medium ${paid ? 'text-muted-foreground line-through' : 'text-foreground'}`}
           >
             {formatCurrency(c.amount, locale)}
           </span>
@@ -296,6 +377,13 @@ export function ChargesClient({
       </li>
     );
   }
+
+  // "Ce mois" summary, derived from the optimistic paid set so it updates the
+  // instant a toggle is hit (distinct from the smoothed "Effort lissé" total).
+  const paidThisMonthCount = dueThisMonth.filter((c) => optimisticPaid.has(c.id)).length;
+  const remainingThisMonth = dueThisMonth
+    .filter((c) => !optimisticPaid.has(c.id))
+    .reduce((sum, c) => sum + c.amount, 0);
 
   return (
     <div className="flex flex-col gap-6">
@@ -447,6 +535,21 @@ export function ChargesClient({
                   );
                 })}
               </div>
+
+              {/* "Ce mois" payment summary — paid count + remaining cash due
+                  this period. Distinct from the smoothed effort total below. */}
+              {dueThisMonth.length > 0 && (
+                <p
+                  data-testid="charges-paid-summary"
+                  className="bg-surface-muted text-muted-foreground mt-6 rounded-lg px-3 py-2.5 text-sm"
+                >
+                  {t('paidSummary', {
+                    paid: paidThisMonthCount,
+                    total: dueThisMonth.length,
+                    remaining: formatCurrency(remainingThisMonth, locale),
+                  })}
+                </p>
+              )}
 
               {/* Global total — the headline @thierry asked for ("on ne voit
                   jamais le total des factures en bas"). The smoothed monthly

--- a/src/app/[locale]/app/charges/ChargesClient.tsx
+++ b/src/app/[locale]/app/charges/ChargesClient.tsx
@@ -209,7 +209,7 @@ export function ChargesClient({
         // absolute edit/delete buttons (top-2 + size-11 = 52px) now that the
         // card padding (`p-4`) is gone — prevents the tap targets overflowing
         // onto the next row on very short content (mobile-ios-auditor F3).
-        className="md:hover:bg-surface-muted relative min-h-13 py-3 pr-24 transition-colors md:grid md:min-h-0 md:grid-cols-[minmax(8rem,10rem)_minmax(0,1fr)_4.5rem_7rem_auto_auto] md:items-baseline md:gap-4 md:px-2 md:py-3 md:pr-2"
+        className="md:hover:bg-surface-muted relative min-h-13 px-3 py-3 pr-24 transition-colors md:grid md:min-h-0 md:grid-cols-[minmax(8rem,10rem)_minmax(0,1fr)_4.5rem_7rem_auto_auto] md:items-baseline md:gap-4 md:px-4 md:py-3 md:pr-2"
       >
         {/* Mobile: header row (next-due + amount on a single line).
             Desktop: contents — projects next-due + amount as grid cells 1 / 4. */}
@@ -412,23 +412,37 @@ export function ChargesClient({
                       data-testid={`charges-group-${freq}`}
                       aria-labelledby={headingId}
                     >
-                      <div className="border-border/40 flex items-baseline justify-between gap-3 border-b pb-2">
-                        <h2
-                          id={headingId}
-                          className="text-muted-foreground text-sm font-semibold tracking-wide"
-                        >
-                          {tFreq(freq)}
-                        </h2>
-                        <span
-                          data-testid={`charges-group-subtotal-${freq}`}
-                          className="text-muted-foreground text-sm tabular-nums"
-                        >
-                          {t('subtotalLabel')} {formatCurrency(subtotals[freq], locale)}
+                      {/* Group header — neutral recurrence icon + frequency +
+                          item count, adopting the cockpit "Prochaines factures"
+                          card language. The subtotal moves BELOW the list
+                          (validated @thierry 2026-06-04: total read after the
+                          rows, coloured for impact). */}
+                      <h2
+                        id={headingId}
+                        className="text-muted-foreground mb-2 flex items-center gap-2 text-xs font-semibold tracking-wide uppercase"
+                      >
+                        <Repeat aria-hidden strokeWidth={1.5} className="h-4 w-4" />
+                        {tFreq(freq)}
+                        <span className="text-muted-foreground/70 ml-0.5 text-[11px] font-medium normal-case">
+                          {t('count', { count: rows.length })}
                         </span>
-                      </div>
-                      <ul role="list" className="divide-border/40 divide-y">
+                      </h2>
+                      <ul
+                        role="list"
+                        className="border-border divide-border/60 divide-y overflow-hidden rounded-xl border"
+                      >
                         {rows.map((c) => renderChargeRow(c))}
                       </ul>
+                      {/* Subtotal — below the list, coloured brand for impact. */}
+                      <p
+                        data-testid={`charges-group-subtotal-${freq}`}
+                        className="mt-2 flex items-baseline justify-end gap-1.5 px-1"
+                      >
+                        <span className="text-muted-foreground text-xs">{t('subtotalLabel')}</span>
+                        <span className="text-brand-700 text-sm font-semibold tabular-nums">
+                          {formatCurrency(subtotals[freq], locale)}
+                        </span>
+                      </p>
                     </section>
                   );
                 })}

--- a/src/app/[locale]/app/charges/ChargesClient.tsx
+++ b/src/app/[locale]/app/charges/ChargesClient.tsx
@@ -267,7 +267,7 @@ export function ChargesClient({
         // Due-this-month rows reserve left room (`pl-14`/`md:pl-12`) for the
         // absolutely-positioned Payé toggle — keeps the 6-col desktop grid and
         // its baseline contract untouched (plan-reviewer CR-3).
-        className={`md:hover:bg-surface-muted relative min-h-13 py-3 pr-24 transition-colors md:grid md:min-h-0 md:grid-cols-[minmax(8rem,10rem)_minmax(0,1fr)_4.5rem_7rem_auto_auto] md:items-baseline md:gap-4 md:py-3 md:pr-2 ${isDue ? 'pl-14 md:pl-12' : 'px-3 md:px-4'}`}
+        className={`md:hover:bg-surface-muted relative min-h-14 py-3 pr-24 transition-colors md:grid md:min-h-0 md:grid-cols-[minmax(8rem,10rem)_minmax(0,1fr)_4.5rem_7rem_auto_auto] md:items-baseline md:gap-4 md:py-3 md:pr-2 ${isDue ? 'pl-14 md:pl-12' : 'px-3 md:px-4'}`}
       >
         {/* Payé toggle — absolute left for due-this-month charges. Lives
             outside the grid + the mobile flow so it never disturbs the four
@@ -282,7 +282,7 @@ export function ChargesClient({
               paid ? t('unmarkPaidAria', { label: c.label }) : t('markPaidAria', { label: c.label })
             }
             data-testid={`charges-row-paid-${c.id}`}
-            className={`absolute top-2 left-2 flex size-11 items-center justify-center rounded-full border-2 transition-colors md:top-1/2 md:left-3 md:size-7 md:-translate-y-1/2 ${
+            className={`focus-visible:ring-brand-600 absolute top-2 left-2 flex size-11 cursor-pointer items-center justify-center rounded-full border-2 transition-colors [-webkit-tap-highlight-color:transparent] focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:top-1/2 md:left-3 md:size-7 md:-translate-y-1/2 ${
               paid
                 ? 'border-brand-600 bg-brand-600 text-white'
                 : 'border-border hover:border-brand-600 text-transparent'
@@ -402,6 +402,7 @@ export function ChargesClient({
               <Label htmlFor="label">{t('labelLabel')}</Label>
               <Input
                 id="label"
+                autoComplete="off"
                 value={label}
                 onChange={(e) => setLabel(e.target.value)}
                 required
@@ -413,6 +414,7 @@ export function ChargesClient({
               <Input
                 id="amount"
                 type="number"
+                autoComplete="off"
                 inputMode="decimal"
                 min={0}
                 step="0.01"
@@ -456,6 +458,7 @@ export function ChargesClient({
               <Input
                 id="paymentDay"
                 type="number"
+                autoComplete="off"
                 inputMode="numeric"
                 min={1}
                 max={31}

--- a/src/app/[locale]/app/charges/ChargesClient.tsx
+++ b/src/app/[locale]/app/charges/ChargesClient.tsx
@@ -489,6 +489,13 @@ export function ChargesClient({
             </p>
           ) : (
             <>
+              {/* One-time hint teaching the Payé toggle convention
+                  (dashboard-ux F2) — only when a charge is due this month. */}
+              {dueThisMonth.length > 0 && (
+                <p className="text-muted-foreground mb-4 text-xs" data-testid="charges-paid-hint">
+                  {t('paidHint')}
+                </p>
+              )}
               {/* `charges-list` is now a wrapper holding one <section> per
                   non-empty frequency group. The only `listitem`s remain the
                   charge rows inside each group's <ul>, so the total count

--- a/src/app/[locale]/app/charges/__tests__/ChargesClient.test.tsx
+++ b/src/app/[locale]/app/charges/__tests__/ChargesClient.test.tsx
@@ -432,6 +432,11 @@ describe('Factures Phase 2 — Payé toggle', () => {
     renderCharges([monthlyCharge], { currentPeriod: { year: 2026, month: 1 } });
     expect(screen.getByTestId('charges-paid-summary')).toBeInTheDocument();
   });
+
+  it('renders the paid-toggle hint when charges are due this month', () => {
+    renderCharges([monthlyCharge], { currentPeriod: { year: 2026, month: 1 } });
+    expect(screen.getByTestId('charges-paid-hint')).toBeInTheDocument();
+  });
 });
 
 describe('app.charges — i18n parity (5 locales, PR-BETA-CLEANUP-2)', () => {
@@ -453,6 +458,7 @@ describe('app.charges — i18n parity (5 locales, PR-BETA-CLEANUP-2)', () => {
             markPaidAria?: string;
             unmarkPaidAria?: string;
             paidSummary?: string;
+            paidHint?: string;
             drawer?: {
               title?: string;
               save?: string;
@@ -487,6 +493,7 @@ describe('app.charges — i18n parity (5 locales, PR-BETA-CLEANUP-2)', () => {
       expect((c.paidSummary ?? '').includes('{paid}')).toBe(true);
       expect((c.paidSummary ?? '').includes('{total}')).toBe(true);
       expect((c.paidSummary ?? '').includes('{remaining}')).toBe(true);
+      expect((c.paidHint ?? '').length).toBeGreaterThan(0);
     },
   );
 });

--- a/src/app/[locale]/app/charges/__tests__/ChargesClient.test.tsx
+++ b/src/app/[locale]/app/charges/__tests__/ChargesClient.test.tsx
@@ -22,11 +22,16 @@ const deleteChargeMock = vi.hoisted(() => vi.fn());
 const toastSuccessMock = vi.hoisted(() => vi.fn());
 const toastErrorMock = vi.hoisted(() => vi.fn());
 const routerRefreshMock = vi.hoisted(() => vi.fn());
+const togglePaymentMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/actions/charges', () => ({
   createChargeAction: createChargeMock,
   updateChargeAction: updateChargeMock,
   deleteChargeAction: deleteChargeMock,
+}));
+
+vi.mock('@/lib/actions/charge-payments', () => ({
+  togglePaymentAction: togglePaymentMock,
 }));
 
 vi.mock('@/components/ui/toast', () => ({
@@ -71,6 +76,8 @@ function renderCharges(
       subtotals={overrides.subtotals ?? ZERO_SUBTOTALS}
       monthlyProvisionTotal={overrides.monthlyProvisionTotal ?? 0}
       annualTotal={overrides.annualTotal ?? 0}
+      paidChargeIds={overrides.paidChargeIds ?? []}
+      currentPeriod={overrides.currentPeriod ?? { year: 2026, month: 1 }}
     />,
   );
 }
@@ -110,6 +117,7 @@ describe('<ChargesClient /> — PR-BETA-1 visual refactor', () => {
     toastSuccessMock.mockReset();
     toastErrorMock.mockReset();
     routerRefreshMock.mockReset();
+    togglePaymentMock.mockReset();
   });
 
   it('shows the empty-state copy when no charges are provided', () => {
@@ -195,6 +203,7 @@ describe('<ChargesClient /> — PR-BETA-CLEANUP-2 list & form', () => {
     toastSuccessMock.mockReset();
     toastErrorMock.mockReset();
     routerRefreshMock.mockReset();
+    togglePaymentMock.mockReset();
   });
 
   it('renders the next-due column with a locale-aware date for active charges', () => {
@@ -240,6 +249,7 @@ describe('<ChargesClient /> — PR-BETA-CLEANUP-2 edit drawer', () => {
     toastSuccessMock.mockReset();
     toastErrorMock.mockReset();
     routerRefreshMock.mockReset();
+    togglePaymentMock.mockReset();
   });
 
   it('opens the drawer when the Modifier button is clicked', async () => {
@@ -297,6 +307,7 @@ describe('<ChargesClient /> — PR-UI-3a grouping & totals', () => {
     toastSuccessMock.mockReset();
     toastErrorMock.mockReset();
     routerRefreshMock.mockReset();
+    togglePaymentMock.mockReset();
   });
 
   it('renders one section per non-empty frequency group, in fixed order, hiding empty groups', () => {
@@ -362,6 +373,67 @@ describe('<ChargesClient /> — PR-UI-3a grouping & totals', () => {
   });
 });
 
+describe('Factures Phase 2 — Payé toggle', () => {
+  const monthlyCharge = sampleCharges[0]!; // paymentMonths 1..12 → due every month
+
+  it('hides the toggle for a charge not due in the current period', () => {
+    const annualJune = {
+      ...monthlyCharge,
+      id: 'an1',
+      frequency: 'annual',
+      paymentMonths: [6] as readonly number[],
+    };
+    renderCharges([annualJune], { currentPeriod: { year: 2026, month: 1 } });
+    expect(screen.queryByTestId('charges-row-paid-an1')).not.toBeInTheDocument();
+  });
+
+  it('reflects the seeded paid state via aria-pressed', () => {
+    renderCharges([monthlyCharge], {
+      paidChargeIds: [monthlyCharge.id],
+      currentPeriod: { year: 2026, month: 1 },
+    });
+    expect(screen.getByTestId(`charges-row-paid-${monthlyCharge.id}`)).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
+  it('toggles paid optimistically and calls the action with the current period', async () => {
+    togglePaymentMock.mockResolvedValue({ ok: true, data: { paid: true, paidAmount: 1200 } });
+    renderCharges([monthlyCharge], { currentPeriod: { year: 2026, month: 3 } });
+    const toggle = screen.getByTestId(`charges-row-paid-${monthlyCharge.id}`);
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+    await waitFor(() =>
+      expect(togglePaymentMock).toHaveBeenCalledWith({
+        chargeId: monthlyCharge.id,
+        periodYear: 2026,
+        periodMonth: 3,
+      }),
+    );
+    await waitFor(() => expect(toastSuccessMock).toHaveBeenCalled());
+  });
+
+  it('shows an error toast when the toggle fails', async () => {
+    togglePaymentMock.mockResolvedValue({
+      ok: false,
+      errorCode: 'errors.charges.payments.toggleFailed',
+    });
+    renderCharges([monthlyCharge], { currentPeriod: { year: 2026, month: 1 } });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId(`charges-row-paid-${monthlyCharge.id}`));
+    });
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalled());
+  });
+
+  it('renders the "ce mois" paid summary when charges are due', () => {
+    renderCharges([monthlyCharge], { currentPeriod: { year: 2026, month: 1 } });
+    expect(screen.getByTestId('charges-paid-summary')).toBeInTheDocument();
+  });
+});
+
 describe('app.charges — i18n parity (5 locales, PR-BETA-CLEANUP-2)', () => {
   it.each(['fr-BE', 'en', 'de-DE', 'es-ES', 'nl-BE'] as const)(
     'locale %s exposes paymentDay + edit + drawer + total keys',
@@ -376,6 +448,11 @@ describe('app.charges — i18n parity (5 locales, PR-BETA-CLEANUP-2)', () => {
             subtotalLabel?: string;
             totalMonthlyLabel?: string;
             totalAnnualLabel?: string;
+            toastMarkedPaid?: string;
+            toastMarkedUnpaid?: string;
+            markPaidAria?: string;
+            unmarkPaidAria?: string;
+            paidSummary?: string;
             drawer?: {
               title?: string;
               save?: string;
@@ -402,6 +479,14 @@ describe('app.charges — i18n parity (5 locales, PR-BETA-CLEANUP-2)', () => {
       expect(c.drawer?.saving).toBeTypeOf('string');
       expect(c.drawer?.cancel).toBeTypeOf('string');
       expect(c.drawer?.errorGeneric).toBeTypeOf('string');
+      // Factures Phase 2 (Payé toggle) — keys present + placeholder integrity.
+      expect((c.toastMarkedPaid ?? '').length).toBeGreaterThan(0);
+      expect((c.toastMarkedUnpaid ?? '').length).toBeGreaterThan(0);
+      expect((c.markPaidAria ?? '').includes('{label}')).toBe(true);
+      expect((c.unmarkPaidAria ?? '').includes('{label}')).toBe(true);
+      expect((c.paidSummary ?? '').includes('{paid}')).toBe(true);
+      expect((c.paidSummary ?? '').includes('{total}')).toBe(true);
+      expect((c.paidSummary ?? '').includes('{remaining}')).toBe(true);
     },
   );
 });

--- a/src/app/[locale]/app/charges/page.tsx
+++ b/src/app/[locale]/app/charges/page.tsx
@@ -21,6 +21,13 @@ export default async function ChargesPage() {
   // per-group subtotals reconcile with the global smoothed/annual totals.
   const subtotals = subtotalByFrequency(snapshot.charges);
 
+  // Charge IDs already settled for the current period — seeds the "Payé"
+  // toggle. `currentMonthPayments` is already scoped server-side to the current
+  // Europe/Brussels month (same period the toggle writes to). The action
+  // re-verifies workspace ownership before any write — these IDs are not
+  // trusted authz input, just optimistic-UI seed data the user already owns.
+  const paidChargeIds = snapshot.currentMonthPayments.map((p) => p.chargeId);
+
   return (
     <ChargesClient
       charges={snapshot.rawCharges}
@@ -32,6 +39,8 @@ export default async function ChargesPage() {
       }}
       monthlyProvisionTotal={monthlyProvisionTotal(snapshot.charges).toNumber()}
       annualTotal={annualTotal(snapshot.charges).toNumber()}
+      paidChargeIds={paidChargeIds}
+      currentPeriod={snapshot.currentPeriod}
     />
   );
 }

--- a/src/components/dashboard/ProchainesFacturesCard.tsx
+++ b/src/components/dashboard/ProchainesFacturesCard.tsx
@@ -131,6 +131,13 @@ type BucketTone = 'danger' | 'warning' | 'info' | 'success';
 type BucketKey = keyof UpcomingByBucket;
 type LucideIcon = typeof AlertCircle;
 
+/**
+ * Cap the rows rendered per bucket — the "Mois prochain" (J-30) window can list
+ * a dozen bills, which buries the actionable near-term ones. Overflow collapses
+ * to a "+N autres" link to the full /app/charges page (@thierry 2026-06-04).
+ */
+const MAX_VISIBLE_PER_BUCKET = 4;
+
 const TONE_CLASSES: Record<BucketTone, { text: string; bg: string; chip: string }> = {
   danger: {
     text: 'text-danger',
@@ -204,7 +211,7 @@ function Bucket({
        * amount lock the visual rhythm regardless of content width.
        */}
       <ul className="divide-border divide-y rounded-md border">
-        {items.map((item) => (
+        {items.slice(0, MAX_VISIBLE_PER_BUCKET).map((item) => (
           <li
             key={`${item.charge.id}-${item.dueDateIso}`}
             className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-3 px-3 py-2"
@@ -231,6 +238,15 @@ function Bucket({
           </li>
         ))}
       </ul>
+      {items.length > MAX_VISIBLE_PER_BUCKET && (
+        <Link
+          href="/app/charges"
+          className="text-brand-700 hover:text-brand-800 focus-visible:ring-brand-600 mt-1.5 inline-flex rounded-md text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none"
+          data-testid={`prochaines-factures-more-${bucket}`}
+        >
+          {t('moreCount', { count: items.length - MAX_VISIBLE_PER_BUCKET })}
+        </Link>
+      )}
     </section>
   );
 }

--- a/src/components/dashboard/ProchainesFacturesCard.tsx
+++ b/src/components/dashboard/ProchainesFacturesCard.tsx
@@ -67,7 +67,7 @@ export async function ProchainesFacturesCard({ charges, payments, todayIso, loca
         </div>
         <Link
           href="/app/charges"
-          className="text-brand-700 hover:text-brand-800 focus-visible:ring-brand-600 inline-flex shrink-0 items-center gap-1 rounded-md text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+          className="text-brand-700 hover:text-brand-800 focus-visible:ring-brand-600 inline-flex min-h-11 shrink-0 items-center gap-1 rounded-md text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
           data-testid="prochaines-factures-link-all"
         >
           {t('viewAll')}
@@ -241,7 +241,7 @@ function Bucket({
       {items.length > MAX_VISIBLE_PER_BUCKET && (
         <Link
           href="/app/charges"
-          className="text-brand-700 hover:text-brand-800 focus-visible:ring-brand-600 mt-1.5 inline-flex rounded-md text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none"
+          className="text-brand-700 hover:text-brand-800 focus-visible:ring-brand-600 mt-1.5 inline-flex min-h-11 items-center rounded-md px-1 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none"
           data-testid={`prochaines-factures-more-${bucket}`}
         >
           {t('moreCount', { count: items.length - MAX_VISIBLE_PER_BUCKET })}

--- a/src/components/dashboard/__tests__/ProchainesFacturesCard.test.tsx
+++ b/src/components/dashboard/__tests__/ProchainesFacturesCard.test.tsx
@@ -139,6 +139,20 @@ describe('<ProchainesFacturesCard /> (THI-192 cockpit v3 #5)', () => {
     expect(rows[2]?.textContent).toContain('A');
   });
 
+  it('caps a bucket at 4 visible rows and surfaces a "+N autres" link', async () => {
+    // 6 charges all falling in j7 (today=2026-05-10, paymentDay 11..16 → 1..6d).
+    const charges = [11, 12, 13, 14, 15, 16].map((day, i) =>
+      makeCharge({ id: `j7-${i}`, label: `Bill ${i}`, paymentDay: day }),
+    );
+    await renderCard({ charges });
+    const bucket = screen.getByTestId('prochaines-factures-bucket-j7');
+    expect(bucket.querySelectorAll('li')).toHaveLength(4);
+    expect(screen.getByTestId('prochaines-factures-more-j7')).toHaveAttribute(
+      'href',
+      '/app/charges',
+    );
+  });
+
   it('renders a per-bucket total amount in EUR', async () => {
     await renderCard({
       charges: [


### PR DESCRIPTION
## Factures Phase 2 — Payé toggle + redesign + dashboard trim

Branche l'UI manquante sur le **backend de paiement déjà construit + testé** (la « PR-D4 Phase 2 UI » jamais livrée), applique le redesign visuel **validé par @thierry**, et trimme le dashboard.

### 3 commits atomiques (plan-reviewer CR-4)
1. **Redesign** : liste encadrée arrondie par groupe fréquence, en-tête icône+compteur, sous-total déplacé en bas + coloré brand. Ton neutre (lock THI-299).
2. **Payé toggle** : par ligne due ce mois → `togglePaymentAction` (existant : authz workspace, rate-limit, audit). `useOptimistic` (flip instantané + rollback natif). Ligne payée atténuée+barrée. Résumé « ce mois » (X/Y · reste). **Backend inchangé.**
3. **Trim dashboard** : chaque bucket « Prochaines factures » plafonné à 4 + « +N autres ».

### plan-reviewer 🟡 → APPROVED (4 CR intégrés)
useOptimistic · limite documentée · tests existants nommés · commits atomiques. Doc : `docs/plans/factures-phase2-paid-toggle-design.md`.

### Gates
typecheck · lint · lint:use-server · **1429 tests** · build. i18n ×5 (NL/DE/ES traduits, glossaire). Tous les testids préservés.

### Restant (DoD)
- [ ] Validation visuelle @thierry (preview Vercel — desktop+mobile, **clique le toggle**)
- [ ] QA agents (dashboard-ux, mobile-ios, i18n, security)
- [ ] DoD5 → merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
