### PR TITLE
feat(charges): current-period due date + overdue badge + paid toggle carry (THI-329)

### DIFF
--- a/docs/plans/pr-b-charges-page-current-period.md
+++ b/docs/plans/pr-b-charges-page-current-period.md
@@ -1,0 +1,97 @@
+# PR-B — Page charges : période courante + carry #221 (THI-329)
+
+> Plan @cc-ankora 2026-06-06. Epic « Factures cohérentes » (spec : `docs/plans/epic-factures-coherentes-spec.md`).
+> À valider par `plan-reviewer` avant tout code (touche domaine + UI > 50 lignes).
+
+## Goal
+
+La page `/app/charges` reflète la **réalité du mois courant** par facture (payée / en retard / due ce mois / à venir) au lieu de rouler prématurément vers l'occurrence suivante (« juillet avant juin »), et expose le toggle Payé + le redesign déjà construits sur #221.
+
+## Diagnostic (code-vérifié 2026-06-06)
+
+- **`ChargesClient.tsx` (main)** affiche par ligne `nextDueLabel(c)` → `nextDueDateForCharge(charge, todayIso)` (l.183-194). Cette fonction **roule toujours en avant** : une charge mensuelle dont juin est passé/payé affiche **juillet**. C'est la cause exacte du « tu affiches juillet avant juin » sur la page (verbatim @thierry P5).
+- **#221 (`feat/charges-phase2-paid-toggle`, OPEN, 461+/20−)** a construit + QA'd : toggle Payé (`useOptimistic` + `togglePaymentAction` existant/testé), style payé (line-through), résumé « Payées ce mois : x/y · reste {montant} », redesign groupes (header `Repeat` + compteur, `<ul>` arrondi bordé, sous-total **sous** la liste coloré `brand-700`), `paidHint`. **MAIS `nextDueLabel` y utilise encore `nextDueDateForCharge`** → le bug date persiste même avec le toggle (marquer juin payé tout en affichant « juillet » = incohérent). C'est pourquoi carry #221 **et** fix date doivent shipper ensemble.
+- **#221 trim** (`ProchainesFacturesCard` plafonné à 4 + « +N autres », clé `dashboard.upcomingBills.moreCount`) = **REJETÉ @thierry** (veut un marqueur « à surveiller », PR ultérieure). NON carry.
+- **Faits git réels (CR-1, vérifiés 2026-06-06)** : la session courante est sur la branche `feat/thi-329-payment-aware-due-date` (= #223, HEAD `b97c248`), c'est pourquoi PR-A est présent sur le disque. **`origin/main` (`d1a2b4d`) n'a PAS PR-A** : `next-unpaid-due-date.ts` absent, `index.ts` exporte `upcoming` (pré-existant THI-192) mais pas `nextUnpaid`/`currentPeriod`. **PR-B branche depuis `origin/main`** (`git checkout main` d'abord), donc un main SANS PR-A. L'indépendance tient : `currentPeriodDueDate` (nouveau) + le carry #221 ne dépendent PAS de `nextUnpaidDueDate`/`upcoming.ts`. Conflit au 2e merge = uniquement le bloc d'exports `index.ts` (#223 ajoute `nextUnpaid`, PR-B ajoute `currentPeriod`) → trivial, **garder les deux**.
+- **Deps de carry confirmées sur `origin/main`** : `togglePaymentAction` (`src/lib/actions/charge-payments.ts:46`), snapshot `rawCharges`/`currentMonthPayments`/`currentPeriod` (`workspace-snapshot.ts:99/123/131`), `ChargeEditDrawer.tsx`. Le carry depuis main n'amène que le câblage UI (ChargesClient + page + test + clés i18n).
+- **Snapshot** (`workspace-snapshot.ts`) expose déjà `rawCharges`, `currentMonthPayments` (mois courant, scoping serveur), `currentPeriod {year, month}` (Europe/Brussels). `togglePaymentAction` (`src/lib/actions/charge-payments.ts`) : authz workspace avant write, rate-limit `mutation`, audit `CHARGE_PAYMENT_TOGGLED`, revalidate. **Déjà construit + testé** — PR-B le câble seulement (pas de nouvelle Server Action, pas de migration).
+
+## Domaine — `currentPeriodDueDate` (NOUVEAU, pur)
+
+`src/lib/domain/charges/current-period-due-date.ts`. Pur TS (pas de Decimal, pas de DB). Helpers `daysInMonth/pad2/pad4` locaux au fichier (cohérent avec `next-due-date.ts` / `next-unpaid-due-date.ts` ; extraction d'un util partagé = chore différé post-merge #223, quand les 3 résolveurs sont sur `main` — endorsé financial-formula-validator O3).
+
+```ts
+export type CurrentPeriodCharge = Readonly<{
+  paymentMonths: readonly number[];
+  paymentDay: number;
+  isActive: boolean;
+}>;
+
+export type ChargePeriodStatus = 'paid' | 'overdue' | 'dueThisMonth' | 'upcoming';
+
+export type CurrentPeriodDueResult = Readonly<{
+  /** Date à afficher (ISO YYYY-MM-DD). Mois courant si dû ce mois, sinon prochaine occurrence. */
+  dueDateIso: string;
+  status: ChargePeriodStatus;
+}>;
+
+/**
+ * Statut de l'occurrence ANCRÉE au mois courant (ne roule PAS en avant quand
+ * la charge est due ce mois) :
+ *  - dû ce mois + payé           → 'paid'        (date = ce mois)
+ *  - dû ce mois + jour passé +!payé → 'overdue'  (date = ce mois)
+ *  - dû ce mois + jour à venir   → 'dueThisMonth'(date = ce mois)
+ *  - pas dû ce mois              → 'upcoming'    (date = prochaine occurrence réelle)
+ * Renvoie null si inactive ou paymentMonths vide (le call-site retombe sur
+ * formatMonth(dueMonth), comportement existant).
+ */
+export function currentPeriodDueDate(
+  charge: CurrentPeriodCharge,
+  period: Readonly<{ year: number; month: number }>,
+  todayIso: string,
+  isPaid: boolean,
+): CurrentPeriodDueResult | null;
+```
+
+**Algo** : si `!isActive` ou `paymentMonths.length===0` → null. Scan `offset` 0..23 depuis `(period.year, period.month)` ; première occurrence dont le mois ∈ `paymentMonths`. Si `offset===0` (le mois courant EST un mois de paiement) → date = ce mois (clamp jour), statut **`paid` si `isPaid` (priorité absolue), sinon** `overdue` si `dueDateIso < todayIso`, sinon `dueThisMonth`. Si `offset>0` → date = cette occurrence future, statut `upcoming` (`isPaid` ignoré). Comparaison overdue = lexicale ISO (cohérent `next-unpaid-due-date.ts`).
+
+**Invariant ledger (CR-2) — à documenter en JSDoc** (calqué sur `next-unpaid-due-date.ts:14-20`) : `isPaid` est un scalaire **scopé au mois courant** `(period.year, period.month)` uniquement — le call-site le dérive de `optimisticPaid.has(c.id)`, et le ledger snapshot (`currentMonthPayments`) est **mono-mois**. Ne JAMAIS passer un `isPaid` d'une occurrence future (statut `upcoming` ignore `isPaid` par construction). **Différence délibérée avec `nextUnpaidDueDate`** : ce résolveur **ancre** au mois courant et se contente de le **labelliser** `paid` (il ne saute pas l'occurrence payée) ; `nextUnpaidDueDate` **saute** les occurrences payées via une Map. Documenter cette divergence pour éviter une fusion incorrecte des deux résolveurs lors d'un refactor futur.
+
+## Scope (fichiers exacts)
+
+| Fichier                                                            | Action                                                                                                                                                                                                                                                                                                                                                                                                  |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/lib/domain/charges/current-period-due-date.ts`                | **NEW** — fonction ci-dessus                                                                                                                                                                                                                                                                                                                                                                            |
+| `src/lib/domain/charges/__tests__/current-period-due-date.test.ts` | **NEW** — TDD (voir tests)                                                                                                                                                                                                                                                                                                                                                                              |
+| `src/lib/domain/charges/index.ts`                                  | export `currentPeriodDueDate` + types                                                                                                                                                                                                                                                                                                                                                                   |
+| `src/app/[locale]/app/charges/page.tsx`                            | **carry #221** : `paidChargeIds` + `currentPeriod`                                                                                                                                                                                                                                                                                                                                                      |
+| `src/app/[locale]/app/charges/ChargesClient.tsx`                   | **carry #221** intégral, PUIS remplacer `nextDueLabel`→`currentPeriodDueDate` + badge « En retard » sur ligne `overdue` ; retirer import `nextDueDateForCharge`                                                                                                                                                                                                                                         |
+| `src/app/[locale]/app/charges/__tests__/ChargesClient.test.tsx`    | **carry #221** + tests badge overdue / date mois-courant / paid                                                                                                                                                                                                                                                                                                                                         |
+| `messages/{fr-BE,en,nl-BE,de-DE,es-ES}.json`                       | **NEW** (vérifiés absents des 5 locales de main) `app.charges.{toastMarkedPaid,toastMarkedUnpaid,markPaidAria,unmarkPaidAria,paidSummary,paidHint,statusOverdue}` ; **déjà sur main, ne pas ré-ajouter** `errors.charges.payments.toggleFailed` (présent sur les 5 locales d'origin/main) ; **NE PAS carry** `dashboard.upcomingBills.moreCount` (CR-3 : n'existe que sur #221, rien à retirer de main) |
+
+**Carry mécanique** : `git checkout main` PUIS `git checkout -b feat/cc-charges-current-period`, puis `git checkout origin/feat/charges-phase2-paid-toggle -- "src/app/[locale]/app/charges/ChargesClient.tsx" "src/app/[locale]/app/charges/page.tsx" "src/app/[locale]/app/charges/__tests__/ChargesClient.test.tsx"` (récupère le travail #221 testé sans le retaper). **Gate CR-4** : juste après le checkout, lancer `npm run typecheck` — ça surface immédiatement tout import présent uniquement sur #221 (avant d'empiler les modifs date/badge). Messages : **ajout manuel ciblé** des clés ci-dessus, **dans le même commit que le client carry**, sur les **5 locales** (sinon `i18n-auditor` + hydratation/tests échouent). PUIS layer `currentPeriodDueDate` + badge + retrait import `nextDueDateForCharge`. **NE PAS** carry `ProchainesFacturesCard.tsx` (= reste la version `main`, sans trim).
+
+## Badge UI
+
+Ligne `overdue` (due ce mois, jour passé, non payée) : petit badge texte `app.charges.statusOverdue` (« En retard ») en `text-danger`, à côté de la date. `paid` : déjà signalé par le toggle ✓ + amount line-through (#221) — pas de badge texte supplémentaire. `dueThisMonth` / `upcoming` : date seule. Tokens sémantiques only, pas d'inline style (CSP). Mobile-first.
+
+## Tests (TDD)
+
+**Domaine** (`current-period-due-date.test.ts`) : dû ce mois jour passé non payé→`overdue` (date=ce mois, PAS le mois suivant) ; dû ce mois jour à venir non payé→`dueThisMonth` ; **payé bat overdue** (jour passé + `isPaid`→`paid`) ; **payé bat dueThisMonth** (jour à venir + `isPaid`→`paid`) ; mensuel juin payé→reste juin `paid` (ne roule PAS en juillet) ; trimestriel [1,4,7,10] en juin→`upcoming` juillet ; annuel [3] en juin→`upcoming` mars N+1 ; clamp 31 fév→28/29 ; inactive→null ; paymentMonths vide→null ; passage année.
+
+**UI** (`ChargesClient.test.tsx`, carry + ajouts) : badge « En retard » rendu pour charge overdue ; pas de badge si dueThisMonth/upcoming ; ligne mensuelle due ce mois affiche le mois courant (pas le suivant) ; toggle Payé bascule overdue→paid (badge disparaît). Conserver tous les testids #221.
+
+## Non-goals
+
+- Pas de modif `nextDueDateForCharge` (les autres call-sites le gardent), `next-unpaid-due-date.ts` (#223), `togglePaymentAction`, schéma, migration.
+- Pas le trim / `moreCount` / `ProchainesFacturesCard`.
+- Pas le marqueur `is_watched` ni le remaniement dashboard « Ce mois 5 / À surveiller » → PR suivante.
+- Pas d'extraction du util date partagé (chore différé post-merge #223).
+
+## Risk tiering / QA — voie LOURDE (domaine + UI métier)
+
+`plan-reviewer` (ce doc) → `financial-formula-validator` (currentPeriodDueDate) → `dashboard-ux-auditor` (page charges) → `mobile-ios-auditor` (toggle 44px, badge, safe-area) → `i18n-auditor` (parité 5 locales + drop moreCount cohérent) → `test-runner`. Pas de `security-auditor`/`rls-flow-tester` (aucune action/RLS/migration nouvelle).
+
+## DoD
+
+CI verte · `lint:use-server` OK · Sourcery silencieux/résolu · review @thierry · pas de conflit `main` · rapport (corps PR). Smoke : `/app/charges` en juin → charge mensuelle payée affiche juin payé (pas juillet) ; charge jour passé non payée = badge « En retard » ; toggle bascule l'état ; trimestriel hors-mois = prochaine date réelle.

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -723,6 +723,13 @@
       "toastCreated": "Fixkosten hinzugefügt",
       "toastUpdated": "Fixkosten aktualisiert",
       "toastDeleted": "Fixkosten gelöscht",
+      "toastMarkedPaid": "Rechnung als bezahlt markiert",
+      "toastMarkedUnpaid": "Rechnung als zu zahlen markiert",
+      "markPaidAria": "{label} als bezahlt markieren",
+      "unmarkPaidAria": "{label} als zu zahlen markieren",
+      "paidSummary": "Diesen Monat bezahlt: {paid}/{total} · noch {remaining}",
+      "paidHint": "Hake die Rechnungen ab, die du diesen Monat schon bezahlt hast.",
+      "statusOverdue": "Überfällig",
       "drawer": {
         "title": "Fixkosten bearbeiten",
         "save": "Speichern",

--- a/messages/en.json
+++ b/messages/en.json
@@ -723,6 +723,13 @@
       "toastCreated": "Bill added",
       "toastUpdated": "Bill updated",
       "toastDeleted": "Bill deleted",
+      "toastMarkedPaid": "Bill marked as paid",
+      "toastMarkedUnpaid": "Bill marked as to pay",
+      "markPaidAria": "Mark {label} as paid",
+      "unmarkPaidAria": "Mark {label} as to pay",
+      "paidSummary": "Paid this month: {paid}/{total} · {remaining} left",
+      "paidHint": "Tick the bills you've already paid this month.",
+      "statusOverdue": "Overdue",
       "drawer": {
         "title": "Edit bill",
         "save": "Save",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -723,6 +723,13 @@
       "toastCreated": "Gasto fijo añadido",
       "toastUpdated": "Gasto fijo actualizado",
       "toastDeleted": "Gasto fijo eliminado",
+      "toastMarkedPaid": "Factura marcada como pagada",
+      "toastMarkedUnpaid": "Factura marcada como por pagar",
+      "markPaidAria": "Marcar {label} como pagada",
+      "unmarkPaidAria": "Marcar {label} como por pagar",
+      "paidSummary": "Pagadas este mes: {paid}/{total} · quedan {remaining}",
+      "paidHint": "Marca las facturas que ya has pagado este mes.",
+      "statusOverdue": "Atrasadas",
       "drawer": {
         "title": "Modificar gasto fijo",
         "save": "Guardar",

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -723,6 +723,13 @@
       "toastCreated": "Charge ajoutée",
       "toastUpdated": "Charge mise à jour",
       "toastDeleted": "Charge supprimée",
+      "toastMarkedPaid": "Facture marquée payée",
+      "toastMarkedUnpaid": "Facture marquée à payer",
+      "markPaidAria": "Marquer {label} comme payée",
+      "unmarkPaidAria": "Marquer {label} comme à payer",
+      "paidSummary": "Payées ce mois : {paid}/{total} · reste {remaining}",
+      "paidHint": "Coche les factures que tu as déjà payées ce mois.",
+      "statusOverdue": "En retard",
       "drawer": {
         "title": "Modifier la charge",
         "save": "Enregistrer",

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -723,6 +723,13 @@
       "toastCreated": "Vaste kost toegevoegd",
       "toastUpdated": "Vaste kost bijgewerkt",
       "toastDeleted": "Vaste kost verwijderd",
+      "toastMarkedPaid": "Factuur als betaald gemarkeerd",
+      "toastMarkedUnpaid": "Factuur als te betalen gemarkeerd",
+      "markPaidAria": "{label} als betaald markeren",
+      "unmarkPaidAria": "{label} als te betalen markeren",
+      "paidSummary": "Deze maand betaald: {paid}/{total} · nog {remaining}",
+      "paidHint": "Vink de facturen aan die je deze maand al betaald hebt.",
+      "statusOverdue": "Te laat",
       "drawer": {
         "title": "Vaste kost bewerken",
         "save": "Opslaan",

--- a/src/app/[locale]/app/charges/ChargesClient.tsx
+++ b/src/app/[locale]/app/charges/ChargesClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useMemo, useState, useTransition } from 'react';
-import { Pencil, Plus, Repeat, Trash2 } from 'lucide-react';
+import { useMemo, useOptimistic, useState, useTransition } from 'react';
+import { Check, Pencil, Plus, Repeat, Trash2 } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 
 import { Button } from '@/components/ui/button';
@@ -18,8 +18,9 @@ import {
 import { toast } from '@/components/ui/toast';
 import type { Locale } from '@/i18n/routing';
 import { createChargeAction, deleteChargeAction } from '@/lib/actions/charges';
+import { togglePaymentAction } from '@/lib/actions/charge-payments';
 import { isNextControlFlowError } from '@/lib/actions/next-control-flow';
-import { nextDueDateForCharge, paymentMonthsFromFrequency } from '@/lib/domain/charges';
+import { currentPeriodDueDate, paymentMonthsFromFrequency } from '@/lib/domain/charges';
 import { formatCurrency, formatDate, formatMonth } from '@/lib/i18n/formatters';
 import { useActionErrorTranslator } from '@/lib/i18n/action-errors';
 
@@ -68,6 +69,10 @@ type ChargesClientProps = {
   monthlyProvisionTotal: number;
   /** Annual equivalent of all active charges. */
   annualTotal: number;
+  /** Charge IDs already settled for `currentPeriod` (seeds the Payé toggle). */
+  paidChargeIds: string[];
+  /** Current period (Europe/Brussels), the toggle's write target. */
+  currentPeriod: { year: number; month: number };
 };
 
 export function ChargesClient({
@@ -75,6 +80,8 @@ export function ChargesClient({
   subtotals,
   monthlyProvisionTotal,
   annualTotal,
+  paidChargeIds,
+  currentPeriod,
 }: ChargesClientProps) {
   const t = useTranslations('app.charges');
   const tFreq = useTranslations('common.frequency');
@@ -105,6 +112,52 @@ export function ChargesClient({
       })).filter((group) => group.rows.length > 0),
     [charges],
   );
+
+  // Optimistic "Payé" state (plan-reviewer CR-1): `useOptimistic` seeds from
+  // the server `paidChargeIds` and reconciles automatically once the action's
+  // `revalidateAppPath('charges')` re-renders the page — no double source of
+  // truth. On a failed toggle the DB is unchanged, so the base stays the same
+  // and the optimistic flip rolls back when the transition settles.
+  const paidBase = useMemo(() => new Set(paidChargeIds), [paidChargeIds]);
+  const [optimisticPaid, applyOptimisticPaid] = useOptimistic(
+    paidBase,
+    (current: ReadonlySet<string>, chargeId: string) => {
+      const next = new Set(current);
+      if (next.has(chargeId)) next.delete(chargeId);
+      else next.add(chargeId);
+      return next;
+    },
+  );
+
+  // Active charges due in the current period — the only ones exposing a toggle
+  // (Phase 2 limit: a charge not due this month has no toggle, cf. plan CR-2).
+  const dueThisMonth = useMemo(
+    () => charges.filter((c) => c.isActive && c.paymentMonths.includes(currentPeriod.month)),
+    [charges, currentPeriod.month],
+  );
+
+  function onTogglePaid(c: RawCharge) {
+    startTransition(async () => {
+      applyOptimisticPaid(c.id);
+      try {
+        const result = await togglePaymentAction({
+          chargeId: c.id,
+          periodYear: currentPeriod.year,
+          periodMonth: currentPeriod.month,
+        });
+        if (result.ok) {
+          toast.success(result.data.paid ? t('toastMarkedPaid') : t('toastMarkedUnpaid'));
+        } else {
+          toast.error(translateError(result.errorCode));
+        }
+      } catch (err) {
+        if (isNextControlFlowError(err)) throw err;
+        // eslint-disable-next-line no-console
+        console.error('togglePaymentAction threw', err);
+        toast.error(translateError('errors.charges.payments.toggleFailed'));
+      }
+    });
+  }
 
   function onCreate(e: React.FormEvent) {
     e.preventDefault();
@@ -176,21 +229,24 @@ export function ChargesClient({
   }
 
   /**
-   * Compute the next due date label for a row.
-   * Falls back to `formatMonth(dueMonth)` if `nextDueDateForCharge` returns
-   * null (inactive charge or empty paymentMonths from legacy data).
+   * Current-period due date + status for a row (THI-329). Anchors to the
+   * current month — it never rolls a paid or past current-month bill forward
+   * ("juillet avant juin" fix) — and surfaces an `overdue` flag. `paid` is the
+   * optimistic current-period paid state. Falls back to `formatMonth(dueMonth)`
+   * when the resolver returns null (inactive / empty paymentMonths legacy data).
    */
-  function nextDueLabel(c: RawCharge): string {
-    const iso = nextDueDateForCharge(
-      {
-        isActive: c.isActive,
-        paymentMonths: c.paymentMonths,
-        paymentDay: c.paymentDay,
-      } as Parameters<typeof nextDueDateForCharge>[0],
+  function periodDueFor(c: RawCharge, paid: boolean): { label: string; isOverdue: boolean } {
+    const due = currentPeriodDueDate(
+      { isActive: c.isActive, paymentMonths: c.paymentMonths, paymentDay: c.paymentDay },
+      currentPeriod,
       todayIso,
+      paid,
     );
-    if (iso) return formatDate(iso, locale, 'medium');
-    return formatMonth(c.dueMonth, locale, 'long');
+    if (!due) return { label: formatMonth(c.dueMonth, locale, 'long'), isOverdue: false };
+    return {
+      label: formatDate(due.dueDateIso, locale, 'medium'),
+      isOverdue: due.status === 'overdue',
+    };
   }
 
   /**
@@ -201,6 +257,9 @@ export function ChargesClient({
    * (`pr-24` reserves their space) and become inline cells 5/6 on desktop.
    */
   function renderChargeRow(c: RawCharge) {
+    const isDue = c.isActive && c.paymentMonths.includes(currentPeriod.month);
+    const paid = optimisticPaid.has(c.id);
+    const { label: dueLabel, isOverdue } = periodDueFor(c, paid);
     return (
       <li
         key={c.id}
@@ -209,20 +268,59 @@ export function ChargesClient({
         // absolute edit/delete buttons (top-2 + size-11 = 52px) now that the
         // card padding (`p-4`) is gone — prevents the tap targets overflowing
         // onto the next row on very short content (mobile-ios-auditor F3).
-        className="md:hover:bg-surface-muted relative min-h-13 py-3 pr-24 transition-colors md:grid md:min-h-0 md:grid-cols-[minmax(8rem,10rem)_minmax(0,1fr)_4.5rem_7rem_auto_auto] md:items-baseline md:gap-4 md:px-2 md:py-3 md:pr-2"
+        // Due-this-month rows reserve left room (`pl-14`/`md:pl-12`) for the
+        // absolutely-positioned Payé toggle — keeps the 6-col desktop grid and
+        // its baseline contract untouched (plan-reviewer CR-3).
+        className={`md:hover:bg-surface-muted relative min-h-14 py-3 pr-24 transition-colors md:grid md:min-h-0 md:grid-cols-[minmax(8rem,10rem)_minmax(0,1fr)_4.5rem_7rem_auto_auto] md:items-baseline md:gap-4 md:py-3 md:pr-2 ${isDue ? 'pl-14 md:pl-12' : 'px-3 md:px-4'}`}
       >
+        {/* Payé toggle — absolute left for due-this-month charges. Lives
+            outside the grid + the mobile flow so it never disturbs the four
+            baseline-measured cells. 44px touch target on mobile. */}
+        {isDue && (
+          <button
+            type="button"
+            onClick={() => onTogglePaid(c)}
+            disabled={isPending}
+            aria-pressed={paid}
+            aria-label={
+              paid ? t('unmarkPaidAria', { label: c.label }) : t('markPaidAria', { label: c.label })
+            }
+            data-testid={`charges-row-paid-${c.id}`}
+            className={`focus-visible:ring-brand-600 absolute top-2 left-2 flex size-11 cursor-pointer items-center justify-center rounded-full border-2 transition-colors [-webkit-tap-highlight-color:transparent] focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:top-1/2 md:left-3 md:size-7 md:-translate-y-1/2 ${
+              paid
+                ? 'border-brand-600 bg-brand-600 text-white'
+                : 'border-border hover:border-brand-600 text-transparent'
+            }`}
+          >
+            <Check className="h-4 w-4 md:h-3.5 md:w-3.5" strokeWidth={3} aria-hidden />
+          </button>
+        )}
+
         {/* Mobile: header row (next-due + amount on a single line).
             Desktop: contents — projects next-due + amount as grid cells 1 / 4. */}
         <div className="flex items-baseline justify-between gap-3 md:contents">
+          {/* Date stays neutral (muted) in both themes; the overdue signal is
+              carried by the solid badge below — not by colouring the date, which
+              would be color-only (WCAG 1.4.1) and fail AA on the dark card
+              (`--color-danger` has no dark override). The badge uses white on a
+              solid `danger` fill = 4.84:1 in both themes (dashboard-ux C1). */}
           <span
             data-testid="charges-row-next-due"
-            className="text-muted-foreground text-xs font-medium tracking-wide md:order-1 md:text-sm"
+            className="text-muted-foreground inline-flex flex-wrap items-center gap-x-2 gap-y-1 text-xs font-medium tracking-wide md:order-1 md:text-sm"
           >
-            {nextDueLabel(c)}
+            {dueLabel}
+            {isOverdue && (
+              <span
+                data-testid={`charges-row-overdue-${c.id}`}
+                className="bg-danger rounded px-1.5 py-0.5 text-[11px] font-semibold tracking-normal text-white"
+              >
+                {t('statusOverdue')}
+              </span>
+            )}
           </span>
           <span
             data-testid="charges-row-amount"
-            className="text-foreground shrink-0 text-base font-semibold tabular-nums md:order-4 md:text-right md:text-sm md:font-medium"
+            className={`shrink-0 text-base font-semibold tabular-nums md:order-4 md:text-right md:text-sm md:font-medium ${paid ? 'text-muted-foreground line-through' : 'text-foreground'}`}
           >
             {formatCurrency(c.amount, locale)}
           </span>
@@ -297,6 +395,13 @@ export function ChargesClient({
     );
   }
 
+  // "Ce mois" summary, derived from the optimistic paid set so it updates the
+  // instant a toggle is hit (distinct from the smoothed "Effort lissé" total).
+  const paidThisMonthCount = dueThisMonth.filter((c) => optimisticPaid.has(c.id)).length;
+  const remainingThisMonth = dueThisMonth
+    .filter((c) => !optimisticPaid.has(c.id))
+    .reduce((sum, c) => sum + c.amount, 0);
+
   return (
     <div className="flex flex-col gap-6">
       <header>
@@ -314,6 +419,7 @@ export function ChargesClient({
               <Label htmlFor="label">{t('labelLabel')}</Label>
               <Input
                 id="label"
+                autoComplete="off"
                 value={label}
                 onChange={(e) => setLabel(e.target.value)}
                 required
@@ -325,6 +431,7 @@ export function ChargesClient({
               <Input
                 id="amount"
                 type="number"
+                autoComplete="off"
                 inputMode="decimal"
                 min={0}
                 step="0.01"
@@ -368,6 +475,7 @@ export function ChargesClient({
               <Input
                 id="paymentDay"
                 type="number"
+                autoComplete="off"
                 inputMode="numeric"
                 min={1}
                 max={31}
@@ -398,6 +506,13 @@ export function ChargesClient({
             </p>
           ) : (
             <>
+              {/* One-time hint teaching the Payé toggle convention
+                  (dashboard-ux F2) — only when a charge is due this month. */}
+              {dueThisMonth.length > 0 && (
+                <p className="text-muted-foreground mb-4 text-xs" data-testid="charges-paid-hint">
+                  {t('paidHint')}
+                </p>
+              )}
               {/* `charges-list` is now a wrapper holding one <section> per
                   non-empty frequency group. The only `listitem`s remain the
                   charge rows inside each group's <ul>, so the total count
@@ -412,27 +527,56 @@ export function ChargesClient({
                       data-testid={`charges-group-${freq}`}
                       aria-labelledby={headingId}
                     >
-                      <div className="border-border/40 flex items-baseline justify-between gap-3 border-b pb-2">
-                        <h2
-                          id={headingId}
-                          className="text-muted-foreground text-sm font-semibold tracking-wide"
-                        >
-                          {tFreq(freq)}
-                        </h2>
-                        <span
-                          data-testid={`charges-group-subtotal-${freq}`}
-                          className="text-muted-foreground text-sm tabular-nums"
-                        >
-                          {t('subtotalLabel')} {formatCurrency(subtotals[freq], locale)}
+                      {/* Group header — neutral recurrence icon + frequency +
+                          item count, adopting the cockpit "Prochaines factures"
+                          card language. The subtotal moves BELOW the list
+                          (validated @thierry 2026-06-04: total read after the
+                          rows, coloured for impact). */}
+                      <h2
+                        id={headingId}
+                        className="text-muted-foreground mb-2 flex items-center gap-2 text-xs font-semibold tracking-wide uppercase"
+                      >
+                        <Repeat aria-hidden strokeWidth={1.5} className="h-4 w-4" />
+                        {tFreq(freq)}
+                        <span className="text-muted-foreground/70 ml-0.5 text-[11px] font-medium normal-case">
+                          {t('count', { count: rows.length })}
                         </span>
-                      </div>
-                      <ul role="list" className="divide-border/40 divide-y">
+                      </h2>
+                      <ul
+                        role="list"
+                        className="border-border divide-border/60 divide-y overflow-hidden rounded-xl border"
+                      >
                         {rows.map((c) => renderChargeRow(c))}
                       </ul>
+                      {/* Subtotal — below the list, coloured brand for impact. */}
+                      <p
+                        data-testid={`charges-group-subtotal-${freq}`}
+                        className="mt-2 flex items-baseline justify-end gap-1.5 px-1"
+                      >
+                        <span className="text-muted-foreground text-xs">{t('subtotalLabel')}</span>
+                        <span className="text-brand-text text-sm font-semibold tabular-nums">
+                          {formatCurrency(subtotals[freq], locale)}
+                        </span>
+                      </p>
                     </section>
                   );
                 })}
               </div>
+
+              {/* "Ce mois" payment summary — paid count + remaining cash due
+                  this period. Distinct from the smoothed effort total below. */}
+              {dueThisMonth.length > 0 && (
+                <p
+                  data-testid="charges-paid-summary"
+                  className="bg-surface-muted text-muted-foreground mt-6 rounded-lg px-3 py-2.5 text-sm"
+                >
+                  {t('paidSummary', {
+                    paid: paidThisMonthCount,
+                    total: dueThisMonth.length,
+                    remaining: formatCurrency(remainingThisMonth, locale),
+                  })}
+                </p>
+              )}
 
               {/* Global total — the headline @thierry asked for ("on ne voit
                   jamais le total des factures en bas"). The smoothed monthly

--- a/src/app/[locale]/app/charges/__tests__/ChargesClient.test.tsx
+++ b/src/app/[locale]/app/charges/__tests__/ChargesClient.test.tsx
@@ -22,11 +22,16 @@ const deleteChargeMock = vi.hoisted(() => vi.fn());
 const toastSuccessMock = vi.hoisted(() => vi.fn());
 const toastErrorMock = vi.hoisted(() => vi.fn());
 const routerRefreshMock = vi.hoisted(() => vi.fn());
+const togglePaymentMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/actions/charges', () => ({
   createChargeAction: createChargeMock,
   updateChargeAction: updateChargeMock,
   deleteChargeAction: deleteChargeMock,
+}));
+
+vi.mock('@/lib/actions/charge-payments', () => ({
+  togglePaymentAction: togglePaymentMock,
 }));
 
 vi.mock('@/components/ui/toast', () => ({
@@ -71,6 +76,8 @@ function renderCharges(
       subtotals={overrides.subtotals ?? ZERO_SUBTOTALS}
       monthlyProvisionTotal={overrides.monthlyProvisionTotal ?? 0}
       annualTotal={overrides.annualTotal ?? 0}
+      paidChargeIds={overrides.paidChargeIds ?? []}
+      currentPeriod={overrides.currentPeriod ?? { year: 2026, month: 1 }}
     />,
   );
 }
@@ -110,6 +117,7 @@ describe('<ChargesClient /> — PR-BETA-1 visual refactor', () => {
     toastSuccessMock.mockReset();
     toastErrorMock.mockReset();
     routerRefreshMock.mockReset();
+    togglePaymentMock.mockReset();
   });
 
   it('shows the empty-state copy when no charges are provided', () => {
@@ -195,6 +203,7 @@ describe('<ChargesClient /> — PR-BETA-CLEANUP-2 list & form', () => {
     toastSuccessMock.mockReset();
     toastErrorMock.mockReset();
     routerRefreshMock.mockReset();
+    togglePaymentMock.mockReset();
   });
 
   it('renders the next-due column with a locale-aware date for active charges', () => {
@@ -240,6 +249,7 @@ describe('<ChargesClient /> — PR-BETA-CLEANUP-2 edit drawer', () => {
     toastSuccessMock.mockReset();
     toastErrorMock.mockReset();
     routerRefreshMock.mockReset();
+    togglePaymentMock.mockReset();
   });
 
   it('opens the drawer when the Modifier button is clicked', async () => {
@@ -297,6 +307,7 @@ describe('<ChargesClient /> — PR-UI-3a grouping & totals', () => {
     toastSuccessMock.mockReset();
     toastErrorMock.mockReset();
     routerRefreshMock.mockReset();
+    togglePaymentMock.mockReset();
   });
 
   it('renders one section per non-empty frequency group, in fixed order, hiding empty groups', () => {
@@ -362,6 +373,122 @@ describe('<ChargesClient /> — PR-UI-3a grouping & totals', () => {
   });
 });
 
+describe('Factures Phase 2 — Payé toggle', () => {
+  const monthlyCharge = sampleCharges[0]!; // paymentMonths 1..12 → due every month
+
+  it('hides the toggle for a charge not due in the current period', () => {
+    const annualJune = {
+      ...monthlyCharge,
+      id: 'an1',
+      frequency: 'annual',
+      paymentMonths: [6] as readonly number[],
+    };
+    renderCharges([annualJune], { currentPeriod: { year: 2026, month: 1 } });
+    expect(screen.queryByTestId('charges-row-paid-an1')).not.toBeInTheDocument();
+  });
+
+  it('reflects the seeded paid state via aria-pressed', () => {
+    renderCharges([monthlyCharge], {
+      paidChargeIds: [monthlyCharge.id],
+      currentPeriod: { year: 2026, month: 1 },
+    });
+    expect(screen.getByTestId(`charges-row-paid-${monthlyCharge.id}`)).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
+  it('toggles paid optimistically and calls the action with the current period', async () => {
+    togglePaymentMock.mockResolvedValue({ ok: true, data: { paid: true, paidAmount: 1200 } });
+    renderCharges([monthlyCharge], { currentPeriod: { year: 2026, month: 3 } });
+    const toggle = screen.getByTestId(`charges-row-paid-${monthlyCharge.id}`);
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+    await waitFor(() =>
+      expect(togglePaymentMock).toHaveBeenCalledWith({
+        chargeId: monthlyCharge.id,
+        periodYear: 2026,
+        periodMonth: 3,
+      }),
+    );
+    await waitFor(() => expect(toastSuccessMock).toHaveBeenCalled());
+  });
+
+  it('shows an error toast when the toggle fails', async () => {
+    togglePaymentMock.mockResolvedValue({
+      ok: false,
+      errorCode: 'errors.charges.payments.toggleFailed',
+    });
+    renderCharges([monthlyCharge], { currentPeriod: { year: 2026, month: 1 } });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId(`charges-row-paid-${monthlyCharge.id}`));
+    });
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalled());
+  });
+
+  it('renders the "ce mois" paid summary when charges are due', () => {
+    renderCharges([monthlyCharge], { currentPeriod: { year: 2026, month: 1 } });
+    expect(screen.getByTestId('charges-paid-summary')).toBeInTheDocument();
+  });
+
+  it('renders the paid-toggle hint when charges are due this month', () => {
+    renderCharges([monthlyCharge], { currentPeriod: { year: 2026, month: 1 } });
+    expect(screen.getByTestId('charges-paid-hint')).toBeInTheDocument();
+  });
+});
+
+// THI-329 — current-period due date + overdue badge (PR-B). The component reads
+// the real clock for `todayIso`, so to keep "overdue" deterministic without
+// faking timers we drive it through `currentPeriod`: a PAST period is always
+// before today (→ overdue), a far-FUTURE period is always after (→ not overdue).
+describe('<ChargesClient /> — THI-329 current-period date & overdue badge', () => {
+  const monthly = sampleCharges[0]!; // paymentDay 5, due every month
+
+  beforeEach(() => {
+    createChargeMock.mockReset();
+    updateChargeMock.mockReset();
+    deleteChargeMock.mockReset();
+    toastSuccessMock.mockReset();
+    toastErrorMock.mockReset();
+    routerRefreshMock.mockReset();
+    togglePaymentMock.mockReset();
+  });
+
+  it('flags an unpaid current-month charge whose day has passed as overdue, anchored to that month (not the next)', () => {
+    renderCharges([monthly], { currentPeriod: { year: 2020, month: 6 } });
+    const row = screen.getByTestId('charges-row-a1');
+    expect(within(row).getByTestId('charges-row-overdue-a1')).toBeInTheDocument();
+    const due = within(row).getByTestId('charges-row-next-due').textContent ?? '';
+    // Date stays on the current month (June 2020) — does NOT roll to July.
+    expect(due).toMatch(/2020/);
+    expect(due).toMatch(/juin/i);
+    expect(due).not.toMatch(/juillet/i);
+  });
+
+  it('shows no overdue badge when the current-month due day is still ahead', () => {
+    renderCharges([monthly], { currentPeriod: { year: 2099, month: 6 } });
+    expect(screen.queryByTestId('charges-row-overdue-a1')).toBeNull();
+  });
+
+  it('shows no overdue badge for a charge not due in the current month (upcoming)', () => {
+    // annual a2 [6]; current month March → upcoming June, never overdue.
+    renderCharges([sampleCharges[1]!], { currentPeriod: { year: 2020, month: 3 } });
+    expect(screen.queryByTestId('charges-row-overdue-a2')).toBeNull();
+  });
+
+  it('shows no overdue badge for a paid current-month charge (paid beats overdue)', () => {
+    // Same past period that makes the unpaid row overdue above, but seeded paid:
+    // the badge must be gone (status 'paid' wins). Seeding via paidChargeIds (not
+    // the optimistic toggle) keeps this deterministic — useOptimistic reverts to
+    // its base after the transition settles in the test harness.
+    renderCharges([monthly], { currentPeriod: { year: 2020, month: 6 }, paidChargeIds: ['a1'] });
+    expect(screen.queryByTestId('charges-row-overdue-a1')).toBeNull();
+    expect(screen.getByTestId('charges-row-paid-a1')).toHaveAttribute('aria-pressed', 'true');
+  });
+});
+
 describe('app.charges — i18n parity (5 locales, PR-BETA-CLEANUP-2)', () => {
   it.each(['fr-BE', 'en', 'de-DE', 'es-ES', 'nl-BE'] as const)(
     'locale %s exposes paymentDay + edit + drawer + total keys',
@@ -376,6 +503,13 @@ describe('app.charges — i18n parity (5 locales, PR-BETA-CLEANUP-2)', () => {
             subtotalLabel?: string;
             totalMonthlyLabel?: string;
             totalAnnualLabel?: string;
+            toastMarkedPaid?: string;
+            toastMarkedUnpaid?: string;
+            markPaidAria?: string;
+            unmarkPaidAria?: string;
+            paidSummary?: string;
+            paidHint?: string;
+            statusOverdue?: string;
             drawer?: {
               title?: string;
               save?: string;
@@ -402,6 +536,17 @@ describe('app.charges — i18n parity (5 locales, PR-BETA-CLEANUP-2)', () => {
       expect(c.drawer?.saving).toBeTypeOf('string');
       expect(c.drawer?.cancel).toBeTypeOf('string');
       expect(c.drawer?.errorGeneric).toBeTypeOf('string');
+      // Factures Phase 2 (Payé toggle) — keys present + placeholder integrity.
+      expect((c.toastMarkedPaid ?? '').length).toBeGreaterThan(0);
+      expect((c.toastMarkedUnpaid ?? '').length).toBeGreaterThan(0);
+      expect((c.markPaidAria ?? '').includes('{label}')).toBe(true);
+      expect((c.unmarkPaidAria ?? '').includes('{label}')).toBe(true);
+      expect((c.paidSummary ?? '').includes('{paid}')).toBe(true);
+      expect((c.paidSummary ?? '').includes('{total}')).toBe(true);
+      expect((c.paidSummary ?? '').includes('{remaining}')).toBe(true);
+      expect((c.paidHint ?? '').length).toBeGreaterThan(0);
+      // THI-329 (PR-B) — overdue status badge.
+      expect((c.statusOverdue ?? '').length).toBeGreaterThan(0);
     },
   );
 });

--- a/src/app/[locale]/app/charges/page.tsx
+++ b/src/app/[locale]/app/charges/page.tsx
@@ -21,6 +21,13 @@ export default async function ChargesPage() {
   // per-group subtotals reconcile with the global smoothed/annual totals.
   const subtotals = subtotalByFrequency(snapshot.charges);
 
+  // Charge IDs already settled for the current period — seeds the "Payé"
+  // toggle. `currentMonthPayments` is already scoped server-side to the current
+  // Europe/Brussels month (same period the toggle writes to). The action
+  // re-verifies workspace ownership before any write — these IDs are not
+  // trusted authz input, just optimistic-UI seed data the user already owns.
+  const paidChargeIds = snapshot.currentMonthPayments.map((p) => p.chargeId);
+
   return (
     <ChargesClient
       charges={snapshot.rawCharges}
@@ -32,6 +39,8 @@ export default async function ChargesPage() {
       }}
       monthlyProvisionTotal={monthlyProvisionTotal(snapshot.charges).toNumber()}
       annualTotal={annualTotal(snapshot.charges).toNumber()}
+      paidChargeIds={paidChargeIds}
+      currentPeriod={snapshot.currentPeriod}
     />
   );
 }

--- a/src/lib/domain/charges/__tests__/current-period-due-date.test.ts
+++ b/src/lib/domain/charges/__tests__/current-period-due-date.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+
+import { currentPeriodDueDate, type CurrentPeriodCharge } from '../current-period-due-date';
+
+const charge = (over: Partial<CurrentPeriodCharge> = {}): CurrentPeriodCharge => ({
+  paymentMonths: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+  paymentDay: 1,
+  isActive: true,
+  ...over,
+});
+
+const JUNE = { year: 2026, month: 6 } as const;
+
+describe('currentPeriodDueDate', () => {
+  it('labels a due-this-month occurrence whose day has passed as overdue (this month, not next)', () => {
+    const res = currentPeriodDueDate(charge(), JUNE, '2026-06-04', false);
+    expect(res).toEqual({ dueDateIso: '2026-06-01', status: 'overdue' });
+  });
+
+  it('labels a due-this-month occurrence whose day is still ahead as dueThisMonth', () => {
+    const res = currentPeriodDueDate(charge({ paymentDay: 20 }), JUNE, '2026-06-04', false);
+    expect(res).toEqual({ dueDateIso: '2026-06-20', status: 'dueThisMonth' });
+  });
+
+  it('paid beats overdue: a paid current-month bill stays on this month as paid (never rolls to July)', () => {
+    const res = currentPeriodDueDate(charge(), JUNE, '2026-06-04', true);
+    expect(res).toEqual({ dueDateIso: '2026-06-01', status: 'paid' });
+  });
+
+  it('paid beats dueThisMonth: a paid current-month bill due later this month is paid', () => {
+    const res = currentPeriodDueDate(charge({ paymentDay: 20 }), JUNE, '2026-06-04', true);
+    expect(res).toEqual({ dueDateIso: '2026-06-20', status: 'paid' });
+  });
+
+  it('returns the next occurrence as upcoming when the current month is not a payment month (quarterly)', () => {
+    // Quarterly [1,4,7,10]; June is not a payment month → next is July.
+    const res = currentPeriodDueDate(
+      charge({ paymentMonths: [1, 4, 7, 10] }),
+      JUNE,
+      '2026-06-04',
+      false,
+    );
+    expect(res).toEqual({ dueDateIso: '2026-07-01', status: 'upcoming' });
+  });
+
+  it('rolls an annual bill to next year when its month is behind the current one', () => {
+    // Annual [3] (March); June → next March is 2027.
+    const res = currentPeriodDueDate(charge({ paymentMonths: [3] }), JUNE, '2026-06-04', false);
+    expect(res).toEqual({ dueDateIso: '2027-03-01', status: 'upcoming' });
+  });
+
+  it('clamps paymentDay to the last day of a short month (Feb, non-leap)', () => {
+    const res = currentPeriodDueDate(
+      charge({ paymentMonths: [2], paymentDay: 31 }),
+      { year: 2026, month: 2 },
+      '2026-02-01',
+      false,
+    );
+    expect(res).toEqual({ dueDateIso: '2026-02-28', status: 'dueThisMonth' });
+  });
+
+  it('clamps paymentDay to Feb 29 on a leap year', () => {
+    const res = currentPeriodDueDate(
+      charge({ paymentMonths: [2], paymentDay: 31 }),
+      { year: 2028, month: 2 },
+      '2028-02-01',
+      false,
+    );
+    expect(res).toEqual({ dueDateIso: '2028-02-29', status: 'dueThisMonth' });
+  });
+
+  it('handles the year boundary (December current month, January-only charge)', () => {
+    const res = currentPeriodDueDate(
+      charge({ paymentMonths: [1] }),
+      { year: 2026, month: 12 },
+      '2026-12-15',
+      false,
+    );
+    expect(res).toEqual({ dueDateIso: '2027-01-01', status: 'upcoming' });
+  });
+
+  it('returns null for an inactive charge', () => {
+    expect(currentPeriodDueDate(charge({ isActive: false }), JUNE, '2026-06-04', false)).toBeNull();
+  });
+
+  it('returns null when paymentMonths is empty', () => {
+    expect(
+      currentPeriodDueDate(charge({ paymentMonths: [] }), JUNE, '2026-06-04', false),
+    ).toBeNull();
+  });
+
+  it('treats the exact due day as dueThisMonth, not overdue (strict ISO comparison)', () => {
+    // dueDateIso === todayIso → not overdue the day it falls due.
+    const res = currentPeriodDueDate(charge(), JUNE, '2026-06-01', false);
+    expect(res).toEqual({ dueDateIso: '2026-06-01', status: 'dueThisMonth' });
+  });
+
+  it('anchors a paid semiannual charge to the current month (offset 0 wins over the other payment month)', () => {
+    // Semiannual [6, 12]; June is the current month and is paid → paid on the
+    // June occurrence, never the December one.
+    const res = currentPeriodDueDate(charge({ paymentMonths: [6, 12] }), JUNE, '2026-06-15', true);
+    expect(res).toEqual({ dueDateIso: '2026-06-01', status: 'paid' });
+  });
+});

--- a/src/lib/domain/charges/current-period-due-date.ts
+++ b/src/lib/domain/charges/current-period-due-date.ts
@@ -1,0 +1,83 @@
+/**
+ * Resolve a charge's CURRENT-PERIOD due date + status for the charges page.
+ *
+ * Unlike the dashboard's upcoming-bills resolver (`getUpcomingCharges`, which
+ * SKIPS paid occurrences and rolls forward), this resolver ANCHORS to the
+ * current period: when the
+ * charge is due this month it returns THIS month's occurrence and merely
+ * LABELS it (`paid` / `overdue` / `dueThisMonth`) — it never rolls a paid or
+ * past current-month bill into the future ("juillet avant juin" fix, THI-329).
+ * Only when the current month is NOT a payment month does it return the real
+ * next occurrence (`upcoming`).
+ *
+ * Ledger invariant: `isPaid` is a scalar scoped to `(period.year, period.month)`
+ * ONLY — the call-site derives it from the mono-month payment ledger
+ * (`currentMonthPayments`). Never pass the paid state of a future occurrence;
+ * the `upcoming` branch ignores `isPaid` by construction. This is the deliberate
+ * difference from the dashboard's upcoming resolver (which skips paid
+ * occurrences): here we anchor + label, there we skip — do not merge them.
+ */
+export type CurrentPeriodCharge = Readonly<{
+  paymentMonths: readonly number[];
+  paymentDay: number;
+  isActive: boolean;
+}>;
+
+export type ChargePeriodStatus = 'paid' | 'overdue' | 'dueThisMonth' | 'upcoming';
+
+export type CurrentPeriodDueResult = Readonly<{
+  /** Date to display in ISO `YYYY-MM-DD`: this month when due this month, else the next occurrence. */
+  dueDateIso: string;
+  status: ChargePeriodStatus;
+}>;
+
+export function currentPeriodDueDate(
+  charge: CurrentPeriodCharge,
+  period: Readonly<{ year: number; month: number }>,
+  todayIso: string,
+  isPaid: boolean,
+): CurrentPeriodDueResult | null {
+  if (!charge.isActive) return null;
+  if (charge.paymentMonths.length === 0) return null;
+
+  const monthsSet = new Set(charge.paymentMonths);
+
+  for (let offset = 0; offset < 24; offset += 1) {
+    const totalMonth = period.month - 1 + offset;
+    const year = period.year + Math.floor(totalMonth / 12);
+    const month = (totalMonth % 12) + 1;
+    if (!monthsSet.has(month)) continue;
+
+    const day = Math.min(charge.paymentDay, daysInMonth(year, month));
+    const dueDateIso = `${pad4(year)}-${pad2(month)}-${pad2(day)}`;
+
+    if (offset === 0) {
+      // Current month IS a payment month → anchor to it and label.
+      // Paid wins over overdue/dueThisMonth (a settled bill is never "late").
+      const status: ChargePeriodStatus = isPaid
+        ? 'paid'
+        : dueDateIso < todayIso
+          ? 'overdue'
+          : 'dueThisMonth';
+      return { dueDateIso, status };
+    }
+
+    // Current month is not a payment month → the genuine next occurrence.
+    return { dueDateIso, status: 'upcoming' };
+  }
+
+  return null;
+}
+
+/** Last day of `month` (1-based) in `year`, UTC-anchored (handles leap years). */
+function daysInMonth(year: number, month: number): number {
+  return new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+function pad4(n: number): string {
+  return String(n).padStart(4, '0');
+}

--- a/src/lib/domain/charges/index.ts
+++ b/src/lib/domain/charges/index.ts
@@ -6,6 +6,12 @@ export {
   type PaymentAwareCharge,
   type NextUnpaidDueResult,
 } from './next-unpaid-due-date';
+export {
+  currentPeriodDueDate,
+  type CurrentPeriodCharge,
+  type ChargePeriodStatus,
+  type CurrentPeriodDueResult,
+} from './current-period-due-date';
 export { chargeMatchesMonth } from './match-month';
 export { paymentMonthsFromFrequency } from './payment-months-from-frequency';
 export {


### PR DESCRIPTION
## PR-B — Page charges : période courante + carry #221 (THI-329)

Epic « Factures cohérentes ». La page `/app/charges` reflète enfin la **réalité du mois courant** par facture, au lieu de rouler prématurément vers l'occurrence suivante. **Branchée depuis `main`, indépendante de PR-A #223** (seul overlap au merge = bloc d'exports `index.ts`, trivial).

### Le fix « juillet avant juin »
Domaine pur nouveau **`currentPeriodDueDate(charge, period, todayIso, isPaid)`** : ancre au mois courant (`paid` / `overdue` / `dueThisMonth`) et ne roule vers la vraie prochaine occurrence (`upcoming`) que si le mois courant n'est pas un mois de paiement. Remplace `nextDueLabel` (qui utilisait `nextDueDateForCharge`, lequel roulait en avant → affichait « juillet » pour une facture de juin). 13 tests.

### Carry de #221 (trim rejeté retiré)
Toggle **Payé** (`useOptimistic` + `togglePaymentAction` existant), style payé (line-through), résumé « Payées ce mois : x/y · reste {montant} », redesign groupes (header Repeat + compteur, `<ul>` arrondi bordé, sous-total bas). **Le trim dashboard (`moreCount`) n'est PAS carrié** (rejeté @thierry — un marqueur « à surveiller » viendra). **Nouveau** : badge par-ligne « En retard ».

### a11y (dashboard-ux C1/H1 corrigés)
- Badge « En retard » = **blanc sur `danger` plein** → **4.84:1** dans les 2 thèmes (`--color-danger` n'a pas d'override dark, donc `text-danger` y échouait).
- Date reste **neutre** (plus de couleur seule = WCAG 1.4.1).
- Sous-total groupe `text-brand-700` → `text-brand-text` (overridé dark → AA les 2 thèmes).

### Gouvernance
plan-reviewer 🟡→intégré (CR-1..4 + faits git vérifiés) · **financial-formula-validator GO** · **i18n-auditor GO** (parité 5 locales) · **dashboard-ux C1/H1 corrigés** · **mobile-ios PASS_WITH_NOTES** · 47 tests charges + suite complète (1444) + build verts.

### ⚠️ Dette a11y hors-scope (à tracker)
`ProchainesFacturesCard.tsx` (dashboard, **sur main**, non touché ici) a le **même** pattern `bg-danger/10 text-danger` (chip danger) + `text-brand-700` (tone info) → même fail dark. À corriger dans une passe a11y dédiée.

### Smoke @thierry (preview, **desktop + mobile**)
`/app/charges` en juin : facture mensuelle payée → affiche **juin payé** (plus juillet) ; facture jour passé non payée → badge **« En retard »** ; toggle bascule l'état ; trimestriel hors-mois → prochaine date réelle. Vérifier badge lisible en **dark mode** + pas de chevauchement date/badge/montant sur **iPhone SE**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
