### PR TITLE
feat(charges): live remaining-to-pay headline at top of list (THI-329)

### DIFF
--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -729,6 +729,8 @@
       "unmarkPaidAria": "{label} als zu zahlen markieren",
       "paidSummary": "Diesen Monat bezahlt: {paid}/{total} · noch {remaining}",
       "paidHint": "Hake die Rechnungen ab, die du diesen Monat schon bezahlt hast.",
+      "remainingLabel": "Diesen Monat noch zu zahlen",
+      "paidCount": "{paid}/{total} bezahlt",
       "statusOverdue": "Überfällig",
       "drawer": {
         "title": "Fixkosten bearbeiten",

--- a/messages/en.json
+++ b/messages/en.json
@@ -729,6 +729,8 @@
       "unmarkPaidAria": "Mark {label} as to pay",
       "paidSummary": "Paid this month: {paid}/{total} · {remaining} left",
       "paidHint": "Tick the bills you've already paid this month.",
+      "remainingLabel": "Left to pay this month",
+      "paidCount": "{paid}/{total} paid",
       "statusOverdue": "Overdue",
       "drawer": {
         "title": "Edit bill",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -729,6 +729,8 @@
       "unmarkPaidAria": "Marcar {label} como por pagar",
       "paidSummary": "Pagadas este mes: {paid}/{total} · quedan {remaining}",
       "paidHint": "Marca las facturas que ya has pagado este mes.",
+      "remainingLabel": "Pendiente de pagar este mes",
+      "paidCount": "{paid}/{total} pagadas",
       "statusOverdue": "Atrasadas",
       "drawer": {
         "title": "Modificar gasto fijo",

--- a/messages/fr-BE.json
+++ b/messages/fr-BE.json
@@ -729,6 +729,8 @@
       "unmarkPaidAria": "Marquer {label} comme à payer",
       "paidSummary": "Payées ce mois : {paid}/{total} · reste {remaining}",
       "paidHint": "Coche les factures que tu as déjà payées ce mois.",
+      "remainingLabel": "Reste à payer ce mois",
+      "paidCount": "{paid}/{total} payées",
       "statusOverdue": "En retard",
       "drawer": {
         "title": "Modifier la charge",

--- a/messages/nl-BE.json
+++ b/messages/nl-BE.json
@@ -729,6 +729,8 @@
       "unmarkPaidAria": "{label} als te betalen markeren",
       "paidSummary": "Deze maand betaald: {paid}/{total} · nog {remaining}",
       "paidHint": "Vink de facturen aan die je deze maand al betaald hebt.",
+      "remainingLabel": "Nog te betalen deze maand",
+      "paidCount": "{paid}/{total} betaald",
       "statusOverdue": "Te laat",
       "drawer": {
         "title": "Vaste kost bewerken",

--- a/src/app/[locale]/app/charges/ChargesClient.tsx
+++ b/src/app/[locale]/app/charges/ChargesClient.tsx
@@ -516,13 +516,16 @@ export function ChargesClient({
                   data-testid="charges-paid-summary"
                   className="bg-surface-muted mb-4 flex items-center justify-between gap-3 rounded-lg px-4 py-3"
                 >
-                  <div className="min-w-0">
+                  {/* aria-live sits on the container (label + amount) with
+                      aria-atomic, so screen readers announce "Reste à payer ce
+                      mois 45 €" as one utterance on each tick — not the bare
+                      currency value (Sourcery review). */}
+                  <div className="min-w-0" aria-live="polite" role="status" aria-atomic="true">
                     <p className="text-muted-foreground text-xs font-medium">
                       {t('remainingLabel')}
                     </p>
                     <p
                       data-testid="charges-remaining-amount"
-                      aria-live="polite"
                       className="text-foreground text-xl font-bold tabular-nums"
                     >
                       {formatCurrency(remainingThisMonth, locale)}

--- a/src/app/[locale]/app/charges/ChargesClient.tsx
+++ b/src/app/[locale]/app/charges/ChargesClient.tsx
@@ -506,6 +506,33 @@ export function ChargesClient({
             </p>
           ) : (
             <>
+              {/* Live "reste à payer" headline — promoted to the TOP of the list
+                  (dashboard-ux M2: the old bottom summary was invisible after 16
+                  rows). Derived from `optimisticPaid`, so the amount counts down
+                  the instant a bill is ticked. Distinct from the smoothed
+                  "Effort lissé" total below (which intentionally never moves). */}
+              {dueThisMonth.length > 0 && (
+                <div
+                  data-testid="charges-paid-summary"
+                  className="bg-surface-muted mb-4 flex items-center justify-between gap-3 rounded-lg px-4 py-3"
+                >
+                  <div className="min-w-0">
+                    <p className="text-muted-foreground text-xs font-medium">
+                      {t('remainingLabel')}
+                    </p>
+                    <p
+                      data-testid="charges-remaining-amount"
+                      aria-live="polite"
+                      className="text-foreground text-xl font-bold tabular-nums"
+                    >
+                      {formatCurrency(remainingThisMonth, locale)}
+                    </p>
+                  </div>
+                  <span className="text-muted-foreground shrink-0 text-sm tabular-nums">
+                    {t('paidCount', { paid: paidThisMonthCount, total: dueThisMonth.length })}
+                  </span>
+                </div>
+              )}
               {/* One-time hint teaching the Payé toggle convention
                   (dashboard-ux F2) — only when a charge is due this month. */}
               {dueThisMonth.length > 0 && (
@@ -562,21 +589,6 @@ export function ChargesClient({
                   );
                 })}
               </div>
-
-              {/* "Ce mois" payment summary — paid count + remaining cash due
-                  this period. Distinct from the smoothed effort total below. */}
-              {dueThisMonth.length > 0 && (
-                <p
-                  data-testid="charges-paid-summary"
-                  className="bg-surface-muted text-muted-foreground mt-6 rounded-lg px-3 py-2.5 text-sm"
-                >
-                  {t('paidSummary', {
-                    paid: paidThisMonthCount,
-                    total: dueThisMonth.length,
-                    remaining: formatCurrency(remainingThisMonth, locale),
-                  })}
-                </p>
-              )}
 
               {/* Global total — the headline @thierry asked for ("on ne voit
                   jamais le total des factures en bas"). The smoothed monthly

--- a/src/app/[locale]/app/charges/__tests__/ChargesClient.test.tsx
+++ b/src/app/[locale]/app/charges/__tests__/ChargesClient.test.tsx
@@ -433,6 +433,22 @@ describe('Factures Phase 2 — Payé toggle', () => {
     expect(screen.getByTestId('charges-paid-summary')).toBeInTheDocument();
   });
 
+  it('shows the remaining amount headline: full when unpaid, zero once seeded paid', () => {
+    // Unpaid: remaining = the bill's full amount (1 200 €).
+    const { unmount } = renderCharges([monthlyCharge], {
+      currentPeriod: { year: 2026, month: 1 },
+    });
+    expect(screen.getByTestId('charges-remaining-amount')).toHaveTextContent(/1[  ]200/);
+    unmount();
+    // Seeded paid: the countdown reflects it — remaining drops to 0, count 1/1.
+    renderCharges([monthlyCharge], {
+      currentPeriod: { year: 2026, month: 1 },
+      paidChargeIds: [monthlyCharge.id],
+    });
+    expect(screen.getByTestId('charges-remaining-amount')).toHaveTextContent(/^0/);
+    expect(screen.getByTestId('charges-paid-summary')).toHaveTextContent('1/1');
+  });
+
   it('renders the paid-toggle hint when charges are due this month', () => {
     renderCharges([monthlyCharge], { currentPeriod: { year: 2026, month: 1 } });
     expect(screen.getByTestId('charges-paid-hint')).toBeInTheDocument();


### PR DESCRIPTION
## Décompte « reste à payer » proéminent + live (THI-329, retour @thierry 2026-07-17)

Le décompte existait mais était **enterré sous les 16 lignes**, en petit texte gris (finding M2 du dashboard-ux-auditor sur #224) — invisible quand on coche.

### Changement
Bandeau promu **en tête de liste** : label « Reste à payer ce mois » + **montant en gros chiffre tabulaire** qui **décrémente instantanément** à chaque coche (dérivé de l'état optimiste) + compteur « x/y payées ». `aria-live="polite"` pour les lecteurs d'écran. L'ancien résumé du bas est supprimé (une seule source). Le total « Effort lissé » reste volontairement immobile (métrique lissée, décision FSMA actée).

### Scope
UI-only, voie LÉGÈRE : aucun domaine/action/migration touché. i18n `app.charges.{remainingLabel,paidCount}` ×5 locales. 35 tests ChargesClient verts (dont 1 nouveau : montant plein non payé → 0 une fois payé).

### Smoke @thierry
`/app/charges` : bandeau visible en haut sans scroller ; cocher une facture → le montant descend immédiatement ; dark mode + mobile OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Promouvoir le récapitulatif du montant restant à payer pour les prélèvements mensuels en tant que titre dynamique en haut de la liste et garantir qu’il se met à jour immédiatement lorsque des éléments sont marqués comme payés.

Nouvelles fonctionnalités :
- Afficher une bannière bien visible du montant restant à payer au-dessus de la liste des prélèvements, indiquant le montant restant actuel ainsi que le nombre payé/total, avec des mises à jour en temps réel basées sur l’état optimiste.

Améliorations :
- Supprimer l’ancien récapitulatif de paiement en bas de page au profit de la nouvelle bannière en haut, afin d’éviter les doublons de source de vérité.
- Ajouter un texte accessible du montant restant, mis à jour en direct pour les lecteurs d’écran via aria-live.
- Mettre à jour les messages i18n pour prendre en charge le nouveau libellé du montant restant et le texte du nombre payé dans toutes les locales prises en charge.

Tests :
- Ajouter un test vérifiant que le titre du montant restant reflète à la fois les états entièrement impayés et prépayés, y compris l’affichage du nombre d’éléments payés.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Promote the remaining-to-pay summary for monthly charges to a live headline at the top of the list and ensure it updates immediately as items are marked paid.

New Features:
- Display a prominent remaining-to-pay banner above the charges list, showing the current remaining amount and paid/total count with live updates based on optimistic state.

Enhancements:
- Remove the old bottom-of-page payment summary in favor of the new top banner to avoid duplicate sources of truth.
- Add accessible live-updating remaining amount text for screen readers via aria-live.
- Update i18n messages to support the new remaining amount label and paid count copy across supported locales.

Tests:
- Add a test verifying that the remaining amount headline reflects both fully unpaid and pre-paid states, including the paid count display.

</details>