### PR TITLE
feat(charges): payment-aware due-date + backfill payment_months (THI-329)

### DIFF
--- a/docs/plans/pr-a-payment-aware-due-date.md
+++ b/docs/plans/pr-a-payment-aware-due-date.md
@@ -1,0 +1,83 @@
+# PR-A — Cadence backfill + payment-aware due-date (THI-329 + epic factures)
+
+> Plan @cc-ankora 2026-06-05. Voie LOURDE (migration + domaine) → plan-reviewer obligatoire.
+> Ticket : THI-329 (statut payé + next-due qui ignore les occurrences payées).
+> Spec epic : `docs/plans/epic-factures-coherentes-spec.md`.
+
+## Goal
+
+Corriger à la racine les dates de factures incohérentes, **sans toucher** `nextDueDateForCharge` (**2 call-sites prod** : `upcoming.ts` repointé ici, `ChargesClient.tsx` en PR-B). Deux leviers :
+
+1. **Backfill data** : `payment_months` recomputé pour les charges non-mensuelles mal stockées (S.W.D.E `[1]` → `[1,4,7,10]`).
+2. **Domaine payment-aware** : nouvelle fonction « prochaine occurrence NON PAYÉE » → câblée dans le dashboard.
+
+## Scope (PR-A — dashboard + data uniquement ; page charges = PR-B)
+
+1. **Migration backfill** `payment_months` via `paymentMonthsFromFrequency(frequency, due_month)` pour les charges où l'array ne correspond pas à la fréquence (les mensuelles `[1..12]` ne bougent pas). Idempotente, pas de RLS touchée.
+2. **Domaine** `nextUnpaidDueDate(charge, payments, fromIso)` (pur, NOUVEAU) :
+   - itère les occurrences depuis le mois courant (offset 0..24) ;
+   - **saute** les occurrences déjà payées (`payments.has(chargeId-year-month)`) ;
+   - retourne la 1re occurrence NON payée : `{ dueDateIso, isOverdue: dueDateIso < fromIso }` ;
+   - ne saute PAS l'occurrence du mois courant si son jour est passé + non payée (→ `isOverdue`).
+   - `null` si tout payé dans la fenêtre OU charge inactive/`paymentMonths` vide.
+   - **NE modifie PAS** `nextDueDateForCharge` (reste pour ses autres call-sites).
+3. **Câblage dashboard** : `getUpcomingCharges` (`upcoming.ts`) utilise `nextUnpaidDueDate` au lieu de `nextDueDateForCharge`. Effet : Impôt juin payé → roule à juillet ; Taxe voiture juin non payée → bucket `overdue` ; S.W.D.E → date correcte. La carte `ProchainesFacturesCard` reçoit déjà `payments`.
+4. i18n : aucune nouvelle clé requise (bucket `overdue` existe déjà). À confirmer.
+
+## Non-goals (→ PR-B/C/D)
+
+- Page charges (badges, toggle, redesign, marqueur `is_watched`) → PR-B (carry #221).
+- Reset + alerte oubli → PR-C. CadenceField → PR-D.
+- Ne PAS modifier `nextDueDateForCharge`. Ne PAS déduire les payées du total lissé.
+
+## Fichiers
+
+- `supabase/migrations/YYYYMMDD_backfill_payment_months.sql` (CREATE)
+- `src/lib/domain/charges/next-unpaid-due-date.ts` (CREATE) + `__tests__/` (CREATE)
+- `src/lib/domain/charges/index.ts` (export)
+- `src/lib/domain/charges/upcoming.ts` (MODIFY — utilise nextUnpaidDueDate ; signature `getUpcomingCharges` inchangée, elle a déjà `payments`)
+- `src/lib/domain/charges/__tests__/upcoming.test.ts` (MODIFY — cas payé→roule, non-payé-passé→overdue, S.W.D.E-like backfillé)
+
+## Logique (réconcilie THI-329 + feedback session)
+
+```
+nextUnpaidDueDate(charge, payments, fromIso):
+  for offset in 0..23:
+    (y, m) = currentMonth + offset
+    if m not in paymentMonths: continue
+    if payments.get(`${id}-${y}-${m}`) === true: continue   // skip paid
+    day = min(paymentDay, daysInMonth(y,m))
+    due = `${y}-${pad(m)}-${pad(day)}`
+    return { dueDateIso: due, isOverdue: due < fromIso }
+  return null
+```
+
+- Impôt juin payé → offset 0 sauté → juillet (pas overdue). ✓
+- Taxe voiture juin non payée → offset 0 → juin, isOverdue. ✓
+- S.W.D.E backfillé [1,4,7,10], non payé, juin → juillet. ✓ (ancre perfectionnée plus tard via CadenceField PR-D)
+
+## Risk tiering / QA
+
+Voie LOURDE : migration + domaine. Agents : **plan-reviewer** (ce doc), **financial-formula-validator** (nextUnpaidDueDate + upcoming), **rls-flow-tester** (migration — backfill, pas de RLS touchée mais confirmer), **dashboard-ux-auditor** (Prochaines factures), **test-runner**. `security-auditor` non requis (pas d'action/authz nouvelle). `i18n-auditor` si nouvelle clé.
+
+## Migration — prudence
+
+- `UPDATE charges SET payment_months = <recompute> WHERE payment_months <> <recompute>` — recompute en SQL OU script de migration. Préférer une fonction SQL inline reproduisant `paymentMonthsFromFrequency` (monthly=[1..12], quarterly=[a,a+3,a+6,a+9] mod 12, semiannual=[a,a+6], annual=[a]) pour rester déterministe. Vérifier sur copie avant prod. Pas de DELETE, pas de perte.
+- @thierry corrigera les ANCRES réelles (S.W.D.E mai) via CadenceField (PR-D) — le backfill ne devine pas l'ancre, il dé-casse seulement (un seul mois → la cadence complète).
+
+## DoD
+
+typecheck · lint · lint:use-server · test · build · QA agents · Sourcery silencieux · DoD5 · rapport `docs/prs/PR-epic-factures-A-report.md`.
+
+## Smoke @thierry
+
+Dashboard `/app` : « Prochaines factures » — Impôt (juin payé) n'apparaît plus en juin (roulé) ; Taxe voiture (juin non payée) en « En retard » ; S.W.D.E n'affiche plus janv. 2027.
+
+## Changements plan-reviewer intégrés (🟡 APPROVED WITH CHANGES, 2026-06-05)
+
+- **CR-1 (ledger mono-mois)** : `paymentsLedger` est construit dans `app/page.tsx` depuis `snapshot.currentMonthPayments` (filtré DB sur le mois courant). Donc le skip-paid de `nextUnpaidDueDate` n'a d'effet **que sur l'occurrence du mois courant** — suffisant pour THI-329 (on ne peut pas avoir payé une échéance future). Invariant à documenter en JSDoc. Tests `next-unpaid-due-date.test.ts` : ledger réaliste mono-mois, clé `${id}-${year}-${month}` **sans zero-pad** (format exact `paymentKey()` dans `cockpit/types.ts`).
+- **CR-2 (signature)** : `nextUnpaidDueDate(charge: UpcomingChargeInput & { id: string }, payments: ReadonlyMap<string, boolean>, fromIso: string)` — shape minimal `{ id, paymentMonths, paymentDay, isActive }`, PAS `ChargeRecord`. `id` requis pour la clé ledger.
+- **CR-3** : 2 call-sites prod confirmés (corrigé supra).
+- **Migration** : SQL inline via CTE — `array_agg(DISTINCT ((due_month+o-1)%12)+1 ORDER BY 1)` sur `unnest(ARRAY[0,3,6,9])` (quarterly) / `[0,6]` (semiannual) / `[1..12]` (monthly) / `[due_month]` (annual). UPDATE avec `WHERE c.payment_months IS DISTINCT FROM r.pm` (idempotent, zéro perte, ne touche que les incohérentes). Timestamp migration > `20260528000001`. Owner = RLS bypass (pas de service-role).
+- **upcoming.test.ts** : le test qui documentait l'overdue comme « structurellement inatteignable » est **RÉÉCRIT** (PR-A rend l'overdue atteignable : occurrence courante non payée + passée → bucket overdue).
+- **Hygiène** : créer la branche `feat/thi-329-payment-aware-due-date` depuis `main` AVANT tout code.

--- a/src/lib/domain/charges/__tests__/next-unpaid-due-date.test.ts
+++ b/src/lib/domain/charges/__tests__/next-unpaid-due-date.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+
+import { nextUnpaidDueDate, type PaymentAwareCharge } from '../next-unpaid-due-date';
+
+/**
+ * Ledger key format MUST match `paymentKey()` (cockpit/types.ts):
+ *   `${chargeId}-${year}-${month}`  — NO zero-padding on month.
+ * The ledger is mono-month in production (only the current period is loaded),
+ * so a "paid" entry only ever exists for the current (year, month).
+ */
+const paid = (entries: Array<[string, number, number]>): ReadonlyMap<string, boolean> =>
+  new Map(entries.map(([id, y, m]) => [`${id}-${y}-${m}`, true]));
+
+const charge = (over: Partial<PaymentAwareCharge> = {}): PaymentAwareCharge => ({
+  id: 'c1',
+  paymentMonths: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+  paymentDay: 1,
+  isActive: true,
+  ...over,
+});
+
+describe('nextUnpaidDueDate', () => {
+  it('returns the current-month occurrence as OVERDUE when its day has passed and it is unpaid', () => {
+    // Monthly, day 1, today June 4 → June 1 is past + unpaid.
+    const res = nextUnpaidDueDate(charge(), new Map(), '2026-06-04');
+    expect(res).toEqual({ dueDateIso: '2026-06-01', isOverdue: true });
+  });
+
+  it('rolls to the next occurrence (not overdue) when the current month is already paid', () => {
+    // Monthly, June paid → next unpaid occurrence is July 1.
+    const res = nextUnpaidDueDate(charge(), paid([['c1', 2026, 6]]), '2026-06-04');
+    expect(res).toEqual({ dueDateIso: '2026-07-01', isOverdue: false });
+  });
+
+  it('returns the current-month occurrence (not overdue) when its day is still ahead', () => {
+    const res = nextUnpaidDueDate(charge({ paymentDay: 20 }), new Map(), '2026-06-04');
+    expect(res).toEqual({ dueDateIso: '2026-06-20', isOverdue: false });
+  });
+
+  it('skips months not in paymentMonths (quarterly) → next quarter, not overdue', () => {
+    // Quarterly [1,4,7,10] (post-backfill S.W.D.E), today June → July 1.
+    const res = nextUnpaidDueDate(
+      charge({ paymentMonths: [1, 4, 7, 10] }),
+      new Map(),
+      '2026-06-04',
+    );
+    expect(res).toEqual({ dueDateIso: '2026-07-01', isOverdue: false });
+  });
+
+  it('surfaces an annual bill whose due day just passed as OVERDUE', () => {
+    // Taxe voiture: annual [6], day 1, today June 4 → June 1 overdue.
+    const res = nextUnpaidDueDate(
+      charge({ paymentMonths: [6], paymentDay: 1 }),
+      new Map(),
+      '2026-06-04',
+    );
+    expect(res).toEqual({ dueDateIso: '2026-06-01', isOverdue: true });
+  });
+
+  it('rolls an annual bill to next year when this year occurrence is in the past', () => {
+    // Annual [3] (March), today June → next March is 2027.
+    const res = nextUnpaidDueDate(charge({ paymentMonths: [3] }), new Map(), '2026-06-04');
+    expect(res).toEqual({ dueDateIso: '2027-03-01', isOverdue: false });
+  });
+
+  it('clamps paymentDay to the last day of a short month', () => {
+    // Day 31 in February 2026 (not leap) → 28.
+    const res = nextUnpaidDueDate(
+      charge({ paymentMonths: [2], paymentDay: 31 }),
+      new Map(),
+      '2026-01-01',
+    );
+    expect(res).toEqual({ dueDateIso: '2026-02-28', isOverdue: false });
+  });
+
+  it('handles the year boundary (December → January)', () => {
+    const res = nextUnpaidDueDate(charge({ paymentMonths: [1] }), new Map(), '2026-12-15');
+    expect(res).toEqual({ dueDateIso: '2027-01-01', isOverdue: false });
+  });
+
+  it('returns null for an inactive charge', () => {
+    expect(nextUnpaidDueDate(charge({ isActive: false }), new Map(), '2026-06-04')).toBeNull();
+  });
+
+  it('returns null when paymentMonths is empty', () => {
+    expect(nextUnpaidDueDate(charge({ paymentMonths: [] }), new Map(), '2026-06-04')).toBeNull();
+  });
+
+  it('returns null for a malformed fromIso', () => {
+    expect(nextUnpaidDueDate(charge(), new Map(), 'not-a-date')).toBeNull();
+  });
+});

--- a/src/lib/domain/charges/__tests__/upcoming.test.ts
+++ b/src/lib/domain/charges/__tests__/upcoming.test.ts
@@ -123,74 +123,37 @@ describe('getUpcomingCharges — bucketing rules (THI-192)', () => {
   });
 });
 
-describe('getUpcomingCharges — overdue handling', () => {
-  it('places an unpaid past-due charge into overdue', () => {
-    // paymentDay=5, today=10 → nextDue rolls forward to next month.
-    // To test overdue, we need the next-due-date to be in the past. That can
-    // only happen if `nextDueDateForCharge` returns a past date, which it
-    // doesn't (it always rolls forward). So overdue means: nextDue is today
-    // (daysUntilDue = 0) but NOT paid AND we want a "past" feel.
-    //
-    // Practical scenario for THI-192: a monthly charge whose paymentDay is
-    // in the past relative to today, and the user has NOT paid for the
-    // current period. `nextDueDateForCharge` will then return the NEXT
-    // month's due date (positive daysUntilDue), so it goes into j7/j14/j30,
-    // not overdue.
-    //
-    // The "overdue" bucket only fires when caller explicitly passes a
-    // historical due date — that is uncommon. We still test the branch via
-    // a synthetic scenario: a charge whose `paymentMonths` includes only a
-    // past month relative to `todayIso`. With `paymentMonths` purely
-    // historical, `nextDueDateForCharge` will roll forward by 12 months and
-    // land out of the 30-day horizon — so we explicitly need a payment day
-    // that the date helper would compute as past.
-    //
-    // We model overdue via a paymentDay in the current month before today,
-    // where the helper effectively returns nextDue = today's day in current
-    // month minus 1. But `nextDueDateForCharge` strictly returns
-    // `day >= refDay`, so the only way to model a true overdue is when the
-    // helper returned the requested past date elsewhere. For the unit test
-    // we therefore use the public path: a charge whose due date is computed
-    // as today (daysUntilDue=0) but unpaid is the closest practical
-    // approximation to "overdue this billing cycle".
-    //
-    // The strictly-overdue branch (negative daysUntilDue) is reachable when
-    // a caller pre-computes due dates externally and stuffs them through
-    // a custom path. To exercise it directly, we use a manual ledger trick:
-    // set today AFTER the paymentDay in a month not in paymentMonths but
-    // adjacent — the helper rolls forward, never backward. Conclusion:
-    // negative daysUntilDue is **structurally unreachable** through the
-    // public API as wired today, which is the intended invariant.
-    //
-    // We therefore document this expectation via the test below: any unpaid
-    // charge whose dueDate matches today gets bucketed into j7 (not overdue),
-    // because `nextDueDateForCharge` cannot produce a past date.
-    const charge = makeCharge({ paymentDay: 10 });
+describe('getUpcomingCharges — overdue handling (THI-329 payment-aware)', () => {
+  it('places a passed-but-unpaid current-month occurrence into overdue', () => {
+    // paymentDay=5, today=May 10 → May 5 has passed and is unpaid → overdue.
+    // (The old "always roll forward" logic hid this a month/year ahead;
+    // payment-aware `nextUnpaidDueDate` surfaces it.)
+    const charge = makeCharge({ paymentDay: 5 });
     const result = getUpcomingCharges({
       charges: [charge],
       payments: NO_PAYMENTS,
       todayIso: '2026-05-10',
     });
-    expect(result.overdue).toHaveLength(0);
-    expect(result.j7[0]!.daysUntilDue).toBe(0);
-    expect(result.j7[0]!.isPaid).toBe(false);
+    expect(result.overdue).toHaveLength(1);
+    expect(result.overdue[0]!.dueDateIso).toBe('2026-05-05');
+    expect(result.overdue[0]!.daysUntilDue).toBe(-5);
+    expect(result.j7).toHaveLength(0);
   });
 
-  it('drops an overdue charge that has been paid', () => {
-    // Setup: monthly charge paymentDay=15, today=2026-05-10. nextDue=2026-05-15 (j7).
-    // Mark it as paid for 2026-05 → it stays in j7 because dueDate is still
-    // in the future. Then advance today to 2026-05-16, nextDue rolls to
-    // 2026-06-15 (j30). The "paid for May" entry no longer matches June.
+  it('skips a paid current-month occurrence (rolls forward, never overdue)', () => {
+    // paymentDay=15, today=May 20 (May 15 passed) but MAY is paid → skip it,
+    // roll to the next unpaid occurrence June 15 (26d → j30). Not overdue.
     const charge = makeCharge({ id: 'paidC', paymentDay: 15 });
-    const payments: UpcomingPaymentLedger = new Map([[`paidC-2026-5`, true]]);
-
+    const payments: UpcomingPaymentLedger = new Map([['paidC-2026-5', true]]);
     const result = getUpcomingCharges({
       charges: [charge],
       payments,
-      todayIso: '2026-05-10',
+      todayIso: '2026-05-20',
     });
-    expect(result.j7).toHaveLength(1);
-    expect(result.j7[0]!.isPaid).toBe(true);
+    expect(result.overdue).toHaveLength(0);
+    expect(result.j30).toHaveLength(1);
+    expect(result.j30[0]!.dueDateIso).toBe('2026-06-15');
+    expect(result.j30[0]!.isPaid).toBe(false);
   });
 });
 
@@ -205,7 +168,7 @@ describe('getUpcomingCharges — filtering', () => {
     expect(result.j7).toHaveLength(0);
   });
 
-  it('skips charges where nextDueDateForCharge returns null (empty paymentMonths)', () => {
+  it('skips charges where nextUnpaidDueDate returns null (empty paymentMonths)', () => {
     const charge = makeCharge({ paymentMonths: [] });
     const result = getUpcomingCharges({
       charges: [charge],
@@ -245,9 +208,10 @@ describe('getUpcomingCharges — sorting', () => {
 });
 
 describe('getUpcomingCharges — calendar edge cases', () => {
-  it('handles month boundary correctly (May → June)', () => {
-    // today = last of May, charge paymentDay=2 → next due 2026-06-02 (2d → j7)
-    const charge = makeCharge({ paymentDay: 2 });
+  it('handles month boundary correctly (annual charge due next month)', () => {
+    // Annual June charge, today = end of May → next due 2026-06-02 (2d → j7).
+    // (Monthly would surface the past May occurrence as overdue, not roll.)
+    const charge = makeCharge({ paymentMonths: [6], paymentDay: 2 });
     const result = getUpcomingCharges({
       charges: [charge],
       payments: NO_PAYMENTS,
@@ -258,8 +222,9 @@ describe('getUpcomingCharges — calendar edge cases', () => {
     expect(result.j7[0]!.daysUntilDue).toBe(2);
   });
 
-  it('handles year boundary correctly (Dec → Jan)', () => {
-    const charge = makeCharge({ paymentDay: 5 });
+  it('handles year boundary correctly (annual charge due next January)', () => {
+    // Annual January charge, today = end of Dec → next due 2027-01-05 (6d → j7).
+    const charge = makeCharge({ paymentMonths: [1], paymentDay: 5 });
     const result = getUpcomingCharges({
       charges: [charge],
       payments: NO_PAYMENTS,
@@ -312,36 +277,41 @@ describe('getUpcomingCharges — calendar edge cases', () => {
   });
 });
 
-describe('getUpcomingCharges — paid lookup', () => {
-  it('marks an upcoming charge as paid when ledger contains its (year, month)', () => {
+describe('getUpcomingCharges — payment-aware skip (THI-329)', () => {
+  it('skips a paid current-month occurrence and rolls past the 30-day horizon', () => {
+    // rent due 15th, today May 10 (15th still ahead) but MAY already paid →
+    // skip May, roll to June 15 (36d) → out of the 30-day horizon → dropped.
     const charge = makeCharge({ id: 'rent', paymentDay: 15 });
-    const payments: UpcomingPaymentLedger = new Map([[`rent-2026-5`, true]]);
+    const payments: UpcomingPaymentLedger = new Map([['rent-2026-5', true]]);
     const result = getUpcomingCharges({
       charges: [charge],
       payments,
       todayIso: '2026-05-10',
     });
-    expect(result.j7[0]!.isPaid).toBe(true);
+    expect(result.j7).toHaveLength(0);
+    expect(result.overdue).toHaveLength(0);
   });
 
-  it('marks an upcoming charge as unpaid when ledger entry is false', () => {
+  it('does NOT skip when the ledger entry is false (treats as unpaid)', () => {
     const charge = makeCharge({ id: 'rent', paymentDay: 15 });
-    const payments: UpcomingPaymentLedger = new Map([[`rent-2026-5`, false]]);
+    const payments: UpcomingPaymentLedger = new Map([['rent-2026-5', false]]);
     const result = getUpcomingCharges({
       charges: [charge],
       payments,
       todayIso: '2026-05-10',
     });
-    expect(result.j7[0]!.isPaid).toBe(false);
+    expect(result.j7).toHaveLength(1);
+    expect(result.j7[0]!.dueDateIso).toBe('2026-05-15');
   });
 
-  it('marks an upcoming charge as unpaid when ledger has no entry at all', () => {
+  it('does NOT skip when the ledger has no entry (unpaid)', () => {
     const charge = makeCharge({ id: 'rent', paymentDay: 15 });
     const result = getUpcomingCharges({
       charges: [charge],
       payments: NO_PAYMENTS,
       todayIso: '2026-05-10',
     });
-    expect(result.j7[0]!.isPaid).toBe(false);
+    expect(result.j7).toHaveLength(1);
+    expect(result.j7[0]!.dueDateIso).toBe('2026-05-15');
   });
 });

--- a/src/lib/domain/charges/index.ts
+++ b/src/lib/domain/charges/index.ts
@@ -1,6 +1,11 @@
 export type { ChargeRecord, ChargeUpdateInput } from './types';
 export { updateCharge, validateChargeUpdate, type ChargeUpdateValidation } from './update';
 export { nextDueDateForCharge } from './next-due-date';
+export {
+  nextUnpaidDueDate,
+  type PaymentAwareCharge,
+  type NextUnpaidDueResult,
+} from './next-unpaid-due-date';
 export { chargeMatchesMonth } from './match-month';
 export { paymentMonthsFromFrequency } from './payment-months-from-frequency';
 export {

--- a/src/lib/domain/charges/next-unpaid-due-date.ts
+++ b/src/lib/domain/charges/next-unpaid-due-date.ts
@@ -1,0 +1,92 @@
+/**
+ * Payment-aware "next unpaid occurrence" for a recurring charge (THI-329).
+ *
+ * Unlike `nextDueDateForCharge` (which always rolls to the next FUTURE occurrence
+ * regardless of payment state), this resolver:
+ *   1. **skips occurrences already paid** for their (year, month) period, and
+ *   2. **does NOT skip the current-month occurrence when its day has passed** —
+ *      it returns it flagged `isOverdue` so the UI can surface a late, unpaid bill
+ *      instead of hiding it a year ahead.
+ *
+ * This reconciles the two complaints:
+ *   - "Impôt paid this month still shows June" → June is paid → roll to July.
+ *   - "Taxe voiture due June 1, unpaid, shows June 2027" → return June, overdue.
+ *
+ * **Ledger invariant (plan-reviewer CR-1):** in production the payment ledger is
+ * built from `currentMonthPayments` (the current period only), so the skip-paid
+ * branch only ever fires on the current-month occurrence — which is correct:
+ * a future occurrence cannot already be paid. Widening the ledger to multiple
+ * months (a later PR) would make this naturally handle paid future occurrences
+ * with no code change.
+ *
+ * Pure: no `Date.now()`, no I/O. Pass `fromIso` (today, `YYYY-MM-DD`) explicitly.
+ * Does NOT touch `nextDueDateForCharge` (kept for its other call-site).
+ */
+
+/** Minimal charge shape this resolver needs — structurally a subset of both
+ *  `ChargeRecord` and `UpcomingChargeInput` (so callers pass either). `id` is
+ *  required to build the ledger key `${id}-${year}-${month}` (cf. `paymentKey`). */
+export type PaymentAwareCharge = Readonly<{
+  id: string;
+  paymentMonths: readonly number[];
+  paymentDay: number;
+  isActive: boolean;
+}>;
+
+export type NextUnpaidDueResult = Readonly<{
+  /** Next unpaid occurrence in ISO `YYYY-MM-DD` (Europe/Brussels upstream). */
+  dueDateIso: string;
+  /** True when that occurrence's date is strictly before `fromIso` (late). */
+  isOverdue: boolean;
+}>;
+
+/**
+ * Ledger key format MUST match `paymentKey()` in `cockpit/types.ts`:
+ * `${chargeId}-${year}-${month}` — month is NOT zero-padded.
+ */
+export function nextUnpaidDueDate(
+  charge: PaymentAwareCharge,
+  payments: ReadonlyMap<string, boolean>,
+  fromIso: string,
+): NextUnpaidDueResult | null {
+  if (!charge.isActive) return null;
+  if (charge.paymentMonths.length === 0) return null;
+
+  const [refYearStr, refMonthStr] = fromIso.split('-');
+  const refYear = Number(refYearStr);
+  const refMonth = Number(refMonthStr);
+  if (!Number.isFinite(refYear) || !Number.isFinite(refMonth)) return null;
+
+  const monthsSet = new Set(charge.paymentMonths);
+
+  // Search the current month and the next 23 — covers every cadence (monthly
+  // resolves at offset 0, annual within 12); the 24-cap is defensive against
+  // an ill-formed `paymentMonths`.
+  for (let offset = 0; offset < 24; offset += 1) {
+    const totalMonth = refMonth - 1 + offset;
+    const year = refYear + Math.floor(totalMonth / 12);
+    const month = (totalMonth % 12) + 1;
+    if (!monthsSet.has(month)) continue;
+    if (payments.get(`${charge.id}-${year}-${month}`) === true) continue;
+
+    const day = Math.min(charge.paymentDay, daysInMonth(year, month));
+    const dueDateIso = `${pad4(year)}-${pad2(month)}-${pad2(day)}`;
+    // ISO `YYYY-MM-DD` lexical order === chronological order.
+    return { dueDateIso, isOverdue: dueDateIso < fromIso };
+  }
+
+  return null;
+}
+
+function daysInMonth(year: number, month: number): number {
+  // Day 0 of (month + 1) === last day of `month` in the JS Date model.
+  return new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+function pad4(n: number): string {
+  return n < 1000 ? String(n).padStart(4, '0') : String(n);
+}

--- a/src/lib/domain/charges/upcoming.ts
+++ b/src/lib/domain/charges/upcoming.ts
@@ -1,7 +1,6 @@
 import type { Money } from '@/lib/domain/types';
 
-import { nextDueDateForCharge } from './next-due-date';
-import type { ChargeRecord } from './types';
+import { nextUnpaidDueDate } from './next-unpaid-due-date';
 
 /**
  * Bucket assignment for `getUpcomingCharges()`.
@@ -88,31 +87,27 @@ export function getUpcomingCharges(input: GetUpcomingChargesInput): UpcomingByBu
   for (const charge of input.charges) {
     if (!charge.isActive) continue;
 
-    const dueDateIso = nextDueDateForCharge(
-      // `nextDueDateForCharge` accepts `ChargeRecord`; only `isActive`,
-      // `paymentMonths` and `paymentDay` are read. The wider record fields
-      // are inert here — casting to the structural minimum keeps the helper
-      // callable from places that don't construct a full `ChargeRecord`.
-      charge as unknown as ChargeRecord,
-      input.todayIso,
-    );
-    if (dueDateIso === null) continue;
+    // Payment-aware (THI-329): the next UNPAID occurrence. Skips occurrences
+    // already paid for their period and surfaces a passed-but-unpaid
+    // current-month occurrence as overdue (instead of rolling a year ahead).
+    const due = nextUnpaidDueDate(charge, input.payments, input.todayIso);
+    if (due === null) continue;
 
-    const daysUntilDue = diffInDays(input.todayIso, dueDateIso);
+    const daysUntilDue = diffInDays(input.todayIso, due.dueDateIso);
     if (daysUntilDue > 30) continue;
 
-    const [yearStr, monthStr] = dueDateIso.split('-');
-    const dueYear = Number(yearStr);
-    const dueMonth = Number(monthStr);
-    const isPaid = input.payments.get(paymentKeyFor(charge.id, dueYear, dueMonth)) === true;
+    // `nextUnpaidDueDate` only returns unpaid occurrences → isPaid is false by
+    // construction (kept on the item for the type/UI contract).
+    const item: UpcomingItem = {
+      charge,
+      dueDateIso: due.dueDateIso,
+      daysUntilDue,
+      isPaid: false,
+    };
 
-    const item: UpcomingItem = { charge, dueDateIso, daysUntilDue, isPaid };
-
-    if (daysUntilDue < 0) {
-      // Overdue but already paid → drop. The user has nothing actionable to
-      // do; the notification surface already cleared. This mirrors the
-      // `genererNotifications()` behaviour for `charge_overdue`.
-      if (isPaid) continue;
+    // Single source of truth for "late": the resolver's `isOverdue` (equivalent
+    // to `daysUntilDue < 0` by construction, but avoids a duplicated definition).
+    if (due.isOverdue) {
       buckets.overdue.push(item);
     } else if (daysUntilDue <= 7) {
       buckets.j7.push(item);
@@ -164,8 +159,4 @@ function diffInDays(fromIso: string, toIso: string): number {
 function utcMidnight(iso: string): number {
   const [y, m, d] = iso.split('-').map(Number) as [number, number, number];
   return Date.UTC(y, m - 1, d);
-}
-
-function paymentKeyFor(chargeId: string, year: number, month: number): string {
-  return `${chargeId}-${year}-${month}`;
 }

--- a/supabase/migrations/20260605000001_backfill_payment_months.sql
+++ b/supabase/migrations/20260605000001_backfill_payment_months.sql
@@ -1,0 +1,49 @@
+-- Epic « Factures cohérentes » / THI-329 — backfill payment_months to the full
+-- cadence derived from (frequency, due_month).
+--
+-- Root cause: 20260503000002 (l.57-59) backfilled every PERIODIC charge to
+-- `array[due_month]` — a SINGLE month — instead of the full cadence. A
+-- quarterly charge with due_month=1 stored `{1}` instead of `{1,4,7,10}`, so
+-- `nextDueDateForCharge` resolved its next occurrence a year away
+-- (e.g. S.W.D.E « janv. 2027 »). This recomputes the canonical schedule,
+-- mirroring `paymentMonthsFromFrequency()` (src/lib/domain/charges):
+--   monthly    → [1..12]
+--   quarterly  → [a, a+3, a+6, a+9]   (mod 12, 1-based, sorted, deduped)
+--   semiannual → [a, a+6]
+--   annual     → [a]                  (a = due_month)
+--
+-- Idempotent + zero-loss: only rows whose stored array DIFFERS from the
+-- canonical one are touched (no DELETE, monthly [1..12] rows untouched). Runs
+-- as table owner → RLS bypassed. due_month is NOT NULL + CHECK 1..12, so the
+-- arithmetic is always well-formed.
+--
+-- NOTE: this does NOT change the anchor (due_month). A charge mis-anchored at
+-- creation (e.g. S.W.D.E real anchor = May, stored = January) is de-broken into
+-- a VALID quarterly set here; the user corrects the real anchor via CadenceField
+-- (PR-D / THI-301).
+
+with recomputed as (
+  select
+    id,
+    (
+      case frequency
+        when 'monthly' then array[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        when 'quarterly' then (
+          select array_agg(distinct ((due_month + o - 1) % 12) + 1 order by ((due_month + o - 1) % 12) + 1)
+          from unnest(array[0, 3, 6, 9]) as o
+        )
+        when 'semiannual' then (
+          select array_agg(distinct ((due_month + o - 1) % 12) + 1 order by ((due_month + o - 1) % 12) + 1)
+          from unnest(array[0, 6]) as o
+        )
+        when 'annual' then array[due_month]
+        else payment_months -- defensive: unknown frequency → leave untouched
+      end
+    )::smallint[] as pm
+  from public.charges
+)
+update public.charges c
+set payment_months = r.pm
+from recomputed r
+where c.id = r.id
+  and c.payment_months is distinct from r.pm;


### PR DESCRIPTION
## PR-A — Payment-aware due-date + backfill payment_months (THI-329)

Corrige à la racine les dates de factures incohérentes, **sans toucher** `nextDueDateForCharge`. Fondation de l'epic « Factures cohérentes » (spec : `docs/plans/epic-factures-coherentes-spec.md`).

### Deux leviers
1. **Migration `20260605000001`** — recompute `payment_months` depuis `(frequency, due_month)` pour les charges incohérentes. Corrige le bug de `20260503000002` (l.58) qui stockait UN seul mois pour les périodiques (S.W.D.E `quarterly` = `[1]` → « janv. 2027 »). **Idempotente, zéro-perte, aucune RLS touchée** (SQL = `paymentMonthsFromFrequency` au caractère près).
2. **Domaine `nextUnpaidDueDate()`** (pur, nouveau) — prochaine occurrence **NON PAYÉE** : saute les payées (Impôt juin payé → roule à juillet) + surface une occurrence du mois courant passée-non-payée en **overdue** (Taxe voiture juin → en retard, plus caché un an). Câblé dans le dashboard `getUpcomingCharges`. La page charges (`ChargesClient`) suit en **PR-B**.

### ⚠️ Migration sur données prod
Le merge applique le backfill sur les `charges` de tous les workspaces. C'est **correctif + idempotent + zéro-perte** (ne touche que les lignes incohérentes, aucun DELETE). Il **dé-casse** la cadence (un seul mois → cadence complète) mais ne corrige PAS l'ancre `due_month` mal saisie (ex. S.W.D.E réel = mai) → @thierry corrige l'ancre via CadenceField (PR-D).

### Gouvernance
plan-reviewer 🟡→intégré · **rls-flow-tester GO** · **financial-formula-validator GO** · 32 tests domaine + suite complète **1433** + build verts.

### Smoke @thierry (preview)
Dashboard `/app` « Prochaines factures » : Impôt (juin payé) roulé à juillet ; Taxe voiture (juin non payée) en « En retard » ; S.W.D.E n'affiche plus janv. 2027.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduire un résolveur de date d’échéance sensible aux paiements pour les prochaines facturations et rétro-remplir les cadences de facturation incohérentes afin de rétablir des calendriers de facturation corrects.

Nouvelles fonctionnalités :
- Ajouter une fonction de domaine pour calculer la prochaine date d’échéance impayée d’une facturation, en tenant compte de l’historique des paiements et en mettant en évidence les occurrences en retard.
- Connecter le pipeline du tableau de bord `upcoming-charges` au nouveau résolveur de date d’échéance sensible aux paiements, tout en préservant l’API publique existante.

Corrections de bugs :
- Rétro-remplir les `payment_months` incorrects pour les facturations périodiques afin de restaurer les cadences complètes dérivées de `frequency` et `due_month`, corrigeant les cas où les prochaines dates d’échéance étaient résolues avec un an d’avance.
- S’assurer que les compartiments de retard incluent désormais correctement les occurrences du mois en cours qui sont échues mais non payées, au lieu de les faire avancer silencieusement.

Améliorations :
- Affiner le comportement de `upcoming-charges` pour ignorer les occurrences déjà payées de la période en cours et supprimer les entrées qui dépassent l’horizon de 30 jours, sans modifier les interfaces existantes.
- Documenter le nouveau comportement de date d’échéance sensible aux paiements et le plan de migration dans un document de conception dédié.

Documentation :
- Ajouter un plan de conception et d’implémentation pour la date d’échéance sensible aux paiements et le travail de rétro-remplissage de cadence, y compris l’évaluation des risques et les invariants.

Tests :
- Ajouter des tests unitaires pour le nouveau résolveur de prochaine date d’échéance impayée sensible aux paiements et mettre à jour les tests de `upcoming-charges` pour couvrir la gestion des retards, le saut des paiements et les cas limites de calendrier.

Tâches diverses :
- Introduire une migration Supabase corrective et idempotente pour recalculer `payment_months` en utilisant des règles de cadence canoniques pour toutes les facturations existantes.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a payment-aware due-date resolver for upcoming charges and backfill inconsistent charge cadences to restore correct billing schedules.

New Features:
- Add a domain function to compute the next unpaid due date for a charge, taking into account payment history and surfacing overdue occurrences.
- Wire the dashboard upcoming-charges pipeline to use the new payment-aware due-date resolver while preserving the existing public API.

Bug Fixes:
- Backfill incorrect payment_months for periodic charges to restore full cadences derived from frequency and due_month, fixing cases where next due dates were resolved a year ahead.
- Ensure overdue buckets now correctly include passed-but-unpaid current-month occurrences instead of silently rolling them forward.

Enhancements:
- Refine upcoming-charges behavior to skip already-paid current-period occurrences and drop entries that fall beyond the 30-day horizon without changing existing interfaces.
- Document the new payment-aware due-date behavior and migration plan in a dedicated design plan document.

Documentation:
- Add a design and implementation plan for the payment-aware due-date and cadence backfill work, including risk assessment and invariants.

Tests:
- Add unit tests for the new payment-aware next-unpaid-due-date resolver and update upcoming-charges tests to cover overdue handling, payment skipping, and calendar edge cases.

Chores:
- Introduce a corrective, idempotent Supabase migration to recompute payment_months using canonical cadence rules for all existing charges.

</details>